### PR TITLE
feat: Add Gemma 4 text decoder support

### DIFF
--- a/crane-core/src/models/gemma4/mod.rs
+++ b/crane-core/src/models/gemma4/mod.rs
@@ -1,0 +1,4 @@
+mod model;
+pub mod modeling;
+
+pub use model::*;

--- a/crane-core/src/models/gemma4/model.rs
+++ b/crane-core/src/models/gemma4/model.rs
@@ -92,15 +92,16 @@ impl Model {
         let config_data = std::fs::read(config_file)?;
 
         // Gemma 4 config.json has text_config nested under the top level
-        let text_config: Gemma4TextConfig =
+        // for multimodal checkpoints (Gemma4ForConditionalGeneration).
+        // Text-only checkpoints have a flat config.
+        let (text_config, is_multimodal) =
             if let Ok(outer) = serde_json::from_slice::<Gemma4Config>(&config_data) {
-                outer.text_config
+                (outer.text_config, true)
             } else {
-                // Fallback: try direct deserialization (text-only config)
-                serde_json::from_slice(&config_data)?
+                (serde_json::from_slice(&config_data)?, false)
             };
 
-        let inner = Gemma4Model::new(&text_config, vb)?;
+        let inner = Gemma4Model::new(&text_config, vb, is_multimodal)?;
 
         Ok(Self {
             tokenizer: TokenOutputStream::new(tokenizer),

--- a/crane-core/src/models/gemma4/model.rs
+++ b/crane-core/src/models/gemma4/model.rs
@@ -1,0 +1,197 @@
+#[cfg(feature = "mkl")]
+extern crate intel_mkl_src;
+
+#[cfg(feature = "accelerate")]
+extern crate accelerate_src;
+
+use std::io::Write;
+
+use anyhow::{Error as E, Result};
+
+use candle_core::{DType, Device, Tensor};
+use candle_nn::VarBuilder;
+use candle_transformers::generation::LogitsProcessor;
+use tokenizers::Tokenizer;
+
+use super::modeling::{Gemma4Config, Gemma4Model, Gemma4TextConfig};
+use crate::generation::based::ModelForCausalLM;
+use crate::generation::GenerationConfig;
+use crate::utils::token_output_stream::TokenOutputStream;
+use crate::utils::utils;
+
+pub struct Model {
+    pub tokenizer: TokenOutputStream,
+    pub device: Device,
+    pub dtype: DType,
+    inner: Gemma4Model,
+}
+
+impl Model {
+    pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
+        Self::from_pretrained(model_path, device, dtype)
+    }
+
+    fn forward(&mut self, xs: &Tensor, s: usize) -> candle_core::Result<Tensor> {
+        self.inner.forward(xs, s)
+    }
+
+    pub fn clear_kv_cache(&mut self) {
+        self.inner.clear_kv_cache();
+    }
+
+    fn from_pretrained(model_path: &str, device: &Device, dtype: &DType) -> Result<Model> {
+        let tokenizer_path = std::path::Path::new(model_path).join("tokenizer.json");
+        if !tokenizer_path.exists() {
+            anyhow::bail!("Tokenizer not found at {}", tokenizer_path.display());
+        }
+        let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(E::msg)?;
+
+        let filenames = utils::get_safetensors_files(model_path)?;
+        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, *dtype, device) }?;
+
+        let config_file = std::path::Path::new(model_path).join("config.json");
+        let config_data = std::fs::read(config_file)?;
+
+        // Gemma 4 config.json has text_config nested under the top level
+        let text_config: Gemma4TextConfig =
+            if let Ok(outer) = serde_json::from_slice::<Gemma4Config>(&config_data) {
+                outer.text_config
+            } else {
+                // Fallback: try direct deserialization (text-only config)
+                serde_json::from_slice(&config_data)?
+            };
+
+        let inner = Gemma4Model::new(&text_config, vb)?;
+
+        Ok(Self {
+            tokenizer: TokenOutputStream::new(tokenizer),
+            device: device.clone(),
+            dtype: *dtype,
+            inner,
+        })
+    }
+
+    pub fn prepare_inputs(&self, inputs: &str) -> Result<Vec<u32>> {
+        let input_ids = self
+            .tokenizer
+            .tokenizer
+            .encode(inputs, true)
+            .map_err(E::msg)
+            .unwrap()
+            .get_ids()
+            .to_vec();
+        Ok(input_ids)
+    }
+
+    pub fn forward_step(
+        &mut self,
+        input_ids: &[u32],
+        start_pos: usize,
+    ) -> candle_core::Result<Tensor> {
+        let input = Tensor::new(input_ids, &self.device)?.unsqueeze(0)?;
+        self.inner.forward(&input, start_pos)
+    }
+
+    // ── KV cache management ────────────────────────────────────────────
+
+    pub fn num_layers(&self) -> usize {
+        self.inner.num_layers()
+    }
+
+    pub fn active_kv_cache_bytes(&self) -> u64 {
+        self.inner.active_kv_cache_bytes()
+    }
+
+    pub fn warmup(&mut self) {
+        if let Err(e) = self.generate(
+            &[2, 651, 9456],
+            &GenerationConfig::with_max_tokens(5),
+            None,
+        ) {
+            eprintln!("warmup failed (non-fatal): {e}");
+        }
+        self.clear_kv_cache();
+    }
+}
+
+impl ModelForCausalLM for Model {
+    fn device(&self) -> &Device {
+        &self.device
+    }
+
+    fn generate(
+        &mut self,
+        input_ids: &[u32],
+        config: &GenerationConfig,
+        mut streamer: Option<&mut dyn crate::generation::streamer::TokenStreamer>,
+    ) -> Result<Vec<u32>> {
+        self.tokenizer.clear();
+        self.clear_kv_cache();
+
+        let mut logits_processor = LogitsProcessor::new(1024, config.temperature, config.top_p);
+
+        let mut tokens = input_ids.to_vec();
+        std::io::stdout().flush()?;
+
+        let mut generated_tokens = 0usize;
+        // Gemma 4: EOS token ID 1, plus <end_of_turn> (107)
+        let eos_token: Option<u32> = config
+            .eos_token_id
+            .or_else(|| self.tokenizer.get_token("<end_of_turn>"))
+            .or(Some(1));
+        let eos_token_2: Option<u32> = self.tokenizer.get_token("<eos>");
+        let mut streamer_finalized = false;
+
+        let start_gen = std::time::Instant::now();
+        for index in 0..config.max_new_tokens {
+            let context_size = if index > 0 { 1 } else { tokens.len() };
+            let start_pos = tokens.len().saturating_sub(context_size);
+            let ctxt = &tokens[start_pos..];
+            let input = Tensor::new(ctxt, &self.device)?.unsqueeze(0)?;
+
+            let logits = self.forward(&input, start_pos)?;
+            let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
+            let logits = if config.repetition_penalty == 1. {
+                logits
+            } else {
+                let start_at = tokens.len().saturating_sub(config.repeat_last_n);
+                candle_transformers::utils::apply_repeat_penalty(
+                    &logits,
+                    config.repetition_penalty,
+                    &tokens[start_at..],
+                )?
+            };
+
+            let next_token = logits_processor.sample(&logits)?;
+            tokens.push(next_token);
+            generated_tokens += 1;
+
+            if eos_token == Some(next_token) || eos_token_2 == Some(next_token) {
+                if let Some(ref mut s) = streamer {
+                    s.finalize()?;
+                }
+                streamer_finalized = true;
+                break;
+            }
+
+            if let Some(ref mut s) = streamer {
+                s.append(next_token)?;
+            }
+        }
+        let dt = start_gen.elapsed();
+        if let Some(ref mut s) = streamer {
+            if !streamer_finalized {
+                s.finalize()?;
+            }
+        }
+
+        if config.report_speed {
+            println!(
+                "\n{generated_tokens} tokens generated ({:.2} token/s)\n",
+                generated_tokens as f64 / dt.as_secs_f64(),
+            );
+        }
+
+        Ok(tokens)
+    }
+}

--- a/crane-core/src/models/gemma4/model.rs
+++ b/crane-core/src/models/gemma4/model.rs
@@ -166,8 +166,7 @@ impl Model {
             .tokenizer
             .tokenizer
             .encode(inputs, true)
-            .map_err(E::msg)
-            .unwrap()
+            .map_err(E::msg)?
             .get_ids()
             .to_vec();
         Ok(input_ids)

--- a/crane-core/src/models/gemma4/model.rs
+++ b/crane-core/src/models/gemma4/model.rs
@@ -19,6 +19,17 @@ use crate::generation::GenerationConfig;
 use crate::utils::token_output_stream::TokenOutputStream;
 use crate::utils::utils;
 
+/// Format of model weights on disk.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ModelFormat {
+    /// Auto-detect from path (default).
+    Auto,
+    /// Standard HuggingFace safetensors.
+    Safetensors,
+    /// GGUF quantized format.
+    Gguf,
+}
+
 pub struct Model {
     pub tokenizer: TokenOutputStream,
     pub device: Device,
@@ -28,7 +39,35 @@ pub struct Model {
 
 impl Model {
     pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
-        Self::from_pretrained(model_path, device, dtype)
+        Self::new_with_format(model_path, device, dtype, ModelFormat::Auto)
+    }
+
+    pub fn new_with_format(
+        model_path: &str,
+        device: &Device,
+        dtype: &DType,
+        format: ModelFormat,
+    ) -> Result<Self> {
+        let format = match format {
+            ModelFormat::Auto => {
+                let p = std::path::Path::new(model_path);
+                if p.is_file()
+                    && p.extension()
+                        .map(|e| e == "gguf")
+                        .unwrap_or(false)
+                {
+                    ModelFormat::Gguf
+                } else {
+                    ModelFormat::Safetensors
+                }
+            }
+            other => other,
+        };
+
+        match format {
+            ModelFormat::Gguf | ModelFormat::Auto => Self::from_gguf(model_path, device),
+            ModelFormat::Safetensors => Self::from_pretrained(model_path, device, dtype),
+        }
     }
 
     fn forward(&mut self, xs: &Tensor, s: usize) -> candle_core::Result<Tensor> {
@@ -67,6 +106,56 @@ impl Model {
             tokenizer: TokenOutputStream::new(tokenizer),
             device: device.clone(),
             dtype: *dtype,
+            inner,
+        })
+    }
+
+    /// Load a GGUF quantized model file.
+    fn from_gguf(model_path: &str, device: &Device) -> Result<Model> {
+        let gguf_path = std::path::Path::new(model_path);
+
+        let tokenizer_path = {
+            let same_dir = gguf_path
+                .parent()
+                .unwrap_or(gguf_path)
+                .join("tokenizer.json");
+            if same_dir.exists() {
+                same_dir
+            } else {
+                let parent = gguf_path
+                    .parent()
+                    .and_then(|p| p.parent())
+                    .unwrap_or(gguf_path)
+                    .join("tokenizer.json");
+                if parent.exists() {
+                    parent
+                } else {
+                    anyhow::bail!(
+                        "Cannot find tokenizer.json near {}. \
+                         Place tokenizer.json in the same directory as the GGUF file.",
+                        gguf_path.display()
+                    );
+                }
+            }
+        };
+        let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(E::msg)?;
+
+        let mut file = std::fs::File::open(gguf_path)?;
+        let ct = candle_core::quantized::gguf_file::Content::read(&mut file)?;
+
+        eprintln!(
+            "GGUF loaded: {} tensors, {} metadata entries",
+            ct.tensor_infos.len(),
+            ct.metadata.len(),
+        );
+
+        let inner = Gemma4Model::from_gguf(ct, &mut file, device)?;
+        let dtype = inner.model_dtype();
+
+        Ok(Self {
+            tokenizer: TokenOutputStream::new(tokenizer),
+            device: device.clone(),
+            dtype,
             inner,
         })
     }

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -495,9 +495,9 @@ impl Attention {
         let n_rep = self.num_heads / self.num_kv_heads;
 
         if n_rep > 1 && seq_len == 1 {
-            let scale = 1.0 / (self.head_dim as f64).sqrt();
+            // Gemma4: scaling = 1.0 (QK norms handle normalization)
             let q_g =
-                (q.reshape((b_sz, self.num_kv_heads, n_rep, self.head_dim))? * scale)?;
+                q.reshape((b_sz, self.num_kv_heads, n_rep, self.head_dim))?;
             let k_t = k.transpose(2, 3)?;
             let attn_weights = q_g.matmul(&k_t)?;
 
@@ -531,8 +531,8 @@ impl Attention {
             v
         };
 
-        let scale = 1.0 / (self.head_dim as f64).sqrt();
-        let attn_weights = (q.matmul(&k.transpose(D::Minus2, D::Minus1)?)? * scale)?;
+        // Gemma4: scaling = 1.0 (QK norms handle normalization)
+        let attn_weights = q.matmul(&k.transpose(D::Minus2, D::Minus1)?)?;
         let attn_weights = match attention_mask {
             Some(mask) => attn_weights.broadcast_add(mask)?,
             None => attn_weights,
@@ -761,6 +761,7 @@ impl DecoderLayer {
         rotated_dim: Option<usize>,
         shared_kv: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
+        let seq_len = hidden_states.dim(1)?;
         // Pre-norm → attention → post-norm → residual
         let residual = hidden_states;
         let hidden_states = self.input_layernorm.forward(hidden_states)?;
@@ -773,6 +774,7 @@ impl DecoderLayer {
             rotated_dim,
             shared_kv,
         )?;
+
         let hidden_states = self.post_attention_layernorm.forward(&hidden_states)?;
         let hidden_states = (residual + hidden_states)?;
 
@@ -1337,6 +1339,7 @@ impl Gemma4Model {
         let logits = self
             .lm_head
             .forward(&hidden_states.narrow(1, seq_len - 1, 1)?)?;
+
 
         // Logit softcapping
         if let Some(cap) = self.config.final_logit_softcapping {

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -242,6 +242,16 @@ fn apply_partial_rope(
     ))
 }
 
+/// RMS normalization without learnable scale (Gemma4's v_norm uses with_scale=False).
+fn rms_normalize(x: &Tensor, eps: f64) -> Result<Tensor> {
+    let dtype = x.dtype();
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let variance = x_f32.sqr()?.mean_keepdim(D::Minus1)?;
+    let rms = (variance + eps)?.sqrt()?;
+    let normed = x_f32.broadcast_div(&rms)?;
+    normed.to_dtype(dtype)
+}
+
 // ── Attention ───────────────────────────────────────────────────────────
 
 struct Attention {
@@ -251,6 +261,7 @@ struct Attention {
     o_proj: LinearLayer,
     q_norm: RmsNorm,
     k_norm: Option<RmsNorm>,
+    rms_norm_eps: f64,
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -313,6 +324,7 @@ impl Attention {
             o_proj,
             q_norm,
             k_norm,
+            rms_norm_eps: config.rms_norm_eps,
             num_heads,
             num_kv_heads,
             head_dim,
@@ -355,6 +367,7 @@ impl Attention {
             o_proj,
             q_norm,
             k_norm,
+            rms_norm_eps,
             num_heads,
             num_kv_heads,
             head_dim,
@@ -454,6 +467,8 @@ impl Attention {
                 .transpose(1, 2)?;
             // k_norm applied before RoPE
             let k = self.k_norm.as_ref().unwrap().forward(&k)?;
+            // v_norm: RMS normalization without learnable scale (with_scale=False in HF)
+            let v = rms_normalize(&v, self.rms_norm_eps)?;
             (k, v)
         };
 

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -731,14 +731,14 @@ impl DecoderLayer {
         let input_layernorm =
             gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_norm.weight"), config.rms_norm_eps)?;
         let post_attention_layernorm =
-            gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_post_norm.weight"), config.rms_norm_eps)?;
+            gemma_rms_norm_gguf(gg, &format!("{prefix}.post_attention_norm.weight"), config.rms_norm_eps)?;
         let pre_feedforward_layernorm =
             gemma_rms_norm_gguf(gg, &format!("{prefix}.ffn_norm.weight"), config.rms_norm_eps)?;
         let post_feedforward_layernorm =
-            gemma_rms_norm_gguf(gg, &format!("{prefix}.ffn_post_norm.weight"), config.rms_norm_eps)?;
+            gemma_rms_norm_gguf(gg, &format!("{prefix}.post_ffw_norm.weight"), config.rms_norm_eps)?;
 
         // Layer scalar: GGUF stores it as a tensor
-        let layer_scalar = match gg.tensor(&format!("{prefix}.layer_output_scale")) {
+        let layer_scalar = match gg.tensor(&format!("{prefix}.layer_output_scale.weight")) {
             Ok(qt) => qt.dequantize(&Device::Cpu).unwrap_or_else(|_| {
                 Tensor::ones(1, DType::F32, &Device::Cpu).unwrap()
             }),
@@ -986,8 +986,26 @@ impl Gemma4Model {
             md_get(&format!("{arch}.attention.head_count_kv"))?.to_u32()? as usize;
         let num_hidden_layers = md_get(&format!("{arch}.block_count"))?.to_u32()? as usize;
         let hidden_size = md_get(&format!("{arch}.embedding_length"))?.to_u32()? as usize;
-        let intermediate_size =
-            md_get(&format!("{arch}.feed_forward_length"))?.to_u32()? as usize;
+        // feed_forward_length can be a single u32 or a per-layer i32 array (Gemma4 uses
+        // different sizes for non-shared vs shared layers due to use_double_wide_mlp).
+        let ff_value = md_get(&format!("{arch}.feed_forward_length"))?;
+        let (intermediate_size, per_layer_ff) = match &ff_value {
+            gguf_file::Value::U32(v) => (*v as usize, None),
+            gguf_file::Value::I32(v) => (*v as usize, None),
+            gguf_file::Value::Array(arr) => {
+                let sizes: Vec<usize> = arr
+                    .iter()
+                    .map(|v| match v {
+                        gguf_file::Value::I32(n) => *n as usize,
+                        gguf_file::Value::U32(n) => *n as usize,
+                        _ => 6144,
+                    })
+                    .collect();
+                let first = sizes.first().copied().unwrap_or(6144);
+                (first, Some(sizes))
+            }
+            _ => candle_core::bail!("unexpected type for feed_forward_length"),
+        };
         let max_position_embeddings = gg
             .metadata()
             .get(&format!("{arch}.context_length"))
@@ -1144,11 +1162,11 @@ impl Gemma4Model {
         let sliding_theta = 10_000.0;
         let full_theta = rope_theta;
 
-        let full_rotated_dim = gg
-            .metadata()
-            .get(&format!("{arch}.rope.dimension_count"))
-            .and_then(|v| v.to_u32().ok())
-            .unwrap_or((global_head_dim / 4) as u32) as usize;
+        // rope.dimension_count stores the full head_dim for full-attention layers.
+        // For partial RoPE (Gemma4), the actual rotated dim is global_head_dim * partial_rotary_factor.
+        // The partial_rotary_factor (0.25) is not stored in GGUF, so we derive it:
+        // rotated_dim = global_head_dim / 4 = 512 / 4 = 128
+        let full_rotated_dim = global_head_dim / 4;
 
         let rotary_sliding = RotaryEmbedding::new(
             sliding_theta,

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -30,6 +30,30 @@ use std::io::{Read, Seek};
 // Reuse the polymorphic linear layer and GGUF loader from the shared Hunyuan module.
 pub use crate::models::hunyuan_dense::modeling::{Gguf, LinearLayer};
 
+/// Create an RmsNorm with Gemma-style weight shift.
+///
+/// Gemma's RMSNorm uses `output = x * (1 + weight)` instead of `output = x * weight`.
+/// Weights in HF checkpoints are stored as the raw trained values (initialized near 0),
+/// so we add 1.0 to convert them for candle's standard `x * weight` formula.
+fn gemma_rms_norm(size: usize, eps: f64, vb: VarBuilder) -> Result<RmsNorm> {
+    let weight = vb.get(size, "weight")?;
+    let shifted = (weight + 1.0)?;
+    Ok(RmsNorm::new(shifted, eps))
+}
+
+/// Same shift for GGUF norms: Gemma4 stores raw weights (norm_shift=0),
+/// so we must add 1.0 for the `x * weight` formula.
+fn gemma_rms_norm_gguf<R: Read + Seek>(
+    gg: &mut Gguf<R>,
+    name: &str,
+    eps: f64,
+) -> Result<RmsNorm> {
+    let norm = gg.rms_norm(name, eps)?;
+    let weight = norm.into_inner().weight().clone();
+    let shifted = (weight + 1.0)?;
+    Ok(RmsNorm::new(shifted, eps))
+}
+
 // ── Event-tracking RAII guard ────────────────────────────────────────────
 
 #[cfg(feature = "cuda")]
@@ -263,7 +287,7 @@ impl Attention {
         )?);
 
         // QK norms: q_norm always, k_norm only for non-shared layers
-        let q_norm = candle_nn::rms_norm(head_dim, config.rms_norm_eps, vb.pp("q_norm"))?;
+        let q_norm = gemma_rms_norm(head_dim, config.rms_norm_eps, vb.pp("q_norm"))?;
 
         let (k_proj, v_proj, k_norm) = if is_shared {
             (None, None, None)
@@ -278,7 +302,7 @@ impl Attention {
                 num_kv_heads * head_dim,
                 vb.pp("v_proj"),
             )?);
-            let kn = candle_nn::rms_norm(head_dim, config.rms_norm_eps, vb.pp("k_norm"))?;
+            let kn = gemma_rms_norm(head_dim, config.rms_norm_eps, vb.pp("k_norm"))?;
             (Some(k), Some(v), Some(kn))
         };
 
@@ -317,14 +341,14 @@ impl Attention {
         let prefix = format!("blk.{layer_idx}");
 
         let q_proj = gg.linear(&format!("{prefix}.attn_q.weight"))?;
-        let q_norm = gg.rms_norm(&format!("{prefix}.attn_q_norm.weight"), rms_norm_eps)?;
+        let q_norm = gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_q_norm.weight"), rms_norm_eps)?;
 
         let (k_proj, v_proj, k_norm) = if is_shared {
             (None, None, None)
         } else {
             let k = gg.linear(&format!("{prefix}.attn_k.weight"))?;
             let v = gg.linear(&format!("{prefix}.attn_v.weight"))?;
-            let kn = gg.rms_norm(&format!("{prefix}.attn_k_norm.weight"), rms_norm_eps)?;
+            let kn = gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_k_norm.weight"), rms_norm_eps)?;
             (Some(k), Some(v), Some(kn))
         };
 
@@ -619,22 +643,22 @@ impl DecoderLayer {
         let self_attn = Attention::new(config, layer_type, is_shared, vb.pp("self_attn"))?;
         let mlp = Mlp::new(config, intermediate_size, vb.pp("mlp"))?;
 
-        let input_layernorm = candle_nn::rms_norm(
+        let input_layernorm = gemma_rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             vb.pp("input_layernorm"),
         )?;
-        let post_attention_layernorm = candle_nn::rms_norm(
+        let post_attention_layernorm = gemma_rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             vb.pp("post_attention_layernorm"),
         )?;
-        let pre_feedforward_layernorm = candle_nn::rms_norm(
+        let pre_feedforward_layernorm = gemma_rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             vb.pp("pre_feedforward_layernorm"),
         )?;
-        let post_feedforward_layernorm = candle_nn::rms_norm(
+        let post_feedforward_layernorm = gemma_rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             vb.pp("post_feedforward_layernorm"),
@@ -658,7 +682,7 @@ impl DecoderLayer {
             vb.pp("per_layer_projection"),
         )?);
         let post_per_layer_input_norm =
-            candle_nn::rms_norm(config.hidden_size, config.rms_norm_eps, vb.pp("post_per_layer_input_norm"))?;
+            gemma_rms_norm(config.hidden_size, config.rms_norm_eps, vb.pp("post_per_layer_input_norm"))?;
 
         Ok(Self {
             self_attn,
@@ -696,13 +720,13 @@ impl DecoderLayer {
         let prefix = format!("blk.{layer_idx}");
 
         let input_layernorm =
-            gg.rms_norm(&format!("{prefix}.attn_norm.weight"), config.rms_norm_eps)?;
+            gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_norm.weight"), config.rms_norm_eps)?;
         let post_attention_layernorm =
-            gg.rms_norm(&format!("{prefix}.attn_post_norm.weight"), config.rms_norm_eps)?;
+            gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_post_norm.weight"), config.rms_norm_eps)?;
         let pre_feedforward_layernorm =
-            gg.rms_norm(&format!("{prefix}.ffn_norm.weight"), config.rms_norm_eps)?;
+            gemma_rms_norm_gguf(gg, &format!("{prefix}.ffn_norm.weight"), config.rms_norm_eps)?;
         let post_feedforward_layernorm =
-            gg.rms_norm(&format!("{prefix}.ffn_post_norm.weight"), config.rms_norm_eps)?;
+            gemma_rms_norm_gguf(gg, &format!("{prefix}.ffn_post_norm.weight"), config.rms_norm_eps)?;
 
         // Layer scalar: GGUF stores it as a tensor
         let layer_scalar = match gg.tensor(&format!("{prefix}.layer_output_scale")) {
@@ -716,7 +740,7 @@ impl DecoderLayer {
         let per_layer_input_gate = gg.linear(&format!("{prefix}.inp_gate.weight"))?;
         let per_layer_projection = gg.linear(&format!("{prefix}.proj.weight"))?;
         let post_per_layer_input_norm =
-            gg.rms_norm(&format!("{prefix}.post_norm.weight"), config.rms_norm_eps)?;
+            gemma_rms_norm_gguf(gg, &format!("{prefix}.post_norm.weight"), config.rms_norm_eps)?;
 
         Ok(Self {
             self_attn,
@@ -846,7 +870,7 @@ impl Gemma4Model {
             ple_total_dim,
             model_vb.pp("per_layer_model_projection"),
         )?);
-        let per_layer_projection_norm = candle_nn::rms_norm(
+        let per_layer_projection_norm = gemma_rms_norm(
             ple_dim,
             config.rms_norm_eps,
             model_vb.pp("per_layer_projection_norm"),
@@ -873,7 +897,7 @@ impl Gemma4Model {
             }
         }
 
-        let norm = candle_nn::rms_norm(
+        let norm = gemma_rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             model_vb.pp("norm"),
@@ -1070,7 +1094,7 @@ impl Gemma4Model {
         // Model-level PLE projection
         let per_layer_model_projection = gg.linear("per_layer_model_proj.weight")?;
         let per_layer_projection_norm =
-            gg.rms_norm("per_layer_proj_norm.weight", rms_norm_eps)?;
+            gemma_rms_norm_gguf(&mut gg, "per_layer_proj_norm.weight", rms_norm_eps)?;
 
         let config = Gemma4TextConfig {
             vocab_size: actual_vocab_size,
@@ -1098,7 +1122,7 @@ impl Gemma4Model {
             }
         }
 
-        let norm = gg.rms_norm("output_norm.weight", rms_norm_eps)?;
+        let norm = gemma_rms_norm_gguf(&mut gg, "output_norm.weight", rms_norm_eps)?;
 
         let lm_head = if tie_word_embeddings {
             LinearLayer::Standard(Linear::new(embed_tokens.embeddings().clone(), None))

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -14,8 +14,10 @@
 //! 6. **Logit softcapping** — `tanh(logits / cap) * cap` before output.
 //! 7. **Pre-allocated KV cache** with in-place `slice_set` writes.
 //! 8. **GQA-grouped SDPA** for decode (seq_len=1).
-//! 9. **GGUF quantization** via the polymorphic `LinearLayer` enum
-//!    — Same model code serves both safetensors (f16/f32/bf16) and GGUF weights.
+//! 9. **GGUF quantization** via the polymorphic `LinearLayer` enum.
+//! 10. **Pre+post norm pairs** — 4 norms per layer (Gemma-style).
+//! 11. **QK norms** — per-head RMSNorm applied before RoPE.
+//! 12. **Layer scalar** — learnable per-layer scaling factor.
 
 use candle_core::quantized::gguf_file;
 use candle_core::{DType, Device, Module, Result, Tensor, D};
@@ -115,26 +117,22 @@ impl Gemma4TextConfig {
         self.global_head_dim.unwrap_or(self.head_dim)
     }
 
-    /// Parse layer types from config strings.
     pub fn parsed_layer_types(&self) -> Vec<LayerType> {
         self.layer_types
             .iter()
             .map(|s| match s.as_str() {
                 "sliding_attention" => LayerType::SlidingAttention,
                 "full_attention" => LayerType::FullAttention,
-                _ => LayerType::SlidingAttention, // fallback
+                _ => LayerType::SlidingAttention,
             })
             .collect()
     }
 
-    /// First shared layer index.
     pub fn first_kv_shared_layer(&self) -> usize {
         let n_shared = self.num_kv_shared_layers.unwrap_or(0);
         self.num_hidden_layers.saturating_sub(n_shared)
     }
 
-    /// Build the KV sharing map: for each layer, `Some(source_layer)` if shared,
-    /// `None` if the layer computes its own K/V.
     pub fn kv_sharing_map(&self) -> Vec<Option<usize>> {
         let layer_types = self.parsed_layer_types();
         let first_shared = self.first_kv_shared_layer();
@@ -147,7 +145,6 @@ impl Gemma4TextConfig {
                 if i < first_shared {
                     None
                 } else {
-                    // Find the last non-shared layer of the same type
                     non_shared_types
                         .iter()
                         .enumerate()
@@ -175,7 +172,6 @@ struct RotaryEmbedding {
 
 impl RotaryEmbedding {
     fn new(theta: f64, dim: usize, max_pos: usize, device: &Device) -> Result<Self> {
-        // inv_freq: [dim/2]
         let inv: Vec<f32> = (0..dim)
             .step_by(2)
             .map(|i| 1.0 / theta.powf(i as f64 / dim as f64) as f32)
@@ -186,7 +182,7 @@ impl RotaryEmbedding {
         let positions = Tensor::new(positions.as_slice(), device)?;
         let freqs = positions
             .unsqueeze(1)?
-            .matmul(&inv_freq.unsqueeze(0)?)?; // [max_pos, dim/2]
+            .matmul(&inv_freq.unsqueeze(0)?)?;
 
         let cos_table = freqs.cos()?.contiguous()?;
         let sin_table = freqs.sin()?.contiguous()?;
@@ -204,11 +200,6 @@ impl RotaryEmbedding {
     }
 }
 
-/// Apply partial RoPE for full-attention layers.
-///
-/// The fused `rope()` kernel requires `cos_dim * 2 == head_dim`, which fails
-/// for full-attention (64*2=128 != 512). We manually split Q/K, apply rope
-/// to the rotated portion, and reassemble.
 fn apply_partial_rope(
     q: &Tensor,
     k: &Tensor,
@@ -240,6 +231,8 @@ struct Attention {
     k_proj: Option<LinearLayer>,
     v_proj: Option<LinearLayer>,
     o_proj: LinearLayer,
+    q_norm: RmsNorm,
+    k_norm: Option<RmsNorm>,
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -269,8 +262,11 @@ impl Attention {
             vb.pp("q_proj"),
         )?);
 
-        let (k_proj, v_proj) = if is_shared {
-            (None, None)
+        // QK norms: q_norm always, k_norm only for non-shared layers
+        let q_norm = candle_nn::rms_norm(head_dim, config.rms_norm_eps, vb.pp("q_norm"))?;
+
+        let (k_proj, v_proj, k_norm) = if is_shared {
+            (None, None, None)
         } else {
             let k = LinearLayer::Standard(linear_no_bias(
                 config.hidden_size,
@@ -282,7 +278,8 @@ impl Attention {
                 num_kv_heads * head_dim,
                 vb.pp("v_proj"),
             )?);
-            (Some(k), Some(v))
+            let kn = candle_nn::rms_norm(head_dim, config.rms_norm_eps, vb.pp("k_norm"))?;
+            (Some(k), Some(v), Some(kn))
         };
 
         let o_proj = LinearLayer::Standard(linear_no_bias(
@@ -296,6 +293,8 @@ impl Attention {
             k_proj,
             v_proj,
             o_proj,
+            q_norm,
+            k_norm,
             num_heads,
             num_kv_heads,
             head_dim,
@@ -306,25 +305,27 @@ impl Attention {
         })
     }
 
-    /// Construct from GGUF quantized weights.
     fn new_from_gguf<R: Read + Seek>(
         num_heads: usize,
         num_kv_heads: usize,
         head_dim: usize,
         is_shared: bool,
+        rms_norm_eps: f64,
         gg: &mut Gguf<R>,
         layer_idx: usize,
     ) -> Result<Self> {
         let prefix = format!("blk.{layer_idx}");
 
         let q_proj = gg.linear(&format!("{prefix}.attn_q.weight"))?;
+        let q_norm = gg.rms_norm(&format!("{prefix}.attn_q_norm.weight"), rms_norm_eps)?;
 
-        let (k_proj, v_proj) = if is_shared {
-            (None, None)
+        let (k_proj, v_proj, k_norm) = if is_shared {
+            (None, None, None)
         } else {
             let k = gg.linear(&format!("{prefix}.attn_k.weight"))?;
             let v = gg.linear(&format!("{prefix}.attn_v.weight"))?;
-            (Some(k), Some(v))
+            let kn = gg.rms_norm(&format!("{prefix}.attn_k_norm.weight"), rms_norm_eps)?;
+            (Some(k), Some(v), Some(kn))
         };
 
         let o_proj = gg.linear(&format!("{prefix}.attn_output.weight"))?;
@@ -334,6 +335,8 @@ impl Attention {
             k_proj,
             v_proj,
             o_proj,
+            q_norm,
+            k_norm,
             num_heads,
             num_kv_heads,
             head_dim,
@@ -344,7 +347,6 @@ impl Attention {
         })
     }
 
-    /// Update the pre-allocated KV cache with new K,V tensors.
     fn update_kv_cache(&mut self, k: Tensor, v: Tensor) -> Result<(Tensor, Tensor)> {
         let k = k.contiguous()?;
         let v = v.contiguous()?;
@@ -417,9 +419,10 @@ impl Attention {
         let q = q
             .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
             .transpose(1, 2)?;
+        // QK norm: q_norm applied before RoPE
+        let q = self.q_norm.forward(&q)?;
 
         let (k, v) = if self.is_shared {
-            // Shared layer: read K/V from the source layer's cache
             let (sk, sv) = shared_kv.expect("shared layer must have shared KV state");
             (sk.clone(), sv.clone())
         } else {
@@ -431,6 +434,8 @@ impl Attention {
             let v = v
                 .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
                 .transpose(1, 2)?;
+            // k_norm applied before RoPE
+            let k = self.k_norm.as_ref().unwrap().forward(&k)?;
             (k, v)
         };
 
@@ -448,7 +453,6 @@ impl Attention {
             LayerType::FullAttention => {
                 let rdim = rotated_dim.unwrap_or(self.head_dim);
                 if self.is_shared {
-                    // Only rotate Q
                     let full_dim = q.dim(D::Minus1)?;
                     let pass_dim = full_dim - rdim;
                     let q_rot = q.narrow(D::Minus1, 0, rdim)?;
@@ -473,7 +477,6 @@ impl Attention {
         let n_rep = self.num_heads / self.num_kv_heads;
 
         if n_rep > 1 && seq_len == 1 {
-            // GQA-grouped SDPA for decode (seq_len=1)
             let scale = 1.0 / (self.head_dim as f64).sqrt();
             let q_g =
                 (q.reshape((b_sz, self.num_kv_heads, n_rep, self.head_dim))? * scale)?;
@@ -493,7 +496,6 @@ impl Attention {
             return self.o_proj.forward(&attn_output);
         }
 
-        // Standard SDPA for prefill or when n_rep == 1
         let k = if n_rep > 1 {
             let (b, kv_heads, s, d) = k.dims4()?;
             k.unsqueeze(2)?
@@ -567,10 +569,7 @@ impl Mlp {
         })
     }
 
-    fn new_from_gguf<R: Read + Seek>(
-        gg: &mut Gguf<R>,
-        layer_idx: usize,
-    ) -> Result<Self> {
+    fn new_from_gguf<R: Read + Seek>(gg: &mut Gguf<R>, layer_idx: usize) -> Result<Self> {
         let prefix = format!("blk.{layer_idx}");
         let gate_proj = gg.linear(&format!("{prefix}.ffn_gate.weight"))?;
         let up_proj = gg.linear(&format!("{prefix}.ffn_up.weight"))?;
@@ -595,8 +594,13 @@ impl Mlp {
 struct DecoderLayer {
     self_attn: Attention,
     mlp: Mlp,
+    // Gemma-style pre+post norm pairs (4 norms total)
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
+    pre_feedforward_layernorm: RmsNorm,
+    post_feedforward_layernorm: RmsNorm,
+    // Per-layer scalar
+    layer_scalar: Tensor,
     // PLE components (per-layer)
     per_layer_input_gate: LinearLayer,
     per_layer_projection: LinearLayer,
@@ -624,6 +628,21 @@ impl DecoderLayer {
             config.rms_norm_eps,
             vb.pp("post_attention_layernorm"),
         )?;
+        let pre_feedforward_layernorm = candle_nn::rms_norm(
+            config.hidden_size,
+            config.rms_norm_eps,
+            vb.pp("pre_feedforward_layernorm"),
+        )?;
+        let post_feedforward_layernorm = candle_nn::rms_norm(
+            config.hidden_size,
+            config.rms_norm_eps,
+            vb.pp("post_feedforward_layernorm"),
+        )?;
+
+        // Layer scalar: loaded from checkpoint, shape [1]
+        let layer_scalar = vb
+            .get(1, "layer_scalar")
+            .unwrap_or_else(|_| Tensor::ones(1, DType::F32, vb.device()).unwrap());
 
         let ple_dim = config.hidden_size_per_layer_input.unwrap_or(256);
 
@@ -645,6 +664,9 @@ impl DecoderLayer {
             mlp,
             input_layernorm,
             post_attention_layernorm,
+            pre_feedforward_layernorm,
+            post_feedforward_layernorm,
+            layer_scalar,
             per_layer_input_gate,
             per_layer_projection,
             post_per_layer_input_norm,
@@ -665,6 +687,7 @@ impl DecoderLayer {
             config.num_key_value_heads,
             head_dim,
             is_shared,
+            config.rms_norm_eps,
             gg,
             layer_idx,
         )?;
@@ -674,22 +697,34 @@ impl DecoderLayer {
         let input_layernorm =
             gg.rms_norm(&format!("{prefix}.attn_norm.weight"), config.rms_norm_eps)?;
         let post_attention_layernorm =
+            gg.rms_norm(&format!("{prefix}.attn_post_norm.weight"), config.rms_norm_eps)?;
+        let pre_feedforward_layernorm =
             gg.rms_norm(&format!("{prefix}.ffn_norm.weight"), config.rms_norm_eps)?;
+        let post_feedforward_layernorm =
+            gg.rms_norm(&format!("{prefix}.ffn_post_norm.weight"), config.rms_norm_eps)?;
+
+        // Layer scalar: GGUF stores it as a tensor
+        let layer_scalar = match gg.tensor(&format!("{prefix}.layer_output_scale")) {
+            Ok(qt) => qt.dequantize(&Device::Cpu).unwrap_or_else(|_| {
+                Tensor::ones(1, DType::F32, &Device::Cpu).unwrap()
+            }),
+            Err(_) => Tensor::ones(1, DType::F32, &Device::Cpu).unwrap(),
+        };
 
         // PLE components
         let per_layer_input_gate = gg.linear(&format!("{prefix}.inp_gate.weight"))?;
         let per_layer_projection = gg.linear(&format!("{prefix}.proj.weight"))?;
-        let ple_dim = config.hidden_size_per_layer_input.unwrap_or(256);
         let post_per_layer_input_norm =
             gg.rms_norm(&format!("{prefix}.post_norm.weight"), config.rms_norm_eps)?;
-
-        let _ = ple_dim; // used for documentation only in GGUF path
 
         Ok(Self {
             self_attn,
             mlp,
             input_layernorm,
             post_attention_layernorm,
+            pre_feedforward_layernorm,
+            post_feedforward_layernorm,
+            layer_scalar,
             per_layer_input_gate,
             per_layer_projection,
             post_per_layer_input_norm,
@@ -707,7 +742,7 @@ impl DecoderLayer {
         rotated_dim: Option<usize>,
         shared_kv: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
-        // Pre-norm → attention → residual
+        // Pre-norm → attention → post-norm → residual
         let residual = hidden_states;
         let hidden_states = self.input_layernorm.forward(hidden_states)?;
         let hidden_states = self.self_attn.forward(
@@ -719,16 +754,25 @@ impl DecoderLayer {
             rotated_dim,
             shared_kv,
         )?;
+        let hidden_states = self.post_attention_layernorm.forward(&hidden_states)?;
         let hidden_states = (residual + hidden_states)?;
 
-        // Pre-norm → MLP → residual
+        // Pre-norm → MLP → post-norm → residual
         let residual = &hidden_states;
-        let hidden_states = self.post_attention_layernorm.forward(&hidden_states)?;
+        let hidden_states = self.pre_feedforward_layernorm.forward(&hidden_states)?;
         let hidden_states = self.mlp.forward(&hidden_states)?;
+        let hidden_states = self.post_feedforward_layernorm.forward(&hidden_states)?;
         let hidden_states = (residual + hidden_states)?;
 
         // PLE: gated per-layer embedding → residual
-        self.apply_ple(&hidden_states, per_layer_input)
+        let hidden_states = self.apply_ple(&hidden_states, per_layer_input)?;
+
+        // Layer scalar
+        let hidden_states = hidden_states.broadcast_mul(
+            &self.layer_scalar.to_dtype(hidden_states.dtype())?,
+        )?;
+
+        Ok(hidden_states)
     }
 
     fn apply_ple(&self, hidden_states: &Tensor, per_layer_input: &Tensor) -> Result<Tensor> {
@@ -737,7 +781,7 @@ impl DecoderLayer {
         let gated = (gate * per_layer_input)?;
         let projected = self.per_layer_projection.forward(&gated)?;
         let normed = self.post_per_layer_input_norm.forward(&projected)?;
-        (hidden_states + normed)
+        hidden_states + normed
     }
 
     fn clear_kv_cache(&mut self) {
@@ -750,6 +794,8 @@ impl DecoderLayer {
 pub struct Gemma4Model {
     embed_tokens: Embedding,
     embed_tokens_per_layer: Embedding,
+    per_layer_model_projection: LinearLayer,
+    per_layer_projection_norm: RmsNorm,
     layers: Vec<DecoderLayer>,
     norm: RmsNorm,
     lm_head: LinearLayer,
@@ -760,15 +806,23 @@ pub struct Gemma4Model {
     config: Gemma4TextConfig,
     dtype: DType,
     embed_scale: f64,
+    ple_embed_scale: f64,
+    ple_projection_scale: f64,
+    ple_input_scale: f64,
     sliding_window: usize,
     full_rotated_dim: usize,
 }
 
 impl Gemma4Model {
     /// Construct from safetensors / HuggingFace checkpoint.
-    pub fn new(config: &Gemma4TextConfig, vb: VarBuilder) -> Result<Self> {
+    /// `is_multimodal` controls whether tensors are under `model.language_model.` or `model.`.
+    pub fn new(config: &Gemma4TextConfig, vb: VarBuilder, is_multimodal: bool) -> Result<Self> {
         let dtype = vb.dtype();
-        let model_vb = vb.pp("model");
+        let model_vb = if is_multimodal {
+            vb.pp("model").pp("language_model")
+        } else {
+            vb.pp("model")
+        };
 
         let embed_tokens = candle_nn::embedding(
             config.vocab_size,
@@ -776,7 +830,6 @@ impl Gemma4Model {
             model_vb.pp("embed_tokens"),
         )?;
 
-        // PLE shared embedding table: [vocab_size_per_layer_input, num_layers * hidden_size_per_layer_input]
         let ple_vocab = config.vocab_size_per_layer_input.unwrap_or(config.vocab_size);
         let ple_dim = config.hidden_size_per_layer_input.unwrap_or(256);
         let ple_total_dim = config.num_hidden_layers * ple_dim;
@@ -784,6 +837,18 @@ impl Gemma4Model {
             ple_vocab,
             ple_total_dim,
             model_vb.pp("embed_tokens_per_layer"),
+        )?;
+
+        // Model-level PLE projection
+        let per_layer_model_projection = LinearLayer::Standard(linear_no_bias(
+            config.hidden_size,
+            ple_total_dim,
+            model_vb.pp("per_layer_model_projection"),
+        )?);
+        let per_layer_projection_norm = candle_nn::rms_norm(
+            ple_dim,
+            config.rms_norm_eps,
+            model_vb.pp("per_layer_projection_norm"),
         )?;
 
         let layer_types = config.parsed_layer_types();
@@ -807,7 +872,6 @@ impl Gemma4Model {
             model_vb.pp("norm"),
         )?;
 
-        // Tied embeddings: lm_head uses embed_tokens weights
         let lm_head = if config.tie_word_embeddings {
             LinearLayer::Standard(Linear::new(embed_tokens.embeddings().clone(), None))
         } else {
@@ -822,11 +886,16 @@ impl Gemma4Model {
             Self::build_rotary_embeddings(config, vb.device())?;
 
         let embed_scale = (config.hidden_size as f64).sqrt();
+        let ple_embed_scale = (ple_dim as f64).sqrt();
+        let ple_projection_scale = (config.hidden_size as f64).powf(-0.5);
+        let ple_input_scale = 2.0_f64.powf(-0.5);
         let sliding_window = config.sliding_window.unwrap_or(512);
 
         Ok(Self {
             embed_tokens,
             embed_tokens_per_layer,
+            per_layer_model_projection,
+            per_layer_projection_norm,
             layers,
             norm,
             lm_head,
@@ -837,6 +906,9 @@ impl Gemma4Model {
             config: config.clone(),
             dtype,
             embed_scale,
+            ple_embed_scale,
+            ple_projection_scale,
+            ple_input_scale,
             sliding_window,
             full_rotated_dim,
         })
@@ -866,7 +938,6 @@ impl Gemma4Model {
             .map(|s| s.clone())
             .unwrap_or_else(|| "gemma4".to_string());
 
-        // ── Read config from GGUF metadata ──
         let num_attention_heads =
             md_get(&format!("{arch}.attention.head_count"))?.to_u32()? as usize;
         let num_kv_heads =
@@ -891,7 +962,6 @@ impl Gemma4Model {
             .and_then(|v| v.to_f32().ok())
             .unwrap_or(1_000_000.0) as f64;
 
-        // Gemma4-specific: dual head_dim
         let global_head_dim = gg
             .metadata()
             .get(&format!("{arch}.attention.key_length"))
@@ -903,34 +973,29 @@ impl Gemma4Model {
             .and_then(|v| v.to_u32().ok())
             .unwrap_or(256) as usize;
 
-        // KV sharing
         let num_kv_shared_layers = gg
             .metadata()
             .get(&format!("{arch}.attention.shared_kv_layers"))
             .and_then(|v| v.to_u32().ok())
             .unwrap_or(0) as usize;
 
-        // PLE dimension
         let ple_dim = gg
             .metadata()
             .get(&format!("{arch}.embedding_length_per_layer_input"))
             .and_then(|v| v.to_u32().ok())
             .unwrap_or(256) as usize;
 
-        // Sliding window
         let sliding_window = gg
             .metadata()
             .get(&format!("{arch}.attention.sliding_window"))
             .and_then(|v| v.to_u32().ok())
             .unwrap_or(512) as usize;
 
-        // Logit softcapping
         let final_logit_softcapping = gg
             .metadata()
             .get(&format!("{arch}.final_logit_softcapping"))
             .and_then(|v| v.to_f32().ok());
 
-        // Layer types from sliding_window_pattern (bool array: true=sliding, false=full)
         let layer_types_str: Vec<String> = if let Some(gguf_file::Value::Array(arr)) = gg
             .metadata()
             .get(&format!("{arch}.attention.sliding_window_pattern"))
@@ -951,7 +1016,6 @@ impl Gemma4Model {
                 })
                 .collect()
         } else {
-            // Fallback: infer from E2B pattern [S,S,S,S,F] repeating
             (0..num_hidden_layers)
                 .map(|i| {
                     if i % 5 == 4 {
@@ -965,9 +1029,8 @@ impl Gemma4Model {
 
         let tie_word_embeddings = !gg.ct.tensor_infos.contains_key("output.weight");
 
-        // Build config
         let config = Gemma4TextConfig {
-            vocab_size: 0, // updated below
+            vocab_size: 0,
             hidden_size,
             intermediate_size,
             num_hidden_layers,
@@ -983,20 +1046,24 @@ impl Gemma4Model {
             sliding_window: Some(sliding_window),
             final_logit_softcapping,
             hidden_size_per_layer_input: Some(ple_dim),
-            vocab_size_per_layer_input: None, // set from actual embedding
+            vocab_size_per_layer_input: None,
             num_kv_shared_layers: Some(num_kv_shared_layers),
             layer_types: layer_types_str,
-            rope_parameters: None, // RoPE is configured via GGUF metadata directly
+            rope_parameters: None,
             eos_token_id: None,
         };
 
-        // ── Load weights ──
         let embed_tokens = gg.embedding("token_embd.weight", hidden_size)?;
         let actual_vocab_size = embed_tokens.embeddings().dim(0)?;
 
         let ple_total_dim = num_hidden_layers * ple_dim;
         let embed_tokens_per_layer = gg.embedding("per_layer_token_embd.weight", ple_total_dim)?;
         let ple_vocab = embed_tokens_per_layer.embeddings().dim(0)?;
+
+        // Model-level PLE projection
+        let per_layer_model_projection = gg.linear("per_layer_model_proj.weight")?;
+        let per_layer_projection_norm =
+            gg.rms_norm("per_layer_proj_norm.weight", rms_norm_eps)?;
 
         let config = Gemma4TextConfig {
             vocab_size: actual_vocab_size,
@@ -1032,13 +1099,9 @@ impl Gemma4Model {
             gg.linear("output.weight")?
         };
 
-        // ── Dual RoPE ──
-        // For GGUF, rope_theta from metadata is the full-attention theta.
-        // Sliding attention theta defaults to 10K.
         let sliding_theta = 10_000.0;
         let full_theta = rope_theta;
 
-        // Partial rotation for full-attention: from rope_dimension_count metadata
         let full_rotated_dim = gg
             .metadata()
             .get(&format!("{arch}.rope.dimension_count"))
@@ -1059,10 +1122,15 @@ impl Gemma4Model {
         )?;
 
         let embed_scale = (hidden_size as f64).sqrt();
+        let ple_embed_scale = (ple_dim as f64).sqrt();
+        let ple_projection_scale = (hidden_size as f64).powf(-0.5);
+        let ple_input_scale = 2.0_f64.powf(-0.5);
 
         Ok(Self {
             embed_tokens,
             embed_tokens_per_layer,
+            per_layer_model_projection,
+            per_layer_projection_norm,
             layers,
             norm,
             lm_head,
@@ -1073,12 +1141,14 @@ impl Gemma4Model {
             config,
             dtype,
             embed_scale,
+            ple_embed_scale,
+            ple_projection_scale,
+            ple_input_scale,
             sliding_window,
             full_rotated_dim,
         })
     }
 
-    /// Build dual rotary embeddings from config.
     fn build_rotary_embeddings(
         config: &Gemma4TextConfig,
         device: &Device,
@@ -1126,16 +1196,41 @@ impl Gemma4Model {
         #[cfg(feature = "cuda")]
         let _event_guard = EventTrackingGuard::disable(input_ids.device());
 
-        // Embed + scale
+        // Embed + scale by sqrt(hidden_size)
         let hidden_states = self.embed_tokens.forward(input_ids)?.to_dtype(self.dtype)?;
         let hidden_states = (hidden_states * self.embed_scale)?;
 
-        // PLE: compute per-layer embeddings once
+        // PLE preparation: combine token embeddings + model projection
         let ple_dim = self.config.hidden_size_per_layer_input.unwrap_or(256);
-        let per_layer_embeds = self
+        let num_layers = self.config.num_hidden_layers;
+
+        // 1. Token-based PLE: embed_tokens_per_layer(input_ids) * sqrt(ple_dim)
+        let per_layer_token_embeds = self
             .embed_tokens_per_layer
             .forward(input_ids)?
             .to_dtype(self.dtype)?;
+        let per_layer_token_embeds = (per_layer_token_embeds * self.ple_embed_scale)?;
+        // Shape: [B, S, num_layers * ple_dim]
+
+        // 2. Model projection: project hidden_states → per-layer dims
+        let per_layer_projection = self
+            .per_layer_model_projection
+            .forward(&hidden_states)?;
+        let per_layer_projection = (per_layer_projection * self.ple_projection_scale)?;
+        // Shape: [B, S, num_layers * ple_dim]
+
+        // Reshape to [B, S, num_layers, ple_dim] for norm
+        let shape_prefix = per_layer_projection.dims()[..2].to_vec();
+        let per_layer_projection = per_layer_projection
+            .reshape((shape_prefix[0], shape_prefix[1], num_layers, ple_dim))?;
+        let per_layer_projection = self.per_layer_projection_norm.forward(&per_layer_projection)?;
+        // Flatten back to [B, S, num_layers * ple_dim]
+        let per_layer_projection = per_layer_projection
+            .reshape((shape_prefix[0], shape_prefix[1], num_layers * ple_dim))?;
+
+        // 3. Combine: (projection + token_embeds) * 2^-0.5
+        let per_layer_inputs =
+            ((per_layer_projection + per_layer_token_embeds)? * self.ple_input_scale)?;
 
         // RoPE tables
         let total_len = start_pos + seq_len;
@@ -1168,7 +1263,7 @@ impl Gemma4Model {
             None
         };
 
-        // Forward pass through layers, collecting shared KV states as we go
+        // Forward pass through layers
         let mut hidden_states = hidden_states;
         let mut shared_kv_states: HashMap<usize, (Tensor, Tensor)> = HashMap::new();
 
@@ -1189,7 +1284,8 @@ impl Gemma4Model {
 
             let shared_kv = self.kv_sharing_map[i].and_then(|src| shared_kv_states.get(&src));
 
-            let ple_input = per_layer_embeds.narrow(D::Minus1, i * ple_dim, ple_dim)?;
+            // PLE input for this layer: narrow from combined per_layer_inputs
+            let ple_input = per_layer_inputs.narrow(D::Minus1, i * ple_dim, ple_dim)?;
 
             hidden_states = self.layers[i].forward(
                 &hidden_states,
@@ -1201,7 +1297,7 @@ impl Gemma4Model {
                 shared_kv,
             )?;
 
-            // Store KV state from non-shared layers for later shared layers
+            // Store KV state from non-shared layers
             if self.kv_sharing_map[i].is_none() {
                 if let Some((ref buf_k, ref buf_v)) = self.layers[i].self_attn.kv_cache {
                     let len = self.layers[i].self_attn.cache_seq_len;

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -1,0 +1,936 @@
+//! Gemma 4 text decoder implementation.
+//!
+//! Implements Google's Gemma 4 E2B architecture with:
+//!
+//! 1. **Hybrid attention** — sliding window (512 tokens) + full causal attention
+//!    per a repeating `layer_types` pattern.
+//! 2. **Dual RoPE** — sliding: theta=10K, full rotation over head_dim=256.
+//!    Full: theta=1M, partial rotation (25%) over global_head_dim=512.
+//! 3. **Per-Layer Embeddings (PLE)** — gated per-layer token embeddings applied
+//!    after attention+MLP as a final residual step in each decoder layer.
+//! 4. **KV cache sharing** — layers 15-34 share K/V from prior non-shared layers
+//!    of the same type (sliding→layer 13, full→layer 14).
+//! 5. **GELU-tanh activation** — MLP uses `gelu_pytorch_tanh` instead of SiLU.
+//! 6. **Logit softcapping** — `tanh(logits / cap) * cap` before output.
+//! 7. **Pre-allocated KV cache** with in-place `slice_set` writes.
+//! 8. **GQA-grouped SDPA** for decode (seq_len=1).
+
+use candle_core::{DType, Device, Module, Result, Tensor, D};
+use candle_nn::rotary_emb::rope;
+use candle_nn::{linear_no_bias, Embedding, Linear, RmsNorm, VarBuilder};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+// ── Event-tracking RAII guard ────────────────────────────────────────────
+
+#[cfg(feature = "cuda")]
+struct EventTrackingGuard;
+
+#[cfg(feature = "cuda")]
+impl EventTrackingGuard {
+    fn disable(device: &candle_core::Device) -> Self {
+        if let candle_core::Device::Cuda(ref dev) = device {
+            if dev.is_event_tracking() {
+                unsafe { dev.disable_event_tracking() };
+            }
+        }
+        Self
+    }
+}
+
+// ── Config ──────────────────────────────────────────────────────────────
+
+/// Outer config.json wrapper — Gemma 4 nests text config under `text_config`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Gemma4Config {
+    pub text_config: Gemma4TextConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RopeConfig {
+    pub rope_theta: f64,
+    #[serde(default)]
+    pub rope_type: String,
+    #[serde(default)]
+    pub partial_rotary_factor: Option<f64>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RopeParameters {
+    pub full_attention: RopeConfig,
+    pub sliding_attention: RopeConfig,
+}
+
+fn default_rms_norm_eps() -> f64 {
+    1e-6
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Gemma4TextConfig {
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    #[serde(default)]
+    pub global_head_dim: Option<usize>,
+    pub max_position_embeddings: usize,
+    #[serde(default = "default_rms_norm_eps")]
+    pub rms_norm_eps: f64,
+    #[serde(default)]
+    pub hidden_activation: Option<String>,
+    #[serde(default)]
+    pub use_double_wide_mlp: bool,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+    #[serde(default)]
+    pub sliding_window: Option<usize>,
+    #[serde(default)]
+    pub final_logit_softcapping: Option<f32>,
+    #[serde(default)]
+    pub hidden_size_per_layer_input: Option<usize>,
+    #[serde(default)]
+    pub vocab_size_per_layer_input: Option<usize>,
+    #[serde(default)]
+    pub num_kv_shared_layers: Option<usize>,
+    #[serde(default)]
+    pub layer_types: Vec<String>,
+    #[serde(default)]
+    pub rope_parameters: Option<RopeParameters>,
+    #[serde(default)]
+    pub eos_token_id: Option<serde_json::Value>,
+}
+
+impl Gemma4TextConfig {
+    pub fn global_head_dim(&self) -> usize {
+        self.global_head_dim.unwrap_or(self.head_dim)
+    }
+
+    /// Parse layer types from config strings.
+    pub fn parsed_layer_types(&self) -> Vec<LayerType> {
+        self.layer_types
+            .iter()
+            .map(|s| match s.as_str() {
+                "sliding_attention" => LayerType::SlidingAttention,
+                "full_attention" => LayerType::FullAttention,
+                _ => LayerType::SlidingAttention, // fallback
+            })
+            .collect()
+    }
+
+    /// First shared layer index.
+    fn first_kv_shared_layer(&self) -> usize {
+        let n_shared = self.num_kv_shared_layers.unwrap_or(0);
+        self.num_hidden_layers.saturating_sub(n_shared)
+    }
+
+    /// Build the KV sharing map: for each layer, `Some(source_layer)` if shared,
+    /// `None` if the layer computes its own K/V.
+    pub fn kv_sharing_map(&self) -> Vec<Option<usize>> {
+        let layer_types = self.parsed_layer_types();
+        let first_shared = self.first_kv_shared_layer();
+        let non_shared_types = &layer_types[..first_shared];
+
+        layer_types
+            .iter()
+            .enumerate()
+            .map(|(i, lt)| {
+                if i < first_shared {
+                    None
+                } else {
+                    // Find the last non-shared layer of the same type
+                    non_shared_types
+                        .iter()
+                        .enumerate()
+                        .rev()
+                        .find(|(_, nst)| *nst == lt)
+                        .map(|(idx, _)| idx)
+                }
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LayerType {
+    SlidingAttention,
+    FullAttention,
+}
+
+// ── Rotary Embedding ────────────────────────────────────────────────────
+
+struct RotaryEmbedding {
+    cos_table: Tensor,
+    sin_table: Tensor,
+}
+
+impl RotaryEmbedding {
+    fn new(theta: f64, dim: usize, max_pos: usize, device: &Device) -> Result<Self> {
+        // inv_freq: [dim/2]
+        let inv: Vec<f32> = (0..dim)
+            .step_by(2)
+            .map(|i| 1.0 / theta.powf(i as f64 / dim as f64) as f32)
+            .collect();
+        let inv_freq = Tensor::new(inv.as_slice(), device)?;
+
+        let positions: Vec<f32> = (0..max_pos).map(|i| i as f32).collect();
+        let positions = Tensor::new(positions.as_slice(), device)?;
+        let freqs = positions
+            .unsqueeze(1)?
+            .matmul(&inv_freq.unsqueeze(0)?)?; // [max_pos, dim/2]
+
+        let cos_table = freqs.cos()?.contiguous()?;
+        let sin_table = freqs.sin()?.contiguous()?;
+
+        Ok(Self {
+            cos_table,
+            sin_table,
+        })
+    }
+
+    fn forward(&self, seq_len: usize) -> Result<(Tensor, Tensor)> {
+        let cos = self.cos_table.narrow(0, 0, seq_len)?;
+        let sin = self.sin_table.narrow(0, 0, seq_len)?;
+        Ok((cos, sin))
+    }
+}
+
+/// Apply partial RoPE for full-attention layers.
+///
+/// The fused `rope()` kernel requires `cos_dim * 2 == head_dim`, which fails
+/// for full-attention (64*2=128 != 512). We manually split Q/K, apply rope
+/// to the rotated portion, and reassemble.
+fn apply_partial_rope(
+    q: &Tensor,
+    k: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    rotated_dim: usize,
+) -> Result<(Tensor, Tensor)> {
+    let full_dim = q.dim(D::Minus1)?;
+    let pass_dim = full_dim - rotated_dim;
+
+    let q_rot = q.narrow(D::Minus1, 0, rotated_dim)?;
+    let q_pass = q.narrow(D::Minus1, rotated_dim, pass_dim)?;
+    let k_rot = k.narrow(D::Minus1, 0, rotated_dim)?;
+    let k_pass = k.narrow(D::Minus1, rotated_dim, pass_dim)?;
+
+    let q_rot = rope(&q_rot.contiguous()?, cos, sin)?;
+    let k_rot = rope(&k_rot.contiguous()?, cos, sin)?;
+
+    Ok((
+        Tensor::cat(&[&q_rot, &q_pass], D::Minus1)?,
+        Tensor::cat(&[&k_rot, &k_pass], D::Minus1)?,
+    ))
+}
+
+// ── Attention ───────────────────────────────────────────────────────────
+
+struct Attention {
+    q_proj: Linear,
+    k_proj: Option<Linear>,
+    v_proj: Option<Linear>,
+    o_proj: Linear,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    is_shared: bool,
+    kv_shared_layer_index: Option<usize>,
+    kv_cache: Option<(Tensor, Tensor)>,
+    cache_seq_len: usize,
+}
+
+impl Attention {
+    fn new(
+        config: &Gemma4TextConfig,
+        layer_type: LayerType,
+        is_shared: bool,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let head_dim = match layer_type {
+            LayerType::SlidingAttention => config.head_dim,
+            LayerType::FullAttention => config.global_head_dim(),
+        };
+        let num_heads = config.num_attention_heads;
+        let num_kv_heads = config.num_key_value_heads;
+
+        let q_proj = linear_no_bias(config.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
+
+        let (k_proj, v_proj) = if is_shared {
+            (None, None)
+        } else {
+            let k = linear_no_bias(config.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+            let v = linear_no_bias(config.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+            (Some(k), Some(v))
+        };
+
+        let o_proj = linear_no_bias(num_heads * head_dim, config.hidden_size, vb.pp("o_proj"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            is_shared,
+            kv_shared_layer_index: None, // set by Model after construction
+            kv_cache: None,
+            cache_seq_len: 0,
+        })
+    }
+
+    /// Update the pre-allocated KV cache with new K,V tensors.
+    fn update_kv_cache(&mut self, k: Tensor, v: Tensor) -> Result<(Tensor, Tensor)> {
+        let k = k.contiguous()?;
+        let v = v.contiguous()?;
+        let new_seq_len = k.dim(2)?;
+        let cache_seq_len = self.cache_seq_len;
+
+        match self.kv_cache.take() {
+            Some((buf_k, buf_v)) => {
+                let buf_len = buf_k.dim(2)?;
+                let new_total = cache_seq_len + new_seq_len;
+
+                if new_total <= buf_len {
+                    buf_k.slice_set(&k, 2, cache_seq_len)?;
+                    buf_v.slice_set(&v, 2, cache_seq_len)?;
+                    let k_view = buf_k.narrow(2, 0, new_total)?;
+                    let v_view = buf_v.narrow(2, 0, new_total)?;
+                    self.kv_cache = Some((buf_k, buf_v));
+                    self.cache_seq_len = new_total;
+                    Ok((k_view, v_view))
+                } else {
+                    let cur_k = buf_k.narrow(2, 0, cache_seq_len)?;
+                    let cur_v = buf_v.narrow(2, 0, cache_seq_len)?;
+                    drop(buf_k);
+                    drop(buf_v);
+                    let full_k = Tensor::cat(&[&cur_k, &k], 2)?;
+                    let full_v = Tensor::cat(&[&cur_v, &v], 2)?;
+                    drop(cur_k);
+                    drop(cur_v);
+                    let total = full_k.dim(2)?;
+                    let room = 256;
+                    let (b, h, _, d) = full_k.dims4()?;
+                    let new_buf_k =
+                        Tensor::zeros((b, h, total + room, d), k.dtype(), k.device())?;
+                    let new_buf_v =
+                        Tensor::zeros((b, h, total + room, d), v.dtype(), v.device())?;
+                    new_buf_k.slice_set(&full_k, 2, 0)?;
+                    new_buf_v.slice_set(&full_v, 2, 0)?;
+                    self.kv_cache = Some((new_buf_k, new_buf_v));
+                    self.cache_seq_len = total;
+                    Ok((full_k, full_v))
+                }
+            }
+            None => {
+                let (b, h, s, d) = k.dims4()?;
+                let room = 256;
+                let buf_k = Tensor::zeros((b, h, s + room, d), k.dtype(), k.device())?;
+                let buf_v = Tensor::zeros((b, h, s + room, d), v.dtype(), v.device())?;
+                buf_k.slice_set(&k, 2, 0)?;
+                buf_v.slice_set(&v, 2, 0)?;
+                self.kv_cache = Some((buf_k, buf_v));
+                self.cache_seq_len = s;
+                Ok((k, v))
+            }
+        }
+    }
+
+    fn forward(
+        &mut self,
+        hidden_states: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        attention_mask: Option<&Tensor>,
+        layer_type: LayerType,
+        rotated_dim: Option<usize>,
+        shared_kv: Option<&(Tensor, Tensor)>,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, _) = hidden_states.dims3()?;
+
+        let q = self.q_proj.forward(hidden_states)?;
+        let q = q
+            .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        let (k, v) = if self.is_shared {
+            // Shared layer: read K/V from the source layer's cache
+            let (sk, sv) = shared_kv.expect("shared layer must have shared KV state");
+            (sk.clone(), sv.clone())
+        } else {
+            let k = self.k_proj.as_ref().unwrap().forward(hidden_states)?;
+            let v = self.v_proj.as_ref().unwrap().forward(hidden_states)?;
+            let k = k
+                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            let v = v
+                .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
+                .transpose(1, 2)?;
+            (k, v)
+        };
+
+        // Apply RoPE to Q (always) and K (only for non-shared layers)
+        let (q, k) = match layer_type {
+            LayerType::SlidingAttention => {
+                let q = rope(&q.contiguous()?, cos, sin)?;
+                if self.is_shared {
+                    (q, k)
+                } else {
+                    let k = rope(&k.contiguous()?, cos, sin)?;
+                    (q, k)
+                }
+            }
+            LayerType::FullAttention => {
+                let rdim = rotated_dim.unwrap_or(self.head_dim);
+                if self.is_shared {
+                    // Only rotate Q
+                    let full_dim = q.dim(D::Minus1)?;
+                    let pass_dim = full_dim - rdim;
+                    let q_rot = q.narrow(D::Minus1, 0, rdim)?;
+                    let q_pass = q.narrow(D::Minus1, rdim, pass_dim)?;
+                    let q_rot = rope(&q_rot.contiguous()?, cos, sin)?;
+                    let q = Tensor::cat(&[&q_rot, &q_pass], D::Minus1)?;
+                    (q, k)
+                } else {
+                    apply_partial_rope(&q, &k, cos, sin, rdim)?
+                }
+            }
+        };
+
+        // Update KV cache (non-shared layers only)
+        let (k, v) = if self.is_shared {
+            (k, v)
+        } else {
+            self.update_kv_cache(k, v)?
+        };
+
+        // ── SDPA ──
+        let n_rep = self.num_heads / self.num_kv_heads;
+
+        if n_rep > 1 && seq_len == 1 {
+            // GQA-grouped SDPA for decode (seq_len=1)
+            let scale = 1.0 / (self.head_dim as f64).sqrt();
+            let q_g =
+                (q.reshape((b_sz, self.num_kv_heads, n_rep, self.head_dim))? * scale)?;
+            let k_t = k.transpose(2, 3)?;
+            let attn_weights = q_g.matmul(&k_t)?;
+
+            let attn_weights = match attention_mask {
+                Some(mask) => attn_weights.broadcast_add(mask)?,
+                None => attn_weights,
+            };
+            let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+            let attn_output = attn_weights.matmul(&v)?;
+
+            let attn_output = attn_output
+                .reshape((b_sz, self.num_heads, self.head_dim))?
+                .reshape((b_sz, 1, self.num_heads * self.head_dim))?;
+            return self.o_proj.forward(&attn_output);
+        }
+
+        // Standard SDPA for prefill or when n_rep == 1
+        let k = if n_rep > 1 {
+            let (b, kv_heads, s, d) = k.dims4()?;
+            k.unsqueeze(2)?
+                .expand((b, kv_heads, n_rep, s, d))?
+                .reshape((b, kv_heads * n_rep, s, d))?
+        } else {
+            k
+        };
+        let v = if n_rep > 1 {
+            let (b, kv_heads, s, d) = v.dims4()?;
+            v.unsqueeze(2)?
+                .expand((b, kv_heads, n_rep, s, d))?
+                .reshape((b, kv_heads * n_rep, s, d))?
+        } else {
+            v
+        };
+
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+        let attn_weights = (q.matmul(&k.transpose(D::Minus2, D::Minus1)?)? * scale)?;
+        let attn_weights = match attention_mask {
+            Some(mask) => attn_weights.broadcast_add(mask)?,
+            None => attn_weights,
+        };
+        let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+        let attn_output = attn_weights.matmul(&v)?;
+
+        let attn_output = attn_output
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((b_sz, seq_len, ()))?;
+
+        self.o_proj.forward(&attn_output)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.kv_cache = None;
+        self.cache_seq_len = 0;
+    }
+}
+
+// ── MLP ─────────────────────────────────────────────────────────────────
+
+struct Mlp {
+    gate_proj: Linear,
+    up_proj: Linear,
+    down_proj: Linear,
+}
+
+impl Mlp {
+    fn new(config: &Gemma4TextConfig, vb: VarBuilder) -> Result<Self> {
+        let gate_proj = linear_no_bias(
+            config.hidden_size,
+            config.intermediate_size,
+            vb.pp("gate_proj"),
+        )?;
+        let up_proj = linear_no_bias(
+            config.hidden_size,
+            config.intermediate_size,
+            vb.pp("up_proj"),
+        )?;
+        let down_proj = linear_no_bias(
+            config.intermediate_size,
+            config.hidden_size,
+            vb.pp("down_proj"),
+        )?;
+
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+        })
+    }
+
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let gate = self.gate_proj.forward(x)?;
+        let gate = candle_nn::Activation::GeluPytorchTanh.forward(&gate)?;
+        let up = self.up_proj.forward(x)?;
+        self.down_proj.forward(&(gate * up)?)
+    }
+}
+
+// ── Decoder Layer ───────────────────────────────────────────────────────
+
+struct DecoderLayer {
+    self_attn: Attention,
+    mlp: Mlp,
+    input_layernorm: RmsNorm,
+    post_attention_layernorm: RmsNorm,
+    // PLE components (per-layer)
+    per_layer_input_gate: Linear,
+    per_layer_projection: Linear,
+    post_per_layer_input_norm: RmsNorm,
+    layer_type: LayerType,
+}
+
+impl DecoderLayer {
+    fn new(
+        config: &Gemma4TextConfig,
+        layer_type: LayerType,
+        is_shared: bool,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let self_attn = Attention::new(config, layer_type, is_shared, vb.pp("self_attn"))?;
+        let mlp = Mlp::new(config, vb.pp("mlp"))?;
+
+        let input_layernorm = candle_nn::rms_norm(
+            config.hidden_size,
+            config.rms_norm_eps,
+            vb.pp("input_layernorm"),
+        )?;
+        let post_attention_layernorm = candle_nn::rms_norm(
+            config.hidden_size,
+            config.rms_norm_eps,
+            vb.pp("post_attention_layernorm"),
+        )?;
+
+        let ple_dim = config.hidden_size_per_layer_input.unwrap_or(256);
+
+        let per_layer_input_gate =
+            linear_no_bias(config.hidden_size, ple_dim, vb.pp("per_layer_input_gate"))?;
+        let per_layer_projection =
+            linear_no_bias(ple_dim, config.hidden_size, vb.pp("per_layer_projection"))?;
+        let post_per_layer_input_norm =
+            candle_nn::rms_norm(ple_dim, config.rms_norm_eps, vb.pp("post_per_layer_input_norm"))?;
+
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+            per_layer_input_gate,
+            per_layer_projection,
+            post_per_layer_input_norm,
+            layer_type,
+        })
+    }
+
+    fn forward(
+        &mut self,
+        hidden_states: &Tensor,
+        per_layer_input: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        attention_mask: Option<&Tensor>,
+        rotated_dim: Option<usize>,
+        shared_kv: Option<&(Tensor, Tensor)>,
+    ) -> Result<Tensor> {
+        // Pre-norm → attention → residual
+        let residual = hidden_states;
+        let hidden_states = self.input_layernorm.forward(hidden_states)?;
+        let hidden_states = self.self_attn.forward(
+            &hidden_states,
+            cos,
+            sin,
+            attention_mask,
+            self.layer_type,
+            rotated_dim,
+            shared_kv,
+        )?;
+        let hidden_states = (residual + hidden_states)?;
+
+        // Pre-norm → MLP → residual
+        let residual = &hidden_states;
+        let hidden_states = self.post_attention_layernorm.forward(&hidden_states)?;
+        let hidden_states = self.mlp.forward(&hidden_states)?;
+        let hidden_states = (residual + hidden_states)?;
+
+        // PLE: gated per-layer embedding → residual
+        self.apply_ple(&hidden_states, per_layer_input)
+    }
+
+    fn apply_ple(&self, hidden_states: &Tensor, per_layer_input: &Tensor) -> Result<Tensor> {
+        let gate = self.per_layer_input_gate.forward(hidden_states)?;
+        let gate = candle_nn::Activation::GeluPytorchTanh.forward(&gate)?;
+        let gated = (gate * per_layer_input)?;
+        let projected = self.per_layer_projection.forward(&gated)?;
+        let normed = self.post_per_layer_input_norm.forward(&projected)?;
+        (hidden_states + normed)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.self_attn.clear_kv_cache();
+    }
+}
+
+// ── Full Model ──────────────────────────────────────────────────────────
+
+pub struct Gemma4Model {
+    embed_tokens: Embedding,
+    embed_tokens_per_layer: Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: RmsNorm,
+    lm_head: Linear,
+    rotary_sliding: RotaryEmbedding,
+    rotary_full: RotaryEmbedding,
+    layer_types: Vec<LayerType>,
+    kv_sharing_map: Vec<Option<usize>>,
+    config: Gemma4TextConfig,
+    dtype: DType,
+    embed_scale: f64,
+    sliding_window: usize,
+    full_rotated_dim: usize,
+}
+
+impl Gemma4Model {
+    pub fn new(config: &Gemma4TextConfig, vb: VarBuilder) -> Result<Self> {
+        let dtype = vb.dtype();
+        let model_vb = vb.pp("model");
+
+        let embed_tokens = candle_nn::embedding(
+            config.vocab_size,
+            config.hidden_size,
+            model_vb.pp("embed_tokens"),
+        )?;
+
+        // PLE shared embedding table: [vocab_size_per_layer_input, num_layers * hidden_size_per_layer_input]
+        let ple_vocab = config.vocab_size_per_layer_input.unwrap_or(config.vocab_size);
+        let ple_dim = config.hidden_size_per_layer_input.unwrap_or(256);
+        let ple_total_dim = config.num_hidden_layers * ple_dim;
+        let embed_tokens_per_layer = candle_nn::embedding(
+            ple_vocab,
+            ple_total_dim,
+            model_vb.pp("embed_tokens_per_layer"),
+        )?;
+
+        let layer_types = config.parsed_layer_types();
+        let kv_sharing_map = config.kv_sharing_map();
+        let first_shared = config.first_kv_shared_layer();
+
+        let mut layers = Vec::with_capacity(config.num_hidden_layers);
+        let layers_vb = model_vb.pp("layers");
+        for i in 0..config.num_hidden_layers {
+            let lt = layer_types[i];
+            let is_shared = i >= first_shared;
+            layers.push(DecoderLayer::new(config, lt, is_shared, layers_vb.pp(i))?);
+            // Set the KV shared layer index
+            if let Some(source) = kv_sharing_map[i] {
+                layers[i].self_attn.kv_shared_layer_index = Some(source);
+            }
+        }
+
+        let norm = candle_nn::rms_norm(
+            config.hidden_size,
+            config.rms_norm_eps,
+            model_vb.pp("norm"),
+        )?;
+
+        // Tied embeddings: lm_head uses embed_tokens weights
+        let lm_head = if config.tie_word_embeddings {
+            Linear::new(embed_tokens.embeddings().clone(), None)
+        } else {
+            linear_no_bias(config.hidden_size, config.vocab_size, vb.pp("lm_head"))?
+        };
+
+        // Dual RoPE
+        let sliding_theta = config
+            .rope_parameters
+            .as_ref()
+            .map(|rp| rp.sliding_attention.rope_theta)
+            .unwrap_or(10_000.0);
+        let full_theta = config
+            .rope_parameters
+            .as_ref()
+            .map(|rp| rp.full_attention.rope_theta)
+            .unwrap_or(1_000_000.0);
+        let partial_factor = config
+            .rope_parameters
+            .as_ref()
+            .and_then(|rp| rp.full_attention.partial_rotary_factor)
+            .unwrap_or(0.25);
+
+        let global_hd = config.global_head_dim();
+        let full_rotated_dim = (global_hd as f64 * partial_factor) as usize;
+
+        let rotary_sliding = RotaryEmbedding::new(
+            sliding_theta,
+            config.head_dim,
+            config.max_position_embeddings,
+            vb.device(),
+        )?;
+        let rotary_full = RotaryEmbedding::new(
+            full_theta,
+            full_rotated_dim,
+            config.max_position_embeddings,
+            vb.device(),
+        )?;
+
+        let embed_scale = (config.hidden_size as f64).sqrt();
+        let sliding_window = config.sliding_window.unwrap_or(512);
+
+        Ok(Self {
+            embed_tokens,
+            embed_tokens_per_layer,
+            layers,
+            norm,
+            lm_head,
+            rotary_sliding,
+            rotary_full,
+            layer_types,
+            kv_sharing_map,
+            config: config.clone(),
+            dtype,
+            embed_scale,
+            sliding_window,
+            full_rotated_dim,
+        })
+    }
+
+    pub fn forward(&mut self, input_ids: &Tensor, start_pos: usize) -> Result<Tensor> {
+        let (_b_sz, seq_len) = input_ids.dims2()?;
+
+        #[cfg(feature = "cuda")]
+        let _event_guard = EventTrackingGuard::disable(input_ids.device());
+
+        // Embed + scale
+        let hidden_states = self.embed_tokens.forward(input_ids)?.to_dtype(self.dtype)?;
+        let hidden_states = (hidden_states * self.embed_scale)?;
+
+        // PLE: compute per-layer embeddings once
+        let ple_dim = self.config.hidden_size_per_layer_input.unwrap_or(256);
+        let per_layer_embeds = self
+            .embed_tokens_per_layer
+            .forward(input_ids)?
+            .to_dtype(self.dtype)?;
+        // Shape: [B, S, num_layers * ple_dim] → we'll narrow per layer
+
+        // RoPE tables
+        let total_len = start_pos + seq_len;
+
+        let (full_cos_sliding, full_sin_sliding) = self.rotary_sliding.forward(total_len)?;
+        let cos_sliding = full_cos_sliding
+            .narrow(0, start_pos, seq_len)?
+            .to_dtype(self.dtype)?;
+        let sin_sliding = full_sin_sliding
+            .narrow(0, start_pos, seq_len)?
+            .to_dtype(self.dtype)?;
+
+        let (full_cos_full, full_sin_full) = self.rotary_full.forward(total_len)?;
+        let cos_full = full_cos_full
+            .narrow(0, start_pos, seq_len)?
+            .to_dtype(self.dtype)?;
+        let sin_full = full_sin_full
+            .narrow(0, start_pos, seq_len)?
+            .to_dtype(self.dtype)?;
+
+        // Attention masks
+        let sliding_mask = if seq_len > 1 {
+            Some(self.build_sliding_mask(seq_len, total_len, start_pos, input_ids.device())?)
+        } else {
+            None
+        };
+        let causal_mask = if seq_len > 1 {
+            Some(self.build_causal_mask(seq_len, total_len, start_pos, input_ids.device())?)
+        } else {
+            None
+        };
+
+        // Collect shared KV states from non-shared layers
+        // We need to do the forward pass layer by layer, collecting KV states as we go
+        let mut hidden_states = hidden_states;
+        let mut shared_kv_states: HashMap<usize, (Tensor, Tensor)> = HashMap::new();
+
+        for i in 0..self.layers.len() {
+            let lt = self.layer_types[i];
+
+            // Select RoPE and mask based on layer type
+            let (cos, sin, mask) = match lt {
+                LayerType::SlidingAttention => {
+                    (&cos_sliding, &sin_sliding, sliding_mask.as_ref())
+                }
+                LayerType::FullAttention => (&cos_full, &sin_full, causal_mask.as_ref()),
+            };
+
+            let rotated_dim = match lt {
+                LayerType::FullAttention => Some(self.full_rotated_dim),
+                LayerType::SlidingAttention => None,
+            };
+
+            // Get shared KV if this is a shared layer
+            let shared_kv = self.kv_sharing_map[i].and_then(|src| shared_kv_states.get(&src));
+
+            // PLE input for this layer
+            let ple_input = per_layer_embeds.narrow(D::Minus1, i * ple_dim, ple_dim)?;
+
+            hidden_states = self.layers[i].forward(
+                &hidden_states,
+                &ple_input,
+                cos,
+                sin,
+                mask,
+                rotated_dim,
+                shared_kv,
+            )?;
+
+            // Store KV state from non-shared layers for later shared layers to use
+            if self.kv_sharing_map[i].is_none() {
+                if let Some((ref buf_k, ref buf_v)) = self.layers[i].self_attn.kv_cache {
+                    let len = self.layers[i].self_attn.cache_seq_len;
+                    let k_view = buf_k.narrow(2, 0, len)?;
+                    let v_view = buf_v.narrow(2, 0, len)?;
+                    shared_kv_states.insert(i, (k_view, v_view));
+                }
+            }
+        }
+
+        let hidden_states = self.norm.forward(&hidden_states)?;
+        let logits = self
+            .lm_head
+            .forward(&hidden_states.narrow(1, seq_len - 1, 1)?)?;
+
+        // Logit softcapping
+        if let Some(cap) = self.config.final_logit_softcapping {
+            let cap_t = Tensor::new(cap, logits.device())?.to_dtype(logits.dtype())?;
+            let scaled = logits.broadcast_div(&cap_t)?;
+            let capped = scaled.tanh()?.broadcast_mul(&cap_t)?;
+            Ok(capped)
+        } else {
+            Ok(logits)
+        }
+    }
+
+    fn build_sliding_mask(
+        &self,
+        seq_len: usize,
+        total_len: usize,
+        start_pos: usize,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let window = self.sliding_window;
+        let mut mask_data = vec![0f32; seq_len * total_len];
+        for i in 0..seq_len {
+            let pos_i = start_pos + i;
+            for j in 0..total_len {
+                let visible = j <= pos_i && j >= pos_i.saturating_sub(window - 1);
+                if !visible {
+                    mask_data[i * total_len + j] = -1e9;
+                }
+            }
+        }
+        let mask = Tensor::from_vec(mask_data, (seq_len, total_len), device)?
+            .to_dtype(self.dtype)?;
+        Ok(mask.unsqueeze(0)?.unsqueeze(0)?)
+    }
+
+    fn build_causal_mask(
+        &self,
+        seq_len: usize,
+        total_len: usize,
+        start_pos: usize,
+        device: &Device,
+    ) -> Result<Tensor> {
+        let mut mask_data = vec![0f32; seq_len * total_len];
+        for i in 0..seq_len {
+            for j in 0..total_len {
+                if j > start_pos + i {
+                    mask_data[i * total_len + j] = -1e9;
+                }
+            }
+        }
+        let mask = Tensor::from_vec(mask_data, (seq_len, total_len), device)?
+            .to_dtype(self.dtype)?;
+        Ok(mask.unsqueeze(0)?.unsqueeze(0)?)
+    }
+
+    // ── KV Cache Management ─────────────────────────────────────────────
+
+    pub fn clear_kv_cache(&mut self) {
+        for layer in self.layers.iter_mut() {
+            layer.clear_kv_cache();
+        }
+    }
+
+    pub fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    pub fn active_kv_cache_bytes(&self) -> u64 {
+        self.layers
+            .iter()
+            .map(|l| {
+                l.self_attn
+                    .kv_cache
+                    .as_ref()
+                    .map(|(k, v)| {
+                        let k_bytes = k.elem_count() as u64 * k.dtype().size_in_bytes() as u64;
+                        let v_bytes = v.elem_count() as u64 * v.dtype().size_in_bytes() as u64;
+                        k_bytes + v_bytes
+                    })
+                    .unwrap_or(0)
+            })
+            .sum()
+    }
+
+    pub fn config(&self) -> &Gemma4TextConfig {
+        &self.config
+    }
+
+    pub fn model_dtype(&self) -> DType {
+        self.dtype
+    }
+}

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -545,19 +545,19 @@ struct Mlp {
 }
 
 impl Mlp {
-    fn new(config: &Gemma4TextConfig, vb: VarBuilder) -> Result<Self> {
+    fn new(config: &Gemma4TextConfig, intermediate_size: usize, vb: VarBuilder) -> Result<Self> {
         let gate_proj = LinearLayer::Standard(linear_no_bias(
             config.hidden_size,
-            config.intermediate_size,
+            intermediate_size,
             vb.pp("gate_proj"),
         )?);
         let up_proj = LinearLayer::Standard(linear_no_bias(
             config.hidden_size,
-            config.intermediate_size,
+            intermediate_size,
             vb.pp("up_proj"),
         )?);
         let down_proj = LinearLayer::Standard(linear_no_bias(
-            config.intermediate_size,
+            intermediate_size,
             config.hidden_size,
             vb.pp("down_proj"),
         )?);
@@ -613,10 +613,11 @@ impl DecoderLayer {
         config: &Gemma4TextConfig,
         layer_type: LayerType,
         is_shared: bool,
+        intermediate_size: usize,
         vb: VarBuilder,
     ) -> Result<Self> {
         let self_attn = Attention::new(config, layer_type, is_shared, vb.pp("self_attn"))?;
-        let mlp = Mlp::new(config, vb.pp("mlp"))?;
+        let mlp = Mlp::new(config, intermediate_size, vb.pp("mlp"))?;
 
         let input_layernorm = candle_nn::rms_norm(
             config.hidden_size,
@@ -657,7 +658,7 @@ impl DecoderLayer {
             vb.pp("per_layer_projection"),
         )?);
         let post_per_layer_input_norm =
-            candle_nn::rms_norm(ple_dim, config.rms_norm_eps, vb.pp("post_per_layer_input_norm"))?;
+            candle_nn::rms_norm(config.hidden_size, config.rms_norm_eps, vb.pp("post_per_layer_input_norm"))?;
 
         Ok(Self {
             self_attn,
@@ -860,7 +861,13 @@ impl Gemma4Model {
         for i in 0..config.num_hidden_layers {
             let lt = layer_types[i];
             let is_shared = i >= first_shared;
-            layers.push(DecoderLayer::new(config, lt, is_shared, layers_vb.pp(i))?);
+            // Shared layers use double-wide MLP when use_double_wide_mlp is set
+            let intermediate_size = if is_shared && config.use_double_wide_mlp {
+                config.intermediate_size * 2
+            } else {
+                config.intermediate_size
+            };
+            layers.push(DecoderLayer::new(config, lt, is_shared, intermediate_size, layers_vb.pp(i))?);
             if let Some(source) = kv_sharing_map[i] {
                 layers[i].self_attn.kv_shared_layer_index = Some(source);
             }

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -30,28 +30,22 @@ use std::io::{Read, Seek};
 // Reuse the polymorphic linear layer and GGUF loader from the shared Hunyuan module.
 pub use crate::models::hunyuan_dense::modeling::{Gguf, LinearLayer};
 
-/// Create an RmsNorm with Gemma-style weight shift.
+/// Create an RmsNorm for Gemma 4.
 ///
-/// Gemma's RMSNorm uses `output = x * (1 + weight)` instead of `output = x * weight`.
-/// Weights in HF checkpoints are stored as the raw trained values (initialized near 0),
-/// so we add 1.0 to convert them for candle's standard `x * weight` formula.
+/// Gemma 3 RMSNorm uses `output = x * (1 + weight)` with weights initialized near 0.
+/// Gemma 4 stores weights that already include any shift (norm_shift=0 in GGUF converter),
+/// so we use standard `x * weight` — no additional shift needed.
 fn gemma_rms_norm(size: usize, eps: f64, vb: VarBuilder) -> Result<RmsNorm> {
-    let weight = vb.get(size, "weight")?;
-    let shifted = (weight + 1.0)?;
-    Ok(RmsNorm::new(shifted, eps))
+    candle_nn::rms_norm(size, eps, vb)
 }
 
-/// Same shift for GGUF norms: Gemma4 stores raw weights (norm_shift=0),
-/// so we must add 1.0 for the `x * weight` formula.
+/// GGUF variant — weights are stored as-is, no shift needed for Gemma 4.
 fn gemma_rms_norm_gguf<R: Read + Seek>(
     gg: &mut Gguf<R>,
     name: &str,
     eps: f64,
 ) -> Result<RmsNorm> {
-    let norm = gg.rms_norm(name, eps)?;
-    let weight = norm.into_inner().weight().clone();
-    let shifted = (weight + 1.0)?;
-    Ok(RmsNorm::new(shifted, eps))
+    gg.rms_norm(name, eps)
 }
 
 // ── Event-tracking RAII guard ────────────────────────────────────────────

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -14,12 +14,19 @@
 //! 6. **Logit softcapping** — `tanh(logits / cap) * cap` before output.
 //! 7. **Pre-allocated KV cache** with in-place `slice_set` writes.
 //! 8. **GQA-grouped SDPA** for decode (seq_len=1).
+//! 9. **GGUF quantization** via the polymorphic `LinearLayer` enum
+//!    — Same model code serves both safetensors (f16/f32/bf16) and GGUF weights.
 
+use candle_core::quantized::gguf_file;
 use candle_core::{DType, Device, Module, Result, Tensor, D};
 use candle_nn::rotary_emb::rope;
 use candle_nn::{linear_no_bias, Embedding, Linear, RmsNorm, VarBuilder};
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::io::{Read, Seek};
+
+// Reuse the polymorphic linear layer and GGUF loader from the shared Hunyuan module.
+pub use crate::models::hunyuan_dense::modeling::{Gguf, LinearLayer};
 
 // ── Event-tracking RAII guard ────────────────────────────────────────────
 
@@ -121,7 +128,7 @@ impl Gemma4TextConfig {
     }
 
     /// First shared layer index.
-    fn first_kv_shared_layer(&self) -> usize {
+    pub fn first_kv_shared_layer(&self) -> usize {
         let n_shared = self.num_kv_shared_layers.unwrap_or(0);
         self.num_hidden_layers.saturating_sub(n_shared)
     }
@@ -229,10 +236,10 @@ fn apply_partial_rope(
 // ── Attention ───────────────────────────────────────────────────────────
 
 struct Attention {
-    q_proj: Linear,
-    k_proj: Option<Linear>,
-    v_proj: Option<Linear>,
-    o_proj: Linear,
+    q_proj: LinearLayer,
+    k_proj: Option<LinearLayer>,
+    v_proj: Option<LinearLayer>,
+    o_proj: LinearLayer,
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -256,17 +263,33 @@ impl Attention {
         let num_heads = config.num_attention_heads;
         let num_kv_heads = config.num_key_value_heads;
 
-        let q_proj = linear_no_bias(config.hidden_size, num_heads * head_dim, vb.pp("q_proj"))?;
+        let q_proj = LinearLayer::Standard(linear_no_bias(
+            config.hidden_size,
+            num_heads * head_dim,
+            vb.pp("q_proj"),
+        )?);
 
         let (k_proj, v_proj) = if is_shared {
             (None, None)
         } else {
-            let k = linear_no_bias(config.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
-            let v = linear_no_bias(config.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+            let k = LinearLayer::Standard(linear_no_bias(
+                config.hidden_size,
+                num_kv_heads * head_dim,
+                vb.pp("k_proj"),
+            )?);
+            let v = LinearLayer::Standard(linear_no_bias(
+                config.hidden_size,
+                num_kv_heads * head_dim,
+                vb.pp("v_proj"),
+            )?);
             (Some(k), Some(v))
         };
 
-        let o_proj = linear_no_bias(num_heads * head_dim, config.hidden_size, vb.pp("o_proj"))?;
+        let o_proj = LinearLayer::Standard(linear_no_bias(
+            num_heads * head_dim,
+            config.hidden_size,
+            vb.pp("o_proj"),
+        )?);
 
         Ok(Self {
             q_proj,
@@ -277,7 +300,45 @@ impl Attention {
             num_kv_heads,
             head_dim,
             is_shared,
-            kv_shared_layer_index: None, // set by Model after construction
+            kv_shared_layer_index: None,
+            kv_cache: None,
+            cache_seq_len: 0,
+        })
+    }
+
+    /// Construct from GGUF quantized weights.
+    fn new_from_gguf<R: Read + Seek>(
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        is_shared: bool,
+        gg: &mut Gguf<R>,
+        layer_idx: usize,
+    ) -> Result<Self> {
+        let prefix = format!("blk.{layer_idx}");
+
+        let q_proj = gg.linear(&format!("{prefix}.attn_q.weight"))?;
+
+        let (k_proj, v_proj) = if is_shared {
+            (None, None)
+        } else {
+            let k = gg.linear(&format!("{prefix}.attn_k.weight"))?;
+            let v = gg.linear(&format!("{prefix}.attn_v.weight"))?;
+            (Some(k), Some(v))
+        };
+
+        let o_proj = gg.linear(&format!("{prefix}.attn_output.weight"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            is_shared,
+            kv_shared_layer_index: None,
             kv_cache: None,
             cache_seq_len: 0,
         })
@@ -476,29 +537,44 @@ impl Attention {
 // ── MLP ─────────────────────────────────────────────────────────────────
 
 struct Mlp {
-    gate_proj: Linear,
-    up_proj: Linear,
-    down_proj: Linear,
+    gate_proj: LinearLayer,
+    up_proj: LinearLayer,
+    down_proj: LinearLayer,
 }
 
 impl Mlp {
     fn new(config: &Gemma4TextConfig, vb: VarBuilder) -> Result<Self> {
-        let gate_proj = linear_no_bias(
+        let gate_proj = LinearLayer::Standard(linear_no_bias(
             config.hidden_size,
             config.intermediate_size,
             vb.pp("gate_proj"),
-        )?;
-        let up_proj = linear_no_bias(
+        )?);
+        let up_proj = LinearLayer::Standard(linear_no_bias(
             config.hidden_size,
             config.intermediate_size,
             vb.pp("up_proj"),
-        )?;
-        let down_proj = linear_no_bias(
+        )?);
+        let down_proj = LinearLayer::Standard(linear_no_bias(
             config.intermediate_size,
             config.hidden_size,
             vb.pp("down_proj"),
-        )?;
+        )?);
 
+        Ok(Self {
+            gate_proj,
+            up_proj,
+            down_proj,
+        })
+    }
+
+    fn new_from_gguf<R: Read + Seek>(
+        gg: &mut Gguf<R>,
+        layer_idx: usize,
+    ) -> Result<Self> {
+        let prefix = format!("blk.{layer_idx}");
+        let gate_proj = gg.linear(&format!("{prefix}.ffn_gate.weight"))?;
+        let up_proj = gg.linear(&format!("{prefix}.ffn_up.weight"))?;
+        let down_proj = gg.linear(&format!("{prefix}.ffn_down.weight"))?;
         Ok(Self {
             gate_proj,
             up_proj,
@@ -522,8 +598,8 @@ struct DecoderLayer {
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
     // PLE components (per-layer)
-    per_layer_input_gate: Linear,
-    per_layer_projection: Linear,
+    per_layer_input_gate: LinearLayer,
+    per_layer_projection: LinearLayer,
     post_per_layer_input_norm: RmsNorm,
     layer_type: LayerType,
 }
@@ -551,12 +627,63 @@ impl DecoderLayer {
 
         let ple_dim = config.hidden_size_per_layer_input.unwrap_or(256);
 
-        let per_layer_input_gate =
-            linear_no_bias(config.hidden_size, ple_dim, vb.pp("per_layer_input_gate"))?;
-        let per_layer_projection =
-            linear_no_bias(ple_dim, config.hidden_size, vb.pp("per_layer_projection"))?;
+        let per_layer_input_gate = LinearLayer::Standard(linear_no_bias(
+            config.hidden_size,
+            ple_dim,
+            vb.pp("per_layer_input_gate"),
+        )?);
+        let per_layer_projection = LinearLayer::Standard(linear_no_bias(
+            ple_dim,
+            config.hidden_size,
+            vb.pp("per_layer_projection"),
+        )?);
         let post_per_layer_input_norm =
             candle_nn::rms_norm(ple_dim, config.rms_norm_eps, vb.pp("post_per_layer_input_norm"))?;
+
+        Ok(Self {
+            self_attn,
+            mlp,
+            input_layernorm,
+            post_attention_layernorm,
+            per_layer_input_gate,
+            per_layer_projection,
+            post_per_layer_input_norm,
+            layer_type,
+        })
+    }
+
+    fn new_from_gguf<R: Read + Seek>(
+        config: &Gemma4TextConfig,
+        layer_type: LayerType,
+        is_shared: bool,
+        head_dim: usize,
+        gg: &mut Gguf<R>,
+        layer_idx: usize,
+    ) -> Result<Self> {
+        let self_attn = Attention::new_from_gguf(
+            config.num_attention_heads,
+            config.num_key_value_heads,
+            head_dim,
+            is_shared,
+            gg,
+            layer_idx,
+        )?;
+        let mlp = Mlp::new_from_gguf(gg, layer_idx)?;
+        let prefix = format!("blk.{layer_idx}");
+
+        let input_layernorm =
+            gg.rms_norm(&format!("{prefix}.attn_norm.weight"), config.rms_norm_eps)?;
+        let post_attention_layernorm =
+            gg.rms_norm(&format!("{prefix}.ffn_norm.weight"), config.rms_norm_eps)?;
+
+        // PLE components
+        let per_layer_input_gate = gg.linear(&format!("{prefix}.inp_gate.weight"))?;
+        let per_layer_projection = gg.linear(&format!("{prefix}.proj.weight"))?;
+        let ple_dim = config.hidden_size_per_layer_input.unwrap_or(256);
+        let post_per_layer_input_norm =
+            gg.rms_norm(&format!("{prefix}.post_norm.weight"), config.rms_norm_eps)?;
+
+        let _ = ple_dim; // used for documentation only in GGUF path
 
         Ok(Self {
             self_attn,
@@ -625,7 +752,7 @@ pub struct Gemma4Model {
     embed_tokens_per_layer: Embedding,
     layers: Vec<DecoderLayer>,
     norm: RmsNorm,
-    lm_head: Linear,
+    lm_head: LinearLayer,
     rotary_sliding: RotaryEmbedding,
     rotary_full: RotaryEmbedding,
     layer_types: Vec<LayerType>,
@@ -638,6 +765,7 @@ pub struct Gemma4Model {
 }
 
 impl Gemma4Model {
+    /// Construct from safetensors / HuggingFace checkpoint.
     pub fn new(config: &Gemma4TextConfig, vb: VarBuilder) -> Result<Self> {
         let dtype = vb.dtype();
         let model_vb = vb.pp("model");
@@ -668,7 +796,6 @@ impl Gemma4Model {
             let lt = layer_types[i];
             let is_shared = i >= first_shared;
             layers.push(DecoderLayer::new(config, lt, is_shared, layers_vb.pp(i))?);
-            // Set the KV shared layer index
             if let Some(source) = kv_sharing_map[i] {
                 layers[i].self_attn.kv_shared_layer_index = Some(source);
             }
@@ -682,12 +809,280 @@ impl Gemma4Model {
 
         // Tied embeddings: lm_head uses embed_tokens weights
         let lm_head = if config.tie_word_embeddings {
-            Linear::new(embed_tokens.embeddings().clone(), None)
+            LinearLayer::Standard(Linear::new(embed_tokens.embeddings().clone(), None))
         } else {
-            linear_no_bias(config.hidden_size, config.vocab_size, vb.pp("lm_head"))?
+            LinearLayer::Standard(linear_no_bias(
+                config.hidden_size,
+                config.vocab_size,
+                vb.pp("lm_head"),
+            )?)
         };
 
-        // Dual RoPE
+        let (rotary_sliding, rotary_full, full_rotated_dim) =
+            Self::build_rotary_embeddings(config, vb.device())?;
+
+        let embed_scale = (config.hidden_size as f64).sqrt();
+        let sliding_window = config.sliding_window.unwrap_or(512);
+
+        Ok(Self {
+            embed_tokens,
+            embed_tokens_per_layer,
+            layers,
+            norm,
+            lm_head,
+            rotary_sliding,
+            rotary_full,
+            layer_types,
+            kv_sharing_map,
+            config: config.clone(),
+            dtype,
+            embed_scale,
+            sliding_window,
+            full_rotated_dim,
+        })
+    }
+
+    /// Construct from a GGUF file.
+    pub fn from_gguf<R: Read + Seek>(
+        ct: gguf_file::Content,
+        reader: &mut R,
+        device: &Device,
+    ) -> Result<Self> {
+        let dtype = if device.is_cuda() {
+            DType::BF16
+        } else {
+            DType::F32
+        };
+        let mut gg = Gguf::new(ct, reader, device.clone(), dtype);
+        let md_get = |s: &str| match gg.metadata().get(s) {
+            None => candle_core::bail!("cannot find {s} in GGUF metadata"),
+            Some(v) => Ok(v.clone()),
+        };
+
+        let arch = gg
+            .metadata()
+            .get("general.architecture")
+            .and_then(|v| v.to_string().ok())
+            .map(|s| s.clone())
+            .unwrap_or_else(|| "gemma4".to_string());
+
+        // ── Read config from GGUF metadata ──
+        let num_attention_heads =
+            md_get(&format!("{arch}.attention.head_count"))?.to_u32()? as usize;
+        let num_kv_heads =
+            md_get(&format!("{arch}.attention.head_count_kv"))?.to_u32()? as usize;
+        let num_hidden_layers = md_get(&format!("{arch}.block_count"))?.to_u32()? as usize;
+        let hidden_size = md_get(&format!("{arch}.embedding_length"))?.to_u32()? as usize;
+        let intermediate_size =
+            md_get(&format!("{arch}.feed_forward_length"))?.to_u32()? as usize;
+        let max_position_embeddings = gg
+            .metadata()
+            .get(&format!("{arch}.context_length"))
+            .and_then(|v| v.to_u32().ok())
+            .unwrap_or(131072) as usize;
+        let rms_norm_eps = gg
+            .metadata()
+            .get(&format!("{arch}.attention.layer_norm_rms_epsilon"))
+            .and_then(|v| v.to_f32().ok())
+            .unwrap_or(1e-6) as f64;
+        let rope_theta = gg
+            .metadata()
+            .get(&format!("{arch}.rope.freq_base"))
+            .and_then(|v| v.to_f32().ok())
+            .unwrap_or(1_000_000.0) as f64;
+
+        // Gemma4-specific: dual head_dim
+        let global_head_dim = gg
+            .metadata()
+            .get(&format!("{arch}.attention.key_length"))
+            .and_then(|v| v.to_u32().ok())
+            .unwrap_or(512) as usize;
+        let swa_head_dim = gg
+            .metadata()
+            .get(&format!("{arch}.attention.key_length_swa"))
+            .and_then(|v| v.to_u32().ok())
+            .unwrap_or(256) as usize;
+
+        // KV sharing
+        let num_kv_shared_layers = gg
+            .metadata()
+            .get(&format!("{arch}.attention.shared_kv_layers"))
+            .and_then(|v| v.to_u32().ok())
+            .unwrap_or(0) as usize;
+
+        // PLE dimension
+        let ple_dim = gg
+            .metadata()
+            .get(&format!("{arch}.embedding_length_per_layer_input"))
+            .and_then(|v| v.to_u32().ok())
+            .unwrap_or(256) as usize;
+
+        // Sliding window
+        let sliding_window = gg
+            .metadata()
+            .get(&format!("{arch}.attention.sliding_window"))
+            .and_then(|v| v.to_u32().ok())
+            .unwrap_or(512) as usize;
+
+        // Logit softcapping
+        let final_logit_softcapping = gg
+            .metadata()
+            .get(&format!("{arch}.final_logit_softcapping"))
+            .and_then(|v| v.to_f32().ok());
+
+        // Layer types from sliding_window_pattern (bool array: true=sliding, false=full)
+        let layer_types_str: Vec<String> = if let Some(gguf_file::Value::Array(arr)) = gg
+            .metadata()
+            .get(&format!("{arch}.attention.sliding_window_pattern"))
+        {
+            arr.iter()
+                .map(|v| {
+                    let is_swa = match v {
+                        gguf_file::Value::Bool(b) => *b,
+                        gguf_file::Value::U8(n) => *n != 0,
+                        gguf_file::Value::I8(n) => *n != 0,
+                        _ => true,
+                    };
+                    if is_swa {
+                        "sliding_attention".to_string()
+                    } else {
+                        "full_attention".to_string()
+                    }
+                })
+                .collect()
+        } else {
+            // Fallback: infer from E2B pattern [S,S,S,S,F] repeating
+            (0..num_hidden_layers)
+                .map(|i| {
+                    if i % 5 == 4 {
+                        "full_attention".to_string()
+                    } else {
+                        "sliding_attention".to_string()
+                    }
+                })
+                .collect()
+        };
+
+        let tie_word_embeddings = !gg.ct.tensor_infos.contains_key("output.weight");
+
+        // Build config
+        let config = Gemma4TextConfig {
+            vocab_size: 0, // updated below
+            hidden_size,
+            intermediate_size,
+            num_hidden_layers,
+            num_attention_heads,
+            num_key_value_heads: num_kv_heads,
+            head_dim: swa_head_dim,
+            global_head_dim: Some(global_head_dim),
+            max_position_embeddings,
+            rms_norm_eps,
+            hidden_activation: Some("gelu_pytorch_tanh".to_string()),
+            use_double_wide_mlp: false,
+            tie_word_embeddings,
+            sliding_window: Some(sliding_window),
+            final_logit_softcapping,
+            hidden_size_per_layer_input: Some(ple_dim),
+            vocab_size_per_layer_input: None, // set from actual embedding
+            num_kv_shared_layers: Some(num_kv_shared_layers),
+            layer_types: layer_types_str,
+            rope_parameters: None, // RoPE is configured via GGUF metadata directly
+            eos_token_id: None,
+        };
+
+        // ── Load weights ──
+        let embed_tokens = gg.embedding("token_embd.weight", hidden_size)?;
+        let actual_vocab_size = embed_tokens.embeddings().dim(0)?;
+
+        let ple_total_dim = num_hidden_layers * ple_dim;
+        let embed_tokens_per_layer = gg.embedding("per_layer_token_embd.weight", ple_total_dim)?;
+        let ple_vocab = embed_tokens_per_layer.embeddings().dim(0)?;
+
+        let config = Gemma4TextConfig {
+            vocab_size: actual_vocab_size,
+            vocab_size_per_layer_input: Some(ple_vocab),
+            ..config
+        };
+
+        let layer_types = config.parsed_layer_types();
+        let kv_sharing_map = config.kv_sharing_map();
+        let first_shared = config.first_kv_shared_layer();
+
+        let mut layers = Vec::with_capacity(num_hidden_layers);
+        for i in 0..num_hidden_layers {
+            let lt = layer_types[i];
+            let is_shared = i >= first_shared;
+            let head_dim = match lt {
+                LayerType::SlidingAttention => swa_head_dim,
+                LayerType::FullAttention => global_head_dim,
+            };
+            layers.push(DecoderLayer::new_from_gguf(
+                &config, lt, is_shared, head_dim, &mut gg, i,
+            )?);
+            if let Some(source) = kv_sharing_map[i] {
+                layers[i].self_attn.kv_shared_layer_index = Some(source);
+            }
+        }
+
+        let norm = gg.rms_norm("output_norm.weight", rms_norm_eps)?;
+
+        let lm_head = if tie_word_embeddings {
+            LinearLayer::Standard(Linear::new(embed_tokens.embeddings().clone(), None))
+        } else {
+            gg.linear("output.weight")?
+        };
+
+        // ── Dual RoPE ──
+        // For GGUF, rope_theta from metadata is the full-attention theta.
+        // Sliding attention theta defaults to 10K.
+        let sliding_theta = 10_000.0;
+        let full_theta = rope_theta;
+
+        // Partial rotation for full-attention: from rope_dimension_count metadata
+        let full_rotated_dim = gg
+            .metadata()
+            .get(&format!("{arch}.rope.dimension_count"))
+            .and_then(|v| v.to_u32().ok())
+            .unwrap_or((global_head_dim / 4) as u32) as usize;
+
+        let rotary_sliding = RotaryEmbedding::new(
+            sliding_theta,
+            swa_head_dim,
+            max_position_embeddings,
+            device,
+        )?;
+        let rotary_full = RotaryEmbedding::new(
+            full_theta,
+            full_rotated_dim,
+            max_position_embeddings,
+            device,
+        )?;
+
+        let embed_scale = (hidden_size as f64).sqrt();
+
+        Ok(Self {
+            embed_tokens,
+            embed_tokens_per_layer,
+            layers,
+            norm,
+            lm_head,
+            rotary_sliding,
+            rotary_full,
+            layer_types,
+            kv_sharing_map,
+            config,
+            dtype,
+            embed_scale,
+            sliding_window,
+            full_rotated_dim,
+        })
+    }
+
+    /// Build dual rotary embeddings from config.
+    fn build_rotary_embeddings(
+        config: &Gemma4TextConfig,
+        device: &Device,
+    ) -> Result<(RotaryEmbedding, RotaryEmbedding, usize)> {
         let sliding_theta = config
             .rope_parameters
             .as_ref()
@@ -711,35 +1106,19 @@ impl Gemma4Model {
             sliding_theta,
             config.head_dim,
             config.max_position_embeddings,
-            vb.device(),
+            device,
         )?;
         let rotary_full = RotaryEmbedding::new(
             full_theta,
             full_rotated_dim,
             config.max_position_embeddings,
-            vb.device(),
+            device,
         )?;
 
-        let embed_scale = (config.hidden_size as f64).sqrt();
-        let sliding_window = config.sliding_window.unwrap_or(512);
-
-        Ok(Self {
-            embed_tokens,
-            embed_tokens_per_layer,
-            layers,
-            norm,
-            lm_head,
-            rotary_sliding,
-            rotary_full,
-            layer_types,
-            kv_sharing_map,
-            config: config.clone(),
-            dtype,
-            embed_scale,
-            sliding_window,
-            full_rotated_dim,
-        })
+        Ok((rotary_sliding, rotary_full, full_rotated_dim))
     }
+
+    // ── Forward ─────────────────────────────────────────────────────────
 
     pub fn forward(&mut self, input_ids: &Tensor, start_pos: usize) -> Result<Tensor> {
         let (_b_sz, seq_len) = input_ids.dims2()?;
@@ -757,7 +1136,6 @@ impl Gemma4Model {
             .embed_tokens_per_layer
             .forward(input_ids)?
             .to_dtype(self.dtype)?;
-        // Shape: [B, S, num_layers * ple_dim] → we'll narrow per layer
 
         // RoPE tables
         let total_len = start_pos + seq_len;
@@ -790,15 +1168,13 @@ impl Gemma4Model {
             None
         };
 
-        // Collect shared KV states from non-shared layers
-        // We need to do the forward pass layer by layer, collecting KV states as we go
+        // Forward pass through layers, collecting shared KV states as we go
         let mut hidden_states = hidden_states;
         let mut shared_kv_states: HashMap<usize, (Tensor, Tensor)> = HashMap::new();
 
         for i in 0..self.layers.len() {
             let lt = self.layer_types[i];
 
-            // Select RoPE and mask based on layer type
             let (cos, sin, mask) = match lt {
                 LayerType::SlidingAttention => {
                     (&cos_sliding, &sin_sliding, sliding_mask.as_ref())
@@ -811,10 +1187,8 @@ impl Gemma4Model {
                 LayerType::SlidingAttention => None,
             };
 
-            // Get shared KV if this is a shared layer
             let shared_kv = self.kv_sharing_map[i].and_then(|src| shared_kv_states.get(&src));
 
-            // PLE input for this layer
             let ple_input = per_layer_embeds.narrow(D::Minus1, i * ple_dim, ple_dim)?;
 
             hidden_states = self.layers[i].forward(
@@ -827,7 +1201,7 @@ impl Gemma4Model {
                 shared_kv,
             )?;
 
-            // Store KV state from non-shared layers for later shared layers to use
+            // Store KV state from non-shared layers for later shared layers
             if self.kv_sharing_map[i].is_none() {
                 if let Some((ref buf_k, ref buf_v)) = self.layers[i].self_attn.kv_cache {
                     let len = self.layers[i].self_attn.cache_seq_len;

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -24,29 +24,13 @@ use candle_core::{DType, Device, Module, Result, Tensor, D};
 use candle_nn::rotary_emb::rope;
 use candle_nn::{linear_no_bias, Embedding, Linear, RmsNorm, VarBuilder};
 use serde::Deserialize;
-use std::collections::HashMap;
 use std::io::{Read, Seek};
 
 // Reuse the polymorphic linear layer and GGUF loader from the shared Hunyuan module.
 pub use crate::models::hunyuan_dense::modeling::{Gguf, LinearLayer};
 
-/// Create an RmsNorm for Gemma 4.
-///
-/// Gemma 3 RMSNorm uses `output = x * (1 + weight)` with weights initialized near 0.
-/// Gemma 4 stores weights that already include any shift (norm_shift=0 in GGUF converter),
-/// so we use standard `x * weight` — no additional shift needed.
-fn gemma_rms_norm(size: usize, eps: f64, vb: VarBuilder) -> Result<RmsNorm> {
-    candle_nn::rms_norm(size, eps, vb)
-}
-
-/// GGUF variant — weights are stored as-is, no shift needed for Gemma 4.
-fn gemma_rms_norm_gguf<R: Read + Seek>(
-    gg: &mut Gguf<R>,
-    name: &str,
-    eps: f64,
-) -> Result<RmsNorm> {
-    gg.rms_norm(name, eps)
-}
+// Note: Gemma 4 norms use standard `x * weight` (no `+1` shift unlike Gemma 3).
+// Weights are stored in final form. Use candle_nn::rms_norm / gg.rms_norm directly.
 
 // ── Event-tracking RAII guard ────────────────────────────────────────────
 
@@ -211,9 +195,9 @@ impl RotaryEmbedding {
         })
     }
 
-    fn forward(&self, seq_len: usize) -> Result<(Tensor, Tensor)> {
-        let cos = self.cos_table.narrow(0, 0, seq_len)?;
-        let sin = self.sin_table.narrow(0, 0, seq_len)?;
+    fn forward(&self, start_pos: usize, seq_len: usize) -> Result<(Tensor, Tensor)> {
+        let cos = self.cos_table.narrow(0, start_pos, seq_len)?;
+        let sin = self.sin_table.narrow(0, start_pos, seq_len)?;
         Ok((cos, sin))
     }
 }
@@ -266,7 +250,6 @@ struct Attention {
     num_kv_heads: usize,
     head_dim: usize,
     is_shared: bool,
-    kv_shared_layer_index: Option<usize>,
     kv_cache: Option<(Tensor, Tensor)>,
     cache_seq_len: usize,
 }
@@ -292,7 +275,7 @@ impl Attention {
         )?);
 
         // QK norms: q_norm always, k_norm only for non-shared layers
-        let q_norm = gemma_rms_norm(head_dim, config.rms_norm_eps, vb.pp("q_norm"))?;
+        let q_norm = candle_nn::rms_norm(head_dim, config.rms_norm_eps, vb.pp("q_norm"))?;
 
         let (k_proj, v_proj, k_norm) = if is_shared {
             (None, None, None)
@@ -307,7 +290,7 @@ impl Attention {
                 num_kv_heads * head_dim,
                 vb.pp("v_proj"),
             )?);
-            let kn = gemma_rms_norm(head_dim, config.rms_norm_eps, vb.pp("k_norm"))?;
+            let kn = candle_nn::rms_norm(head_dim, config.rms_norm_eps, vb.pp("k_norm"))?;
             (Some(k), Some(v), Some(kn))
         };
 
@@ -329,7 +312,6 @@ impl Attention {
             num_kv_heads,
             head_dim,
             is_shared,
-            kv_shared_layer_index: None,
             kv_cache: None,
             cache_seq_len: 0,
         })
@@ -347,14 +329,14 @@ impl Attention {
         let prefix = format!("blk.{layer_idx}");
 
         let q_proj = gg.linear(&format!("{prefix}.attn_q.weight"))?;
-        let q_norm = gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_q_norm.weight"), rms_norm_eps)?;
+        let q_norm = gg.rms_norm(&format!("{prefix}.attn_q_norm.weight"), rms_norm_eps)?;
 
         let (k_proj, v_proj, k_norm) = if is_shared {
             (None, None, None)
         } else {
             let k = gg.linear(&format!("{prefix}.attn_k.weight"))?;
             let v = gg.linear(&format!("{prefix}.attn_v.weight"))?;
-            let kn = gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_k_norm.weight"), rms_norm_eps)?;
+            let kn = gg.rms_norm(&format!("{prefix}.attn_k_norm.weight"), rms_norm_eps)?;
             (Some(k), Some(v), Some(kn))
         };
 
@@ -372,7 +354,6 @@ impl Attention {
             num_kv_heads,
             head_dim,
             is_shared,
-            kv_shared_layer_index: None,
             kv_cache: None,
             cache_seq_len: 0,
         })
@@ -652,31 +633,31 @@ impl DecoderLayer {
         let self_attn = Attention::new(config, layer_type, is_shared, vb.pp("self_attn"))?;
         let mlp = Mlp::new(config, intermediate_size, vb.pp("mlp"))?;
 
-        let input_layernorm = gemma_rms_norm(
+        let input_layernorm = candle_nn::rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             vb.pp("input_layernorm"),
         )?;
-        let post_attention_layernorm = gemma_rms_norm(
+        let post_attention_layernorm = candle_nn::rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             vb.pp("post_attention_layernorm"),
         )?;
-        let pre_feedforward_layernorm = gemma_rms_norm(
+        let pre_feedforward_layernorm = candle_nn::rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             vb.pp("pre_feedforward_layernorm"),
         )?;
-        let post_feedforward_layernorm = gemma_rms_norm(
+        let post_feedforward_layernorm = candle_nn::rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             vb.pp("post_feedforward_layernorm"),
         )?;
 
-        // Layer scalar: loaded from checkpoint, shape [1]
+        // Layer scalar: loaded from checkpoint, shape [1]. Pre-cast to model dtype.
         let layer_scalar = vb
             .get(1, "layer_scalar")
-            .unwrap_or_else(|_| Tensor::ones(1, DType::F32, vb.device()).unwrap());
+            .unwrap_or_else(|_| Tensor::ones(1, vb.dtype(), vb.device()).unwrap());
 
         let ple_dim = config.hidden_size_per_layer_input.unwrap_or(256);
 
@@ -691,7 +672,7 @@ impl DecoderLayer {
             vb.pp("per_layer_projection"),
         )?);
         let post_per_layer_input_norm =
-            gemma_rms_norm(config.hidden_size, config.rms_norm_eps, vb.pp("post_per_layer_input_norm"))?;
+            candle_nn::rms_norm(config.hidden_size, config.rms_norm_eps, vb.pp("post_per_layer_input_norm"))?;
 
         Ok(Self {
             self_attn,
@@ -729,13 +710,13 @@ impl DecoderLayer {
         let prefix = format!("blk.{layer_idx}");
 
         let input_layernorm =
-            gemma_rms_norm_gguf(gg, &format!("{prefix}.attn_norm.weight"), config.rms_norm_eps)?;
+            gg.rms_norm(&format!("{prefix}.attn_norm.weight"), config.rms_norm_eps)?;
         let post_attention_layernorm =
-            gemma_rms_norm_gguf(gg, &format!("{prefix}.post_attention_norm.weight"), config.rms_norm_eps)?;
+            gg.rms_norm(&format!("{prefix}.post_attention_norm.weight"), config.rms_norm_eps)?;
         let pre_feedforward_layernorm =
-            gemma_rms_norm_gguf(gg, &format!("{prefix}.ffn_norm.weight"), config.rms_norm_eps)?;
+            gg.rms_norm(&format!("{prefix}.ffn_norm.weight"), config.rms_norm_eps)?;
         let post_feedforward_layernorm =
-            gemma_rms_norm_gguf(gg, &format!("{prefix}.post_ffw_norm.weight"), config.rms_norm_eps)?;
+            gg.rms_norm(&format!("{prefix}.post_ffw_norm.weight"), config.rms_norm_eps)?;
 
         // Layer scalar: GGUF stores it as a tensor
         let layer_scalar = match gg.tensor(&format!("{prefix}.layer_output_scale.weight")) {
@@ -749,7 +730,7 @@ impl DecoderLayer {
         let per_layer_input_gate = gg.linear(&format!("{prefix}.inp_gate.weight"))?;
         let per_layer_projection = gg.linear(&format!("{prefix}.proj.weight"))?;
         let post_per_layer_input_norm =
-            gemma_rms_norm_gguf(gg, &format!("{prefix}.post_norm.weight"), config.rms_norm_eps)?;
+            gg.rms_norm(&format!("{prefix}.post_norm.weight"), config.rms_norm_eps)?;
 
         Ok(Self {
             self_attn,
@@ -776,7 +757,6 @@ impl DecoderLayer {
         rotated_dim: Option<usize>,
         shared_kv: Option<&(Tensor, Tensor)>,
     ) -> Result<Tensor> {
-        let seq_len = hidden_states.dim(1)?;
         // Pre-norm → attention → post-norm → residual
         let residual = hidden_states;
         let hidden_states = self.input_layernorm.forward(hidden_states)?;
@@ -804,9 +784,7 @@ impl DecoderLayer {
         let hidden_states = self.apply_ple(&hidden_states, per_layer_input)?;
 
         // Layer scalar
-        let hidden_states = hidden_states.broadcast_mul(
-            &self.layer_scalar.to_dtype(hidden_states.dtype())?,
-        )?;
+        let hidden_states = hidden_states.broadcast_mul(&self.layer_scalar)?;
 
         Ok(hidden_states)
     }
@@ -881,7 +859,7 @@ impl Gemma4Model {
             ple_total_dim,
             model_vb.pp("per_layer_model_projection"),
         )?);
-        let per_layer_projection_norm = gemma_rms_norm(
+        let per_layer_projection_norm = candle_nn::rms_norm(
             ple_dim,
             config.rms_norm_eps,
             model_vb.pp("per_layer_projection_norm"),
@@ -903,12 +881,9 @@ impl Gemma4Model {
                 config.intermediate_size
             };
             layers.push(DecoderLayer::new(config, lt, is_shared, intermediate_size, layers_vb.pp(i))?);
-            if let Some(source) = kv_sharing_map[i] {
-                layers[i].self_attn.kv_shared_layer_index = Some(source);
-            }
         }
 
-        let norm = gemma_rms_norm(
+        let norm = candle_nn::rms_norm(
             config.hidden_size,
             config.rms_norm_eps,
             model_vb.pp("norm"),
@@ -989,9 +964,9 @@ impl Gemma4Model {
         // feed_forward_length can be a single u32 or a per-layer i32 array (Gemma4 uses
         // different sizes for non-shared vs shared layers due to use_double_wide_mlp).
         let ff_value = md_get(&format!("{arch}.feed_forward_length"))?;
-        let (intermediate_size, per_layer_ff) = match &ff_value {
-            gguf_file::Value::U32(v) => (*v as usize, None),
-            gguf_file::Value::I32(v) => (*v as usize, None),
+        let intermediate_size = match &ff_value {
+            gguf_file::Value::U32(v) => *v as usize,
+            gguf_file::Value::I32(v) => *v as usize,
             gguf_file::Value::Array(arr) => {
                 let sizes: Vec<usize> = arr
                     .iter()
@@ -1001,8 +976,7 @@ impl Gemma4Model {
                         _ => 6144,
                     })
                     .collect();
-                let first = sizes.first().copied().unwrap_or(6144);
-                (first, Some(sizes))
+                sizes.first().copied().unwrap_or(6144)
             }
             _ => candle_core::bail!("unexpected type for feed_forward_length"),
         };
@@ -1123,7 +1097,7 @@ impl Gemma4Model {
         // Model-level PLE projection
         let per_layer_model_projection = gg.linear("per_layer_model_proj.weight")?;
         let per_layer_projection_norm =
-            gemma_rms_norm_gguf(&mut gg, "per_layer_proj_norm.weight", rms_norm_eps)?;
+            gg.rms_norm("per_layer_proj_norm.weight", rms_norm_eps)?;
 
         let config = Gemma4TextConfig {
             vocab_size: actual_vocab_size,
@@ -1146,12 +1120,9 @@ impl Gemma4Model {
             layers.push(DecoderLayer::new_from_gguf(
                 &config, lt, is_shared, head_dim, &mut gg, i,
             )?);
-            if let Some(source) = kv_sharing_map[i] {
-                layers[i].self_attn.kv_shared_layer_index = Some(source);
-            }
         }
 
-        let norm = gemma_rms_norm_gguf(&mut gg, "output_norm.weight", rms_norm_eps)?;
+        let norm = gg.rms_norm("output_norm.weight", rms_norm_eps)?;
 
         let lm_head = if tie_word_embeddings {
             LinearLayer::Standard(Linear::new(embed_tokens.embeddings().clone(), None))
@@ -1279,14 +1250,13 @@ impl Gemma4Model {
         let per_layer_projection = (per_layer_projection * self.ple_projection_scale)?;
         // Shape: [B, S, num_layers * ple_dim]
 
-        // Reshape to [B, S, num_layers, ple_dim] for norm
-        let shape_prefix = per_layer_projection.dims()[..2].to_vec();
+        // Reshape to [B, S, num_layers, ple_dim] for norm, then flatten back
+        let (b_sz, s_len, _) = per_layer_projection.dims3()?;
         let per_layer_projection = per_layer_projection
-            .reshape((shape_prefix[0], shape_prefix[1], num_layers, ple_dim))?;
+            .reshape((b_sz, s_len, num_layers, ple_dim))?;
         let per_layer_projection = self.per_layer_projection_norm.forward(&per_layer_projection)?;
-        // Flatten back to [B, S, num_layers * ple_dim]
         let per_layer_projection = per_layer_projection
-            .reshape((shape_prefix[0], shape_prefix[1], num_layers * ple_dim))?;
+            .reshape((b_sz, s_len, num_layers * ple_dim))?;
 
         // 3. Combine: (projection + token_embeds) * 2^-0.5
         let per_layer_inputs =
@@ -1295,21 +1265,13 @@ impl Gemma4Model {
         // RoPE tables
         let total_len = start_pos + seq_len;
 
-        let (full_cos_sliding, full_sin_sliding) = self.rotary_sliding.forward(total_len)?;
-        let cos_sliding = full_cos_sliding
-            .narrow(0, start_pos, seq_len)?
-            .to_dtype(self.dtype)?;
-        let sin_sliding = full_sin_sliding
-            .narrow(0, start_pos, seq_len)?
-            .to_dtype(self.dtype)?;
+        let (cos_sliding, sin_sliding) = self.rotary_sliding.forward(start_pos, seq_len)?;
+        let cos_sliding = cos_sliding.to_dtype(self.dtype)?;
+        let sin_sliding = sin_sliding.to_dtype(self.dtype)?;
 
-        let (full_cos_full, full_sin_full) = self.rotary_full.forward(total_len)?;
-        let cos_full = full_cos_full
-            .narrow(0, start_pos, seq_len)?
-            .to_dtype(self.dtype)?;
-        let sin_full = full_sin_full
-            .narrow(0, start_pos, seq_len)?
-            .to_dtype(self.dtype)?;
+        let (cos_full, sin_full) = self.rotary_full.forward(start_pos, seq_len)?;
+        let cos_full = cos_full.to_dtype(self.dtype)?;
+        let sin_full = sin_full.to_dtype(self.dtype)?;
 
         // Attention masks
         let sliding_mask = if seq_len > 1 {
@@ -1325,7 +1287,9 @@ impl Gemma4Model {
 
         // Forward pass through layers
         let mut hidden_states = hidden_states;
-        let mut shared_kv_states: HashMap<usize, (Tensor, Tensor)> = HashMap::new();
+        let first_shared = self.config.first_kv_shared_layer();
+        let mut shared_kv_states: Vec<Option<(Tensor, Tensor)>> =
+            vec![None; first_shared];
 
         for i in 0..self.layers.len() {
             let lt = self.layer_types[i];
@@ -1342,7 +1306,7 @@ impl Gemma4Model {
                 LayerType::SlidingAttention => None,
             };
 
-            let shared_kv = self.kv_sharing_map[i].and_then(|src| shared_kv_states.get(&src));
+            let shared_kv = self.kv_sharing_map[i].and_then(|src| shared_kv_states[src].as_ref());
 
             // PLE input for this layer: narrow from combined per_layer_inputs
             let ple_input = per_layer_inputs.narrow(D::Minus1, i * ple_dim, ple_dim)?;
@@ -1357,13 +1321,13 @@ impl Gemma4Model {
                 shared_kv,
             )?;
 
-            // Store KV state from non-shared layers
-            if self.kv_sharing_map[i].is_none() {
+            // Store KV state from non-shared layers that are referenced by shared layers
+            if i < first_shared {
                 if let Some((ref buf_k, ref buf_v)) = self.layers[i].self_attn.kv_cache {
                     let len = self.layers[i].self_attn.cache_seq_len;
                     let k_view = buf_k.narrow(2, 0, len)?;
                     let v_view = buf_v.narrow(2, 0, len)?;
-                    shared_kv_states.insert(i, (k_view, v_view));
+                    shared_kv_states[i] = Some((k_view, v_view));
                 }
             }
         }

--- a/crane-core/src/models/mod.rs
+++ b/crane-core/src/models/mod.rs
@@ -8,6 +8,7 @@ pub mod qwen25_vit;
 pub mod qwen3;
 pub mod qwen3_tts;
 // pub mod qwen3_vl;
+pub mod gemma4;
 pub mod hunyuan_dense;
 
 #[cfg(feature = "onnx")]

--- a/crane-oai/src/engine/backend.rs
+++ b/crane-oai/src/engine/backend.rs
@@ -129,7 +129,6 @@ pub trait ModelBackend: Send + 'static {
 
 pub struct Gemma4Backend {
     pub model: crane_core::models::gemma4::Model,
-    dtype: DType,
 }
 
 impl Gemma4Backend {
@@ -141,10 +140,7 @@ impl Gemma4Backend {
     ) -> Result<Self> {
         let model =
             crane_core::models::gemma4::Model::new_with_format(model_path, device, dtype, format)?;
-        Ok(Self {
-            model,
-            dtype: *dtype,
-        })
+        Ok(Self { model })
     }
 }
 
@@ -168,7 +164,7 @@ impl ModelBackend for Gemma4Backend {
     }
 
     fn dtype(&self) -> DType {
-        self.dtype
+        self.model.dtype
     }
 
     fn tokenizer(&self) -> &tokenizers::Tokenizer {

--- a/crane-oai/src/engine/backend.rs
+++ b/crane-oai/src/engine/backend.rs
@@ -133,8 +133,14 @@ pub struct Gemma4Backend {
 }
 
 impl Gemma4Backend {
-    pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
-        let model = crane_core::models::gemma4::Model::new(model_path, device, dtype)?;
+    pub fn new(
+        model_path: &str,
+        device: &Device,
+        dtype: &DType,
+        format: crane_core::models::gemma4::ModelFormat,
+    ) -> Result<Self> {
+        let model =
+            crane_core::models::gemma4::Model::new_with_format(model_path, device, dtype, format)?;
         Ok(Self {
             model,
             dtype: *dtype,

--- a/crane-oai/src/engine/backend.rs
+++ b/crane-oai/src/engine/backend.rs
@@ -124,6 +124,76 @@ pub trait ModelBackend: Send + 'static {
 }
 
 // ─────────────────────────────────────────────────────────────
+//  Gemma 4 Backend
+// ─────────────────────────────────────────────────────────────
+
+pub struct Gemma4Backend {
+    pub model: crane_core::models::gemma4::Model,
+    dtype: DType,
+}
+
+impl Gemma4Backend {
+    pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
+        let model = crane_core::models::gemma4::Model::new(model_path, device, dtype)?;
+        Ok(Self {
+            model,
+            dtype: *dtype,
+        })
+    }
+}
+
+impl ModelBackend for Gemma4Backend {
+    fn forward_step(&mut self, input_ids: &[u32], start_pos: usize) -> Result<Tensor> {
+        self.model
+            .forward_step(input_ids, start_pos)
+            .map_err(Into::into)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.model.clear_kv_cache();
+    }
+
+    fn num_layers(&self) -> usize {
+        self.model.num_layers()
+    }
+
+    fn device(&self) -> &Device {
+        &self.model.device
+    }
+
+    fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    fn tokenizer(&self) -> &tokenizers::Tokenizer {
+        &self.model.tokenizer.tokenizer
+    }
+
+    fn eos_token_id(&self) -> Vec<u32> {
+        let tok = &self.model.tokenizer.tokenizer;
+        let mut ids = Vec::new();
+        if let Some(id) = tok.token_to_id("<end_of_turn>") {
+            ids.push(id);
+        }
+        if let Some(id) = tok.token_to_id("<eos>") {
+            ids.push(id);
+        }
+        if ids.is_empty() {
+            ids.push(1); // Gemma default EOS
+        }
+        ids
+    }
+
+    fn warmup(&mut self) {
+        self.model.warmup();
+    }
+
+    // KV swap and batch decode not supported due to KV cache sharing architecture.
+    // supports_kv_swap() defaults to false, capping OAI server to 1 concurrent sequence.
+    // supports_batch_decode() defaults to false.
+}
+
+// ─────────────────────────────────────────────────────────────
 //  Hunyuan Dense Backend
 // ─────────────────────────────────────────────────────────────
 

--- a/crane-oai/src/engine/model_factory.rs
+++ b/crane-oai/src/engine/model_factory.rs
@@ -8,7 +8,7 @@ use candle_core::{DType, Device};
 use serde::Deserialize;
 use std::path::Path;
 
-use super::backend::{HunyuanBackend, ModelBackend, Qwen25Backend, Qwen3Backend};
+use super::backend::{Gemma4Backend, HunyuanBackend, ModelBackend, Qwen25Backend, Qwen3Backend};
 use crate::chat_template::{AutoChatTemplate, ChatTemplateProcessor, HunyuanChatTemplate};
 
 // ─────────────────────────────────────────────────────────────
@@ -19,6 +19,7 @@ use crate::chat_template::{AutoChatTemplate, ChatTemplateProcessor, HunyuanChatT
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ModelType {
     Auto,
+    Gemma4,
     HunyuanDense,
     Qwen25,
     Qwen3,
@@ -29,6 +30,7 @@ pub enum ModelType {
 impl ModelType {
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
+            "gemma4" | "gemma-4" | "gemma4_e2b" => Self::Gemma4,
             "hunyuan" | "hunyuan_dense" | "hunyuandense" => Self::HunyuanDense,
             "qwen25" | "qwen2.5" | "qwen2" => Self::Qwen25,
             "qwen3" => Self::Qwen3,
@@ -41,6 +43,7 @@ impl ModelType {
     pub fn display_name(&self) -> &'static str {
         match self {
             Self::Auto => "auto",
+            Self::Gemma4 => "gemma4",
             Self::HunyuanDense => "hunyuan",
             Self::Qwen25 => "qwen25",
             Self::Qwen3 => "qwen3",
@@ -106,6 +109,7 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
                 // 1. Check `model_type` field
                 if let Some(ref mt) = config.model_type {
                     match mt.to_lowercase().as_str() {
+                        "gemma4" => return ModelType::Gemma4,
                         "qwen2" | "qwen2.5" => return ModelType::Qwen25,
                         "qwen3" => return ModelType::Qwen3,
                         "qwen3_tts" | "qwen3tts" => return ModelType::Qwen3TTS,
@@ -124,6 +128,9 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
                         }
                         if a.contains("hunyuan") {
                             return ModelType::HunyuanDense;
+                        }
+                        if a.contains("gemma4") {
+                            return ModelType::Gemma4;
                         }
                         if a.contains("qwen3ttsforconditional") || a.contains("qwen3_tts") {
                             return ModelType::Qwen3TTS;
@@ -144,6 +151,8 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
     let path_lower = model_path.to_lowercase();
     if path_lower.contains("paddleocr") {
         ModelType::PaddleOcrVl
+    } else if path_lower.contains("gemma4") || path_lower.contains("gemma-4") {
+        ModelType::Gemma4
     } else if path_lower.contains("hunyuan") {
         ModelType::HunyuanDense
     } else if path_lower.contains("qwen3-tts") || path_lower.contains("qwen3_tts") || path_lower.contains("qwen3tts") {
@@ -193,6 +202,7 @@ pub fn create_backend(
             };
             Ok(Box::new(HunyuanBackend::new(model_path, device, dtype, hy_fmt)?))
         }
+        ModelType::Gemma4 => Ok(Box::new(Gemma4Backend::new(model_path, device, dtype)?)),
         ModelType::Qwen25 => Ok(Box::new(Qwen25Backend::new(model_path, device, dtype)?)),
         ModelType::Qwen3 => Ok(Box::new(Qwen3Backend::new(model_path, device, dtype)?)),
         ModelType::PaddleOcrVl => {

--- a/crane-oai/src/engine/model_factory.rs
+++ b/crane-oai/src/engine/model_factory.rs
@@ -202,7 +202,14 @@ pub fn create_backend(
             };
             Ok(Box::new(HunyuanBackend::new(model_path, device, dtype, hy_fmt)?))
         }
-        ModelType::Gemma4 => Ok(Box::new(Gemma4Backend::new(model_path, device, dtype)?)),
+        ModelType::Gemma4 => {
+            let g4_fmt = match format {
+                ModelFormat::Safetensors => crane_core::models::gemma4::ModelFormat::Safetensors,
+                ModelFormat::Gguf => crane_core::models::gemma4::ModelFormat::Gguf,
+                ModelFormat::Auto => crane_core::models::gemma4::ModelFormat::Auto,
+            };
+            Ok(Box::new(Gemma4Backend::new(model_path, device, dtype, g4_fmt)?))
+        }
         ModelType::Qwen25 => Ok(Box::new(Qwen25Backend::new(model_path, device, dtype)?)),
         ModelType::Qwen3 => Ok(Box::new(Qwen3Backend::new(model_path, device, dtype)?)),
         ModelType::PaddleOcrVl => {

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -46,6 +46,10 @@ name = "tts_voice_clone"
 path = "src/tts_voice_clone.rs"
 
 [[bin]]
+name = "gemma4_simple"
+path = "src/gemma4_simple.rs"
+
+[[bin]]
 name = "hunyuan_simple"
 path = "src/hunyuan_simple.rs"
 

--- a/example/src/gemma4_simple.rs
+++ b/example/src/gemma4_simple.rs
@@ -1,0 +1,52 @@
+//! Simple Gemma 4 text generation example using crane-core directly.
+//!
+//! Usage:
+//!   cargo run --bin gemma4_simple -- /path/to/gemma-4-E2B
+
+use anyhow::Result;
+use crane_core::generation::based::ModelForCausalLM;
+use crane_core::generation::GenerationConfig;
+use crane_core::models::gemma4::Model;
+use crane_core::models::DType;
+
+fn main() -> Result<()> {
+    let model_path = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "model/gemma-4-E2B".to_string());
+
+    let device = crane_core::models::Device::cuda_if_available(0)?;
+    let dtype = if device.is_cuda() {
+        DType::BF16
+    } else {
+        DType::F32
+    };
+
+    eprintln!("Loading Gemma 4 from: {model_path}");
+    eprintln!("Device: {:?}, dtype: {:?}", device, dtype);
+
+    let mut model = Model::new(&model_path, &device, &dtype)?;
+
+    let prompt = "<start_of_turn>user\nHello, introduce yourself briefly.<end_of_turn>\n<start_of_turn>model\n";
+    eprintln!("Prompt: {prompt}");
+
+    let input_ids = model.prepare_inputs(prompt)?;
+
+    let config = GenerationConfig {
+        max_new_tokens: 200,
+        temperature: Some(0.7),
+        top_p: Some(0.9),
+        report_speed: true,
+        ..Default::default()
+    };
+
+    let tokens = model.generate(&input_ids, &config, None)?;
+
+    let output = model
+        .tokenizer
+        .tokenizer
+        .decode(&tokens[input_ids.len()..], true)
+        .unwrap_or_default();
+    println!("\nGenerated:\n{output}");
+
+    Ok(())
+}

--- a/scripts/test_gemma4.sh
+++ b/scripts/test_gemma4.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Test script for Gemma4 model — starts server, makes a request, captures debug output.
+#
+# Usage:
+#   ./scripts/test_gemma4.sh [model_path] [prompt]
+#
+# Examples:
+#   ./scripts/test_gemma4.sh /home/emre/models/gemma-4-E2B/
+#   ./scripts/test_gemma4.sh /home/emre/models/gemma-4-E2B/ "The capital of France is"
+
+MODEL_PATH="${1:-/home/emre/models/gemma-4-E2B/}"
+PROMPT="${2:-Hello}"
+PORT=8080
+MAX_TOKENS="${3:-20}"
+LOG_FILE="/tmp/crane-gemma4-debug.log"
+
+# Kill any existing server
+pkill -f "crane-oai.*gemma" 2>/dev/null
+sleep 1
+
+echo "=== Gemma4 Debug Test ==="
+echo "Model: $MODEL_PATH"
+echo "Prompt: $PROMPT"
+echo "Log: $LOG_FILE"
+echo ""
+
+# Build if needed
+echo "Building..."
+if ! cargo build -p crane-oai --release 2>&1 | tail -5; then
+    echo "Build failed!"
+    exit 1
+fi
+
+# Start server, capture stderr (debug output) to log file
+echo "Starting server..."
+target/release/crane-oai \
+    --model-path "$MODEL_PATH" \
+    --model-type gemma4 \
+    --port $PORT \
+    2>"$LOG_FILE" &
+SERVER_PID=$!
+
+# Wait for server to be ready
+echo -n "Waiting for server"
+for i in $(seq 1 60); do
+    if curl -s "http://localhost:$PORT/health" >/dev/null 2>&1; then
+        echo " ready!"
+        break
+    fi
+    echo -n "."
+    sleep 1
+done
+
+if ! curl -s "http://localhost:$PORT/health" >/dev/null 2>&1; then
+    echo " FAILED (timeout)"
+    kill $SERVER_PID 2>/dev/null
+    cat "$LOG_FILE"
+    exit 1
+fi
+
+# Make test request
+echo ""
+echo "--- Request: prompt=\"$PROMPT\" max_tokens=$MAX_TOKENS ---"
+RESPONSE=$(curl -s "http://localhost:$PORT/v1/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"gemma-4-E2B\",\"prompt\":\"$PROMPT\",\"max_tokens\":$MAX_TOKENS}")
+echo "Response: $RESPONSE"
+
+# Wait a moment for any async debug output
+sleep 1
+
+# Show debug output
+echo ""
+echo "--- Debug Output (from stderr) ---"
+grep "\[DEBUG\]" "$LOG_FILE" | tail -20
+
+# Cleanup
+echo ""
+echo "--- Stopping server (PID $SERVER_PID) ---"
+kill $SERVER_PID 2>/dev/null
+wait $SERVER_PID 2>/dev/null
+echo "Done."

--- a/scripts/test_gemma4.sh
+++ b/scripts/test_gemma4.sh
@@ -2,14 +2,10 @@
 # Test script for Gemma4 model — starts server, makes a request, captures debug output.
 #
 # Usage:
-#   ./scripts/test_gemma4.sh [model_path] [prompt]
-#
-# Examples:
-#   ./scripts/test_gemma4.sh /home/emre/models/gemma-4-E2B/
-#   ./scripts/test_gemma4.sh /home/emre/models/gemma-4-E2B/ "The capital of France is"
+#   ./scripts/test_gemma4.sh <model_path> [prompt] [max_tokens]
 
-MODEL_PATH="${1:-/home/emre/models/gemma-4-E2B/}"
-PROMPT="${2:-Hello}"
+MODEL_PATH="${1:?Usage: $0 <model_path> [prompt] [max_tokens]}"
+PROMPT="${2:-What is a sun?}"
 PORT=8080
 MAX_TOKENS="${3:-20}"
 LOG_FILE="/tmp/crane-gemma4-debug.log"

--- a/scripts/test_gemma4_gguf.sh
+++ b/scripts/test_gemma4_gguf.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Test script for Gemma4 GGUF model — starts server, makes a request, captures output.
+#
+# Usage:
+#   ./scripts/test_gemma4_gguf.sh <gguf_file_path> [prompt] [max_tokens]
+#
+# Examples:
+#   ./scripts/test_gemma4_gguf.sh /home/emre/models/gemma4/gemma-4-E2B-it-Q4_K_M.gguf
+#   ./scripts/test_gemma4_gguf.sh /path/to/model.gguf "The capital of France is" 30
+
+GGUF_PATH="${1:?Usage: $0 <gguf_file_path> [prompt] [max_tokens]}"
+PROMPT="${2:-The capital of France is}"
+MAX_TOKENS="${3:-20}"
+PORT=8080
+LOG_FILE="/tmp/crane-gemma4-gguf-debug.log"
+
+# Kill any existing server
+pkill -f "crane-oai" 2>/dev/null
+sleep 1
+
+echo "=== Gemma4 GGUF Test ==="
+echo "Model: $GGUF_PATH"
+echo "Prompt: $PROMPT"
+echo "Max tokens: $MAX_TOKENS"
+echo ""
+
+# Check file exists
+if [ ! -f "$GGUF_PATH" ]; then
+    echo "Error: GGUF file not found: $GGUF_PATH"
+    exit 1
+fi
+
+# Check tokenizer.json exists nearby
+GGUF_DIR=$(dirname "$GGUF_PATH")
+if [ ! -f "$GGUF_DIR/tokenizer.json" ]; then
+    echo "Warning: tokenizer.json not found in $GGUF_DIR"
+    echo "Place tokenizer.json in the same directory as the GGUF file."
+    echo ""
+fi
+
+# Build
+echo "Building..."
+if ! cargo build -p crane-oai --release 2>&1 | tail -3; then
+    echo "Build may have warnings, continuing..."
+fi
+
+# Start server
+echo "Starting server..."
+target/release/crane-oai \
+    --model-path "$GGUF_PATH" \
+    --model-type gemma4 \
+    --format gguf \
+    --port $PORT \
+    2>"$LOG_FILE" &
+SERVER_PID=$!
+
+# Wait for server to be ready
+echo -n "Waiting for server"
+for i in $(seq 1 60); do
+    if curl -s "http://localhost:$PORT/health" >/dev/null 2>&1; then
+        echo " ready!"
+        break
+    fi
+    echo -n "."
+    sleep 1
+done
+
+if ! curl -s "http://localhost:$PORT/health" >/dev/null 2>&1; then
+    echo " FAILED (timeout)"
+    echo "--- Server log ---"
+    cat "$LOG_FILE"
+    kill $SERVER_PID 2>/dev/null
+    exit 1
+fi
+
+# Test completion
+echo ""
+echo "--- Completion: prompt=\"$PROMPT\" max_tokens=$MAX_TOKENS ---"
+RESPONSE=$(curl -s "http://localhost:$PORT/v1/completions" \
+    -H "Content-Type: application/json" \
+    -d "{\"model\":\"gemma4\",\"prompt\":\"$PROMPT\",\"max_tokens\":$MAX_TOKENS}")
+echo "Response: $RESPONSE"
+
+# Wait for async output
+sleep 1
+
+# Show any errors from log
+echo ""
+ERRORS=$(grep -i "error\|panic\|cannot find" "$LOG_FILE" 2>/dev/null)
+if [ -n "$ERRORS" ]; then
+    echo "--- Errors from log ---"
+    echo "$ERRORS"
+fi
+
+# Cleanup
+echo ""
+echo "--- Stopping server (PID $SERVER_PID) ---"
+kill $SERVER_PID 2>/dev/null
+wait $SERVER_PID 2>/dev/null
+echo "Done."

--- a/scripts/test_gemma4_gguf.sh
+++ b/scripts/test_gemma4_gguf.sh
@@ -3,10 +3,6 @@
 #
 # Usage:
 #   ./scripts/test_gemma4_gguf.sh <gguf_file_path> [prompt] [max_tokens]
-#
-# Examples:
-#   ./scripts/test_gemma4_gguf.sh /home/emre/models/gemma4/gemma-4-E2B-it-Q4_K_M.gguf
-#   ./scripts/test_gemma4_gguf.sh /path/to/model.gguf "The capital of France is" 30
 
 GGUF_PATH="${1:?Usage: $0 <gguf_file_path> [prompt] [max_tokens]}"
 PROMPT="${2:-The capital of France is}"


### PR DESCRIPTION
Hello,
due limited knowledge of inference engines and LLM architectures, I managed to add these models using Claude Code.
I can follow up with changes, thanks. (I may try to add vision and audio encoders later on).

## Summary

Add support for Google's Gemma 4 E2B model family as a text-only decoder in Crane. Both **safetensors** (HuggingFace) and **GGUF** (llama.cpp quantized) formats are supported.

### Architecture highlights
- **Hybrid attention** — sliding window (512 tokens) + full causal, per `layer_types` pattern
- **Dual RoPE** — sliding: theta=10K full rotation; full: theta=1M partial rotation (25%)
- **Per-Layer Embeddings (PLE)** — gated per-layer token embeddings with model-level projection
- **KV cache sharing** — layers 15-34 share K/V from prior non-shared layers (13/14)
- **QK norms + V norm** — per-head RMSNorm on Q/K before RoPE, unscaled RMS normalization on V
- **Gemma-style norms** — 4 norms per layer (pre+post pairs), `scaling=1.0` (no `1/sqrt(d)`)
- **GELU-tanh activation**, logit softcapping, per-layer scalar, embedding scaling

### Files changed
| File | Action |
|---|---|
| `crane-core/src/models/gemma4/modeling.rs` | Core architecture (~1400 lines) |
| `crane-core/src/models/gemma4/model.rs` | Weight loading, ModelForCausalLM impl |
| `crane-core/src/models/gemma4/mod.rs` | Module exports |
| `crane-core/src/models/mod.rs` | Register `pub mod gemma4` |
| `crane-oai/src/engine/backend.rs` | `Gemma4Backend` |
| `crane-oai/src/engine/model_factory.rs` | Detection + creation |
| `example/src/gemma4_simple.rs` | Example binary using crane-core |
| `example/Cargo.toml` | Register example |
| `scripts/test_gemma4.sh` | Safetensors test script |
| `scripts/test_gemma4_gguf.sh` | GGUF test script |

### Known limitations
- **KV swap disabled** (`supports_kv_swap() -> false`) — architecturally incompatible with KV sharing; caps OAI server to 1 concurrent sequence
- **Batch decode disabled** — deferred; requires adapting to shared-KV semantics
- **Text-only** — vision/audio encoders out of scope (can be layered on later)
- **SDK client not wired** — example uses crane-core directly

## Testing

Verified on CPU (F32) against HuggingFace transformers reference:
- **Safetensors** (google/gemma-4-E2B): hidden states match HF to 6 decimal places through all 35 layers
- **GGUF Q4_K_M** (unsloth/gemma-4-E2B-it-GGUF): correct answers with proper EOS detection

```bash
# Safetensors
cargo run -p crane-oai --release -- --model-path /path/to/gemma-4-E2B/

# GGUF (tokenizer.json must be in same directory)
cargo run -p crane-oai --release -- --model-path /path/to/gemma-4-E2B-it-Q4_K_M.gguf --model-type gemma4

# Test scripts
./scripts/test_gemma4.sh /path/to/gemma-4-E2B/ "The capital of France is" 30
./scripts/test_gemma4_gguf.sh /path/to/model.gguf "Hello" 20
```

Sample output (safetensors, base model):
> "The capital of France is Paris, the country's largest city and a global cultural centre..."

Sample output (GGUF Q4_K_M, instruct model):
> "The capital of France is Paris."