### PR TITLE
Add Qwen 3.5 hybrid GDN/attention support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A high-performance inference framework leveraging Rust's Candle for maximum spee
 
 - [x] Qwen3 (0.6B ~ 30B+)
 - [x] Qwen 2.5 (0.5B ~ 72B)
+- [x] Qwen 3.5 (0.8B; hybrid Gated Delta Net + softmax attention, CPU/CUDA/Metal)
 - [x] Hunyuan Dense
 - [x] Gemma 4 (text and vision; no audio)
 - [x] Qwen3 VL (2B, 4B)
@@ -56,8 +57,9 @@ We include:
 
 ## 🔥 Updates
 
+- **`2026.06.29`**: 🌀 Qwen 3.5 support — hybrid Mamba/Transformer (Gated Delta Net + softmax attention), runs on CPU, NVIDIA CUDA, and Apple Metal. New `crane-core/src/gdn/` module with a fused CUDA recurrence kernel for the linear-attention path.
 - **`2026.05.04`**: Gemma 4 support added for text and vision models (audio is not supported);
-- **`2026.02.23`**: 🎙️ Qwen3-TTS support added — full Talker + Code Predictor transformer in Candle, native speech-tokenizer decoder (ONNX fallback), voice cloning (Base model ICL), OpenAI `/v1/audio/speech` endpoint in crane-oai;
+- **`2026.02.23`**: 🎙️ Qwen3-TTS support added — full Talker + Code Predictor transformer in Candle, native speech-tokenizer decoder (ONNX fallback), voice cloning (Base model ICL), OpenAI `/v1/audio/speech` endpoint in crane-serve;
 - **`2026.02.18`**: ⚡ Qwen3 & Hunyuan Dense inference optimization: pre-allocated KV cache, GQA 4D matmul, fused RoPE with cache pre-growth, GGUF quantization, batched decode, smart sampling fallback for large vocabularies;
 - **`2026.01.30`**: PaddleOCR-VL-1.5 supported now! model: https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5/;
 - **`2025.03.21`**: 🔥 Qwen2.5 a more transformers liked Rust interface were supported, you now use Crane just like in your python;
@@ -181,7 +183,7 @@ To use `crane`, here are some notes:
 
 - `crane-core`: All models comes into core, this is a lib;
 - `crane`: All Apps (runnable AI pipelines, such as Qwen2-Chat, Spark-TTS, Qwen2.5-VL etc), you can build your apps inside it, each app is a binary for demonstration purpose;
-- `crane-oai`: OpenAI & SGLang compatible API server with continuous batching, see [crane-oai/README.md](crane-oai/README.md) for full documentation;
+- `crane-serve`: OpenAI & SGLang compatible API server with continuous batching, see [crane-serve/README.md](crane-serve/README.md) for full documentation;
 
 1. Make sure latest Rust were installed;
 2. Build (choose based on your hardware):
@@ -203,15 +205,15 @@ Start a server compatible with OpenAI SDK and SGLang client:
 ```bash
 # Build
 # CPU
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 # CUDA
-cargo build -p crane-oai --release --features cuda
+cargo build -p crane-serve --release --features cuda
 
 # Start (auto-detect model type and device)
-./target/release/crane-oai --model-path /path/to/Qwen2.5-7B-Instruct
+./target/release/crane --model-path /path/to/Qwen2.5-7B-Instruct
 
 # Or run directly
-cargo run -p crane-oai --release -- --model-path /path/to/model --port 8000
+cargo run -p crane-serve --release -- --model-path /path/to/model --port 8000
 ```
 
 Then use it with any OpenAI-compatible client:
@@ -244,7 +246,7 @@ Supported endpoints:
 | Mgmt   | `GET /health` | Health check |
 | Mgmt   | `GET /v1/stats` | Engine statistics |
 
-✨ **Text-to-Speech (Qwen3-TTS)**: For TTS models, the server adds a `/v1/audio/speech` endpoint (OpenAI-compatible). Both **CustomVoice** (predefined speakers) and **Base** (voice cloning via reference audio) models are supported. `response_format` currently supports `wav` and `pcm` (other formats return `400`). See [crane-oai/README.md](crane-oai/README.md) for full TTS API documentation.
+✨ **Text-to-Speech (Qwen3-TTS)**: For TTS models, the server adds a `/v1/audio/speech` endpoint (OpenAI-compatible). Both **CustomVoice** (predefined speakers) and **Base** (voice cloning via reference audio) models are supported. `response_format` currently supports `wav` and `pcm` (other formats return `400`). See [crane-serve/README.md](crane-serve/README.md) for full TTS API documentation.
 
 ### TTS Examples
 
@@ -266,7 +268,7 @@ All TTS examples save generated audio files to `data/audio/output`.
 - Base (voice clone): [vc1_base.wav](data/audio/output/vc1_base.wav), [vc2_base.wav](data/audio/output/vc2_base.wav)
 - CustomVoice: [custom_voice_zh.wav](data/audio/output/custom_voice_zh.wav), [custom_voice_en.wav](data/audio/output/custom_voice_en.wav), [custom_voice_ja.wav](data/audio/output/custom_voice_ja.wav)
 
-✨ **Multimodal & Vision support**: For models like PaddleOCR-VL, the endpoints accept OpenAI's structured `messages.[]content.[{type: "image_url", image_url: {url: "..."}}]` payload or SGLang's `image_url` field. See [crane-oai/README.md](crane-oai/README.md) for full API documentation with request/response examples.
+✨ **Multimodal & Vision support**: For models like PaddleOCR-VL, the endpoints accept OpenAI's structured `messages.[]content.[{type: "image_url", image_url: {url: "..."}}]` payload or SGLang's `image_url` field. See [crane-serve/README.md](crane-serve/README.md) for full API documentation with request/response examples.
 
 Now you can run LLM extremly fast (about 6x faster than vanilla transformers on M1)!
 
@@ -275,9 +277,9 @@ Now you can run LLM extremly fast (about 6x faster than vanilla transformers on 
 ```
 Crane/
 ├── crane-core/          # Core library: model implementations, tokenizer, generation
-│   └── src/models/      # Model architectures (Qwen 2.5, Qwen 3, Hunyuan, etc.)
+│   └── src/models/      # Model architectures (Qwen 2.5, Qwen 3, Qwen 3.5, Hunyuan, etc.)
 ├── crane/               # High-level SDK: Chat, Vision, Audio, Multimodal clients
-├── crane-oai/           # OpenAI & SGLang compatible API server
+├── crane-serve/         # OpenAI & SGLang compatible API server
 │   └── src/
 │       ├── engine/      # Continuous batching inference engine
 │       ├── handlers/    # HTTP request handlers (OpenAI, SGLang, common)

--- a/crane-core/kernels/gdn.cu
+++ b/crane-core/kernels/gdn.cu
@@ -1,0 +1,88 @@
+// Fused Gated Delta Net recurrence (CUDA), f32.
+//
+// One thread block per (batch * value-head); one thread per value column.
+// Each thread owns state column S[:, vcol] (K elements) in a per-thread array,
+// and steps through the whole sequence — collapsing the per-timestep Candle op
+// graph (thousands of tiny launches) into a single kernel launch.
+//
+// Layouts (all contiguous, f32):
+//   q, k     : [BH, S, K]   (q already pre-scaled by 1/sqrt(K) by the caller)
+//   v, y     : [BH, S, V]
+//   g, beta  : [BH, S]      (g is the log-decay; decay = exp(g))
+//   state    : [BH, K, V]   (state_in read once, state_out written once)
+//
+// Recurrence per timestep t (matches the CPU reference exactly):
+//   S      *= exp(g_t)
+//   kv_mem  = sum_k S[k,:] * k_t[k]
+//   delta   = (v_t - kv_mem) * beta_t
+//   S[k,:] += k_t[k] * delta
+//   y_t     = sum_k S[k,:] * q_t[k]
+
+#include <cuda_runtime.h>
+
+#define GDN_MAX_K 256
+
+extern "C" __global__ void gdn_recurrence_f32(
+    const float* __restrict__ q,
+    const float* __restrict__ k,
+    const float* __restrict__ v,
+    const float* __restrict__ g,
+    const float* __restrict__ beta,
+    const float* __restrict__ state_in,
+    float* __restrict__ state_out,
+    float* __restrict__ y,
+    int BH, int S, int K, int V)
+{
+    const int bh = blockIdx.x;
+    const int vcol = threadIdx.x;
+    if (bh >= BH || vcol >= V) return;
+
+    // Per-thread state column S[:, vcol].
+    float Scol[GDN_MAX_K];
+    const float* st_in = state_in + (long long)bh * K * V;
+    for (int kk = 0; kk < K; ++kk) Scol[kk] = st_in[kk * V + vcol];
+
+    // Shared k_t / q_t for the current timestep (2*K floats).
+    extern __shared__ float sh[];
+    float* k_sh = sh;
+    float* q_sh = sh + K;
+
+    const float* qb = q + (long long)bh * S * K;
+    const float* kb = k + (long long)bh * S * K;
+    const float* vb = v + (long long)bh * S * V;
+    const float* gb = g + (long long)bh * S;
+    const float* bb = beta + (long long)bh * S;
+    float* yb = y + (long long)bh * S * V;
+
+    for (int t = 0; t < S; ++t) {
+        for (int kk = threadIdx.x; kk < K; kk += blockDim.x) {
+            k_sh[kk] = kb[t * K + kk];
+            q_sh[kk] = qb[t * K + kk];
+        }
+        __syncthreads();
+
+        const float decay = expf(gb[t]);
+        const float beta_t = bb[t];
+        const float v_t = vb[t * V + vcol];
+
+        float kv_mem = 0.f;
+        #pragma unroll 4
+        for (int kk = 0; kk < K; ++kk) {
+            Scol[kk] *= decay;
+            kv_mem += Scol[kk] * k_sh[kk];
+        }
+        const float delta = (v_t - kv_mem) * beta_t;
+
+        float y_t = 0.f;
+        #pragma unroll 4
+        for (int kk = 0; kk < K; ++kk) {
+            Scol[kk] += k_sh[kk] * delta;
+            y_t += Scol[kk] * q_sh[kk];
+        }
+        yb[t * V + vcol] = y_t;
+        __syncthreads();
+    }
+
+    float* st_out = state_out + (long long)bh * K * V;
+    for (int kk = 0; kk < K; ++kk) st_out[kk * V + vcol] = Scol[kk];
+}

--- a/crane-core/src/gdn/backend.rs
+++ b/crane-core/src/gdn/backend.rs
@@ -1,0 +1,398 @@
+//! Numerical kernels for Gated Delta Net: L2 normalization, softplus, the
+//! gated delta rule recurrence, causal Conv1D, and dispatch.
+//!
+//! The recurrence and Conv1D are written as compositions of Candle tensor ops,
+//! so they run on any device (CPU/CUDA/Metal). On CUDA, an optional fused
+//! kernel is also available (see [`super::cuda_backend`]); set
+//! `CRANE_GDN_PORTABLE=1` to force the op-by-op path for cross-checking
+//! numerics against the reference.
+
+use candle_core::{DType, IndexOp, Result, Tensor, D};
+
+use super::cache::GdnLayerCache;
+use super::config::GdnDims;
+
+// ─────────────────────────────────────────────────────────────────────
+//  Elementwise helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/// `x / sqrt(mean(x^2) + eps)` over the last dim — used to normalize Q and K
+/// before the delta-rule recurrence.
+pub fn l2_norm(x: &Tensor, eps: f64) -> Result<Tensor> {
+    let inv_norm = x
+        .sqr()?
+        .sum_keepdim(D::Minus1)?
+        .broadcast_add(&Tensor::new(eps as f32, x.device())?.to_dtype(x.dtype())?)?
+        .sqrt()?
+        .recip()?;
+    x.broadcast_mul(&inv_norm)
+}
+
+/// `log(1 + exp(x))` — numerically stable; computed as `log1p(exp(x))`.
+pub fn softplus(x: &Tensor) -> Result<Tensor> {
+    (Tensor::ones_like(x)? + x.exp()?)?.log()
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Gated delta rule recurrence (CPU reference)
+// ─────────────────────────────────────────────────────────────────────
+
+/// Per-timestep gated delta rule in pure Candle ops.
+///
+/// Inputs (all contiguous, f32):
+/// - `q, k`: `[BH, S, K]` — queries / keys
+/// - `v`:    `[BH, S, V]` — values
+/// - `g`:    `[BH, S]`    — log-decay (already pre-softplus'd by the caller)
+/// - `beta`: `[BH, S]`    — write strength
+/// - `state`: `[BH, K, V]` — recurrent state (mutated in place)
+///
+/// Returns `y: [BH, S, V]`. `state` is updated to the post-final-step value.
+/// Output dtype matches `q.dtype()`.
+pub fn gated_delta_rule_recurrence(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    state: &mut Tensor,
+) -> Result<Tensor> {
+    let dtype = q.dtype();
+
+    // HF's gated delta rule scales Q by `1/sqrt(head_k_dim)` before the
+    // recurrence (`scale = 1 / query.shape[-1]**0.5` in
+    // `torch_recurrent_gated_delta_rule`). Omitting it leaves the recurrence
+    // output a factor of `sqrt(K)` too large, which is not washed out
+    // downstream because the gated RMSNorm eps and the silu gate make it
+    // observable.
+    let scale = 1.0 / (q.dim(D::Minus1)? as f64).sqrt();
+    let q = (q.affine(scale, 0.0)?).transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let k = k.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let v = v.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let g = g.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let beta = beta.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+
+    let seq_len = q.dim(2)?;
+    let mut s = state.to_dtype(DType::F32)?;
+    let mut outputs = Vec::with_capacity(seq_len);
+
+    for i in 0..seq_len {
+        let q_t = q.i((.., .., i, ..))?;
+        let k_t = k.i((.., .., i, ..))?;
+        let v_t = v.i((.., .., i, ..))?;
+        let g_t = g.i((.., .., i))?;
+        let beta_t = beta.i((.., .., i))?;
+
+        // 1. Decay state by per-head factor.
+        let decay = g_t.exp()?.unsqueeze(D::Minus1)?.unsqueeze(D::Minus1)?;
+        s = s.broadcast_mul(&decay)?;
+
+        // 2. Retrieve kv_mem = sum_d_state(state * k).
+        let k_exp = k_t.unsqueeze(D::Minus1)?;
+        let kv_mem = s.broadcast_mul(&k_exp)?.sum(2)?;
+
+        // 3. Delta rule residual.
+        let beta_exp = beta_t.unsqueeze(D::Minus1)?;
+        let delta = (v_t - kv_mem)?.broadcast_mul(&beta_exp)?;
+
+        // 4. Write state update: S += outer(k, delta).
+        let outer = k_exp.broadcast_mul(&delta.unsqueeze(2)?)?;
+        s = (s + outer)?;
+
+        // 5. Output: y = sum_d_state(state * q).
+        let q_exp = q_t.unsqueeze(D::Minus1)?;
+        let y_t = s.broadcast_mul(&q_exp)?.sum(2)?;
+        outputs.push(y_t);
+    }
+
+    *state = s.to_dtype(state.dtype())?;
+
+    Tensor::stack(&outputs, 2)?
+        .transpose(1, 2)?
+        .contiguous()?
+        .to_dtype(dtype)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  β/g computation (pre-recurrence)
+// ─────────────────────────────────────────────────────────────────────
+
+/// Derive the per-head write strength β and per-step decay g from the
+/// projections, A_log, and dt_bias.
+///
+/// `b: [B, S, H]` raw logits → `beta = sigmoid(b)`.
+/// `a: [B, S, H]` raw values → combined with `A_log` (negative log of decay
+/// rate) and `dt_bias` to produce `g = -exp(A_log) * softplus(a + dt_bias)`.
+pub fn compute_beta_g(
+    b: &Tensor,
+    a: &Tensor,
+    a_log: &Tensor,
+    dt_bias: &Tensor,
+    dtype: DType,
+) -> Result<(Tensor, Tensor)> {
+    // β and g are tiny per-head ops; computed in pure Candle.
+    let beta = candle_nn::ops::sigmoid(b)?;
+    let a_f = a.to_dtype(DType::F32)?;
+    let dt_bias_expanded = dt_bias.to_dtype(DType::F32)?.unsqueeze(0)?.unsqueeze(0)?;
+    let g = a_log
+        .to_dtype(DType::F32)?
+        .exp()?
+        .neg()?
+        .unsqueeze(0)?
+        .unsqueeze(0)?
+        .broadcast_mul(&softplus(&a_f.broadcast_add(&dt_bias_expanded)?)?)?
+        .to_dtype(dtype)?;
+    Ok((beta, g))
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Dispatch entry points
+// ─────────────────────────────────────────────────────────────────────
+
+/// Compute β and g, run the gated delta rule recurrence, return the output.
+///
+/// The recurrence is written in pure-Candle tensor ops, so it runs on any
+/// device (CPU/CUDA/Metal) — every op has a native backend kernel. On CUDA,
+/// a fused single-launch kernel is preferred when available
+/// ([`super::cuda_backend::gdn_recurrence_cuda`]); set
+/// `CRANE_GDN_PORTABLE=1` to force the op-by-op path for cross-checking
+/// numerics.
+#[allow(unused_variables)]
+pub fn apply_recurrence(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    dims: &GdnDims,
+    batch_size: usize,
+    seq_len: usize,
+    cache: &mut GdnLayerCache,
+    dtype: DType,
+) -> Result<Tensor> {
+    #[cfg(feature = "cuda")]
+    if q.device().is_cuda() && std::env::var("CRANE_GDN_PORTABLE").is_err() {
+        return cuda_recurrence(q, k, v, g, beta, dims, batch_size, seq_len, cache, dtype);
+    }
+
+    gated_delta_rule_recurrence(q, k, v, g, beta, &mut cache.recurrent_state)
+}
+
+/// Prepare tensors and launch the fused CUDA recurrence kernel.
+///
+/// Lays inputs out as the kernel expects (`[BH, S, *]`, contiguous f32),
+/// applies the `1/sqrt(K)` query scale here (the kernel takes plain q), then
+/// reshapes the result back to the portable path's `[B, S, num_v_heads, V]`.
+#[cfg(feature = "cuda")]
+fn cuda_recurrence(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    dims: &GdnDims,
+    batch_size: usize,
+    seq_len: usize,
+    cache: &mut GdnLayerCache,
+    dtype: DType,
+) -> Result<Tensor> {
+    let (hv, kd, vd) = (dims.num_v_heads, dims.head_k_dim, dims.head_v_dim);
+    let bh = batch_size * hv;
+    let scale = 1.0 / (kd as f64).sqrt();
+
+    // [B, S, Hv, *] -> [B, Hv, S, *] -> [BH, S, *], contiguous f32.
+    let prep3 = |t: &Tensor| -> Result<Tensor> {
+        t.to_dtype(DType::F32)?
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((bh, seq_len, ()))
+    };
+    let prep2 = |t: &Tensor| -> Result<Tensor> {
+        t.to_dtype(DType::F32)?
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((bh, seq_len))
+    };
+    let q3 = prep3(q)?.affine(scale, 0.0)?;
+    let k3 = prep3(k)?;
+    let v3 = prep3(v)?;
+    let g2 = prep2(g)?;
+    let beta2 = prep2(beta)?;
+    let state3 = cache
+        .recurrent_state
+        .to_dtype(DType::F32)?
+        .reshape((bh, kd, vd))?
+        .contiguous()?;
+
+    let (y, state_out) =
+        super::cuda_backend::gdn_recurrence_cuda(&q3, &k3, &v3, &g2, &beta2, &state3)?;
+
+    cache.recurrent_state = state_out.reshape((batch_size, hv, kd, vd))?;
+    // [BH, S, V] -> [B, Hv, S, V] -> [B, S, Hv, V], back to model dtype.
+    y.reshape((batch_size, hv, seq_len, vd))?
+        .transpose(1, 2)?
+        .contiguous()?
+        .to_dtype(dtype)
+}
+
+/// Causal Conv1D over the QKV channels. Dispatches to a kernel-based
+/// implementation when available, pure-Candle otherwise.
+pub fn causal_conv1d(
+    x: &Tensor,
+    conv1d_weight: &Tensor,
+    dims: &GdnDims,
+    cache: &mut GdnLayerCache,
+    is_decode_step: bool,
+) -> Result<Tensor> {
+    if is_decode_step {
+        causal_conv1d_update(x, conv1d_weight, dims, cache)
+    } else {
+        causal_conv1d_full(x, conv1d_weight, dims, cache)
+    }
+}
+
+/// Single-step Conv1D for autoregressive decode. Concatenates the new token
+/// to the cached conv state, computes one output, then rolls the cache by 1.
+fn causal_conv1d_update(
+    x: &Tensor,
+    conv1d_weight: &Tensor,
+    dims: &GdnDims,
+    cache: &mut GdnLayerCache,
+) -> Result<Tensor> {
+    let (_, seq_len, _) = x.dims3()?;
+    let x_t = x.transpose(1, 2)?.contiguous()?;
+    // `conv_state` is shape `[1, conv_dim, kernel_size]` — the kernel-size
+    // dim is the LAST (matches mistral.rs).
+    let state_len = cache.conv_state.dim(2)?;
+    let hidden_new = Tensor::cat(&[cache.conv_state.clone(), x_t], 2)?;
+    let new_len = hidden_new.dim(2)?;
+    cache.conv_state = hidden_new.narrow(2, new_len - state_len, state_len)?;
+
+    let weight = conv1d_weight.squeeze(1)?.to_dtype(hidden_new.dtype())?;
+    let mut conv_outputs = Vec::with_capacity(seq_len);
+    let total_len = hidden_new.dim(2)?;
+    for i in (total_len - seq_len)..total_len {
+        let window = hidden_new.narrow(2, i + 1 - dims.conv_kernel_size, dims.conv_kernel_size)?;
+        let out = (window * weight.unsqueeze(0)?)?.sum(D::Minus1)?;
+        conv_outputs.push(out);
+    }
+    candle_nn::ops::silu(&Tensor::stack(&conv_outputs, 2)?)?.transpose(1, 2)
+}
+
+/// Multi-step Conv1D used during prefill. Pads on the left by `kernel - 1`,
+/// runs the full convolution, then captures the trailing `kernel - 1` tokens
+/// into the cache for the next decode step.
+fn causal_conv1d_full(
+    x: &Tensor,
+    conv1d_weight: &Tensor,
+    dims: &GdnDims,
+    cache: &mut GdnLayerCache,
+) -> Result<Tensor> {
+    let (batch_size, seq_len, conv_dim) = x.dims3()?;
+    let x_t = x.transpose(1, 2)?.contiguous()?;
+
+    // Pad on the time dim (the last) and capture the trailing `kernel - 1`
+    // tokens into the cache for the next decode step.
+    let pad_width = dims.conv_kernel_size.saturating_sub(seq_len);
+    cache.conv_state = if pad_width > 0 {
+        let zeros = Tensor::zeros((batch_size, conv_dim, pad_width), x_t.dtype(), x_t.device())?;
+        Tensor::cat(&[zeros, x_t.clone()], 2)?
+    } else {
+        x_t.narrow(2, seq_len - dims.conv_kernel_size, dims.conv_kernel_size)?
+    };
+
+    let padded_t = Tensor::cat(
+        &[
+            Tensor::zeros(
+                (batch_size, conv_dim, dims.conv_kernel_size - 1),
+                x_t.dtype(),
+                x_t.device(),
+            )?,
+            x_t,
+        ],
+        2,
+    )?;
+
+    let weight = conv1d_weight.squeeze(1)?.to_dtype(padded_t.dtype())?;
+    let mut conv_outputs = Vec::with_capacity(seq_len);
+    for i in 0..seq_len {
+        let window = padded_t.narrow(2, i, dims.conv_kernel_size)?;
+        let out = (window * weight.unsqueeze(0)?)?.sum(D::Minus1)?;
+        conv_outputs.push(out);
+    }
+    candle_nn::ops::silu(&Tensor::stack(&conv_outputs, 2)?)?.transpose(1, 2)
+}
+// ─────────────────────────────────────────────────────────────────────
+//  Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    /// Smoke test: recurrence runs end-to-end on CPU and produces the right
+    /// output shape. Numerical correctness against HF Transformers is
+    /// exercised by the engine-level smoke tests against a real Qwen 3.5
+    /// checkpoint.
+    #[test]
+    fn recurrence_runs_and_returns_correct_shape() {
+        let dev = Device::Cpu;
+        let q = Tensor::new(
+            &[[
+                [[1.0f32, 0.0]],
+                [[0.0, 1.0]],
+                [[1.0, 1.0]],
+                [[0.5, 0.5]],
+            ]],
+            &dev,
+        )
+        .unwrap();
+        let k = Tensor::new(
+            &[[
+                [[1.0f32, 0.0]],
+                [[0.0, 1.0]],
+                [[1.0, 0.0]],
+                [[0.0, 1.0]],
+            ]],
+            &dev,
+        )
+        .unwrap();
+        let v = Tensor::new(
+            &[[
+                [[1.0f32, 0.0]],
+                [[0.0, 1.0]],
+                [[1.0, 1.0]],
+                [[0.5, 0.5]],
+            ]],
+            &dev,
+        )
+        .unwrap();
+        let g = Tensor::new(&[[[0.0f32], [0.0], [0.0], [0.0]]], &dev).unwrap();
+        let beta = Tensor::new(&[[[1.0f32], [1.0], [1.0], [1.0]]], &dev).unwrap();
+
+        let mut state = Tensor::zeros((1, 1, 2, 2), DType::F32, &dev).unwrap();
+        let y = gated_delta_rule_recurrence(&q, &k, &v, &g, &beta, &mut state).unwrap();
+        assert_eq!(y.dims(), &[1, 4, 1, 2]);
+        // State must have been mutated in place.
+        assert!(state.dims() == [1, 1, 2, 2]);
+    }
+
+    #[test]
+    fn l2_norm_preserves_direction() {
+        let dev = Device::Cpu;
+        let x = Tensor::new(&[[3.0f32, 4.0], [1.0, 0.0]], &dev).unwrap();
+        let n = l2_norm(&x, 1e-6).unwrap();
+        let v0 = n.i((0, ..)).unwrap().to_vec1::<f32>().unwrap();
+        assert!((v0[0] - 0.6).abs() < 1e-3 && (v0[1] - 0.8).abs() < 1e-3);
+        let v1 = n.i((1, ..)).unwrap().to_vec1::<f32>().unwrap();
+        assert!((v1[0] - 1.0).abs() < 1e-3 && v1[1].abs() < 1e-3);
+    }
+
+    #[test]
+    fn softplus_at_zero_is_ln2() {
+        let dev = Device::Cpu;
+        let x = Tensor::new(0.0f32, &dev).unwrap();
+        let s = softplus(&x).unwrap().to_scalar::<f32>().unwrap();
+        assert!((s - std::f32::consts::LN_2).abs() < 1e-4);
+    }
+}

--- a/crane-core/src/gdn/cache.rs
+++ b/crane-core/src/gdn/cache.rs
@@ -1,0 +1,55 @@
+//! Per-layer state for a Gated Delta Net: causal Conv1D ring buffer plus the
+//! recurrent `(K, V)` matrix per head.
+
+use candle_core::{DType, Device, Result, Tensor};
+
+use super::config::GdnDims;
+
+/// State held by one Gated Delta Net layer across decoding steps.
+///
+/// `conv_state` rolls the most recent `conv_kernel_size - 1` QKV channels so
+/// the next decode step can apply the causal Conv1D without reprocessing
+/// history. `recurrent_state` is the per-head `(K, V)` matrix that carries the
+/// linear-attention memory; always f32 regardless of model dtype.
+#[derive(Debug)]
+pub struct GdnLayerCache {
+    pub conv_state: Tensor,
+    pub recurrent_state: Tensor,
+}
+
+impl GdnLayerCache {
+    /// Allocate zero-initialized state for a single sequence.
+    pub fn new(cfg: &dyn super::config::GdnConfig, dtype: DType, device: &Device) -> Result<Self> {
+        let dims = GdnDims::new(cfg);
+        // 3D shape `[1, conv_dim, kernel_size]` — the leading dim lets the
+        // cache broadcast cleanly against per-batch QKV tensors in
+        // `causal_conv1d_full` / `_update`.
+        let conv_state = Tensor::zeros((1, dims.conv_dim, dims.conv_kernel_size), dtype, device)?;
+        let recurrent_state = Tensor::zeros(
+            (1, dims.num_v_heads, dims.head_k_dim, dims.head_v_dim),
+            DType::F32,
+            device,
+        )?;
+        Ok(Self {
+            conv_state,
+            recurrent_state,
+        })
+    }
+
+    /// Zero out the state for reuse (e.g. between unrelated requests sharing a
+    /// pre-allocated layer). Avoids re-allocating the underlying tensors.
+    pub fn reset(&mut self) -> Result<()> {
+        self.conv_state = self.conv_state.zeros_like()?;
+        self.recurrent_state = self.recurrent_state.zeros_like()?;
+        Ok(())
+    }
+}
+
+impl Clone for GdnLayerCache {
+    fn clone(&self) -> Self {
+        Self {
+            conv_state: self.conv_state.clone(),
+            recurrent_state: self.recurrent_state.clone(),
+        }
+    }
+}

--- a/crane-core/src/gdn/config.rs
+++ b/crane-core/src/gdn/config.rs
@@ -1,0 +1,112 @@
+//! Dimension calculations and config trait for Gated Delta Net layers.
+
+use serde::Deserialize;
+
+/// Per-head dimensions derived from a GDN config.
+///
+/// `key_dim = num_k_heads * head_k_dim`, `value_dim = num_v_heads * head_v_dim`,
+/// `conv_dim = 2 * key_dim + value_dim` (Q/K/V concatenated for the causal conv1d).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GdnDims {
+    pub hidden_size: usize,
+    pub num_k_heads: usize,
+    pub num_v_heads: usize,
+    pub head_k_dim: usize,
+    pub head_v_dim: usize,
+    pub conv_kernel_size: usize,
+    pub key_dim: usize,
+    pub value_dim: usize,
+    pub conv_dim: usize,
+    /// Number of value heads per key head (GQA ratio).
+    pub v_per_group: usize,
+}
+
+impl GdnDims {
+    pub fn new(cfg: &dyn GdnConfig) -> Self {
+        let hidden_size = cfg.hidden_size();
+        let num_k_heads = cfg.linear_num_key_heads();
+        let num_v_heads = cfg.linear_num_value_heads();
+        let head_k_dim = cfg.linear_key_head_dim();
+        let head_v_dim = cfg.linear_value_head_dim();
+        let conv_kernel_size = cfg.linear_conv_kernel_dim();
+        let key_dim = num_k_heads * head_k_dim;
+        let value_dim = num_v_heads * head_v_dim;
+        let conv_dim = key_dim * 2 + value_dim;
+        let v_per_group = num_v_heads / num_k_heads;
+
+        Self {
+            hidden_size,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+            conv_kernel_size,
+            key_dim,
+            value_dim,
+            conv_dim,
+            v_per_group,
+        }
+    }
+
+    /// Output dimension of the QKV/Z fused projection (Q + K + V + Z concatenated).
+    pub fn qkvz_out_dim(&self) -> usize {
+        self.key_dim * 2 + self.value_dim * 2
+    }
+
+    /// Output dimension of the B/A fused projection (B + A concatenated).
+    pub fn ba_out_dim(&self) -> usize {
+        self.num_v_heads * 2
+    }
+}
+
+/// Trait implemented by model configs that contain linear-attention parameters.
+///
+/// Default impls compute derived dims (`linear_key_dim`, `linear_value_dim`,
+/// `linear_conv_dim`) from the per-head fields.
+pub trait GdnConfig {
+    fn hidden_size(&self) -> usize;
+    fn rms_norm_eps(&self) -> f64;
+    fn linear_conv_kernel_dim(&self) -> usize;
+    fn linear_key_head_dim(&self) -> usize;
+    fn linear_value_head_dim(&self) -> usize;
+    fn linear_num_key_heads(&self) -> usize;
+    fn linear_num_value_heads(&self) -> usize;
+
+    fn linear_key_dim(&self) -> usize {
+        self.linear_num_key_heads() * self.linear_key_head_dim()
+    }
+
+    fn linear_value_dim(&self) -> usize {
+        self.linear_num_value_heads() * self.linear_value_head_dim()
+    }
+
+    fn linear_conv_dim(&self) -> usize {
+        self.linear_key_dim() * 2 + self.linear_value_dim()
+    }
+}
+
+/// Default values for HF `config.json` fields that are sometimes missing.
+#[allow(dead_code)]
+pub mod defaults {
+    pub fn conv_kernel() -> usize {
+        4
+    }
+
+    pub fn partial_rotary_factor() -> f64 {
+        0.25
+    }
+
+    pub fn rope_theta() -> f64 {
+        10_000_000.0
+    }
+
+    pub fn full_attention_interval() -> usize {
+        4
+    }
+}
+
+/// Marker type used by model configs that deserialize nested blocks with
+/// default values (e.g. an empty `rope_parameters` wrapper).
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Empty {}

--- a/crane-core/src/gdn/cuda_backend.rs
+++ b/crane-core/src/gdn/cuda_backend.rs
@@ -1,0 +1,119 @@
+//! CUDA launcher for the fused Gated Delta Net recurrence kernel.
+//!
+//! Collapses the per-timestep Candle op graph into a single kernel launch
+//! (`kernels/gdn.cu`). Inputs must be contiguous f32 CUDA tensors in the
+//! layouts documented on [`gdn_recurrence_cuda`]; `q` is expected pre-scaled
+//! by `1/sqrt(K)` (the caller does this, matching the CPU reference).
+
+use candle_core::cuda_backend::cudarc::driver::{LaunchConfig, PushKernelArg};
+use candle_core::cuda_backend::WrapErr;
+use candle_core::op::BackpropOp;
+use candle_core::{CudaStorage, Result, Storage, Tensor};
+
+// PTX compiled from kernels/gdn.cu — embedded at build time.
+mod ptx {
+    include!(concat!(env!("OUT_DIR"), "/crane_kernels_ptx.rs"));
+}
+
+const MODULE_NAME: &str = "crane_gdn";
+
+/// Run the gated delta rule recurrence on CUDA.
+///
+/// Shapes: `q,k = [BH,S,K]`, `v = [BH,S,V]`, `g,beta = [BH,S]`,
+/// `state = [BH,K,V]`. Returns `(y = [BH,S,V], state_out = [BH,K,V])`.
+pub fn gdn_recurrence_cuda(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    state: &Tensor,
+) -> Result<(Tensor, Tensor)> {
+    let (bh, s, kdim) = q.dims3()?;
+    let vdim = v.dim(2)?;
+    if kdim > 256 {
+        candle_core::bail!("gdn cuda kernel supports head_k_dim <= 256, got {kdim}");
+    }
+    let dev = q.device().as_cuda_device()?.clone();
+
+    // Hold the storage guards alive until after the launch; the slice views
+    // borrow from them.
+    let (q_s, q_l) = q.storage_and_layout();
+    let q_sl = match &*q_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: q must be a cuda tensor"),
+    };
+    let (k_s, k_l) = k.storage_and_layout();
+    let k_sl = match &*k_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: k must be a cuda tensor"),
+    };
+    let (v_s, v_l) = v.storage_and_layout();
+    let v_sl = match &*v_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: v must be a cuda tensor"),
+    };
+    let (g_s, g_l) = g.storage_and_layout();
+    let g_sl = match &*g_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: g must be a cuda tensor"),
+    };
+    let (beta_s, beta_l) = beta.storage_and_layout();
+    let beta_sl = match &*beta_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: beta must be a cuda tensor"),
+    };
+    let (state_s, state_l) = state.storage_and_layout();
+    let state_sl = match &*state_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: state must be a cuda tensor"),
+    };
+
+    // Offsets (tensors are passed contiguous; honor any start offset anyway).
+    let q_v = q_sl.slice(q_l.start_offset()..);
+    let k_v = k_sl.slice(k_l.start_offset()..);
+    let v_v = v_sl.slice(v_l.start_offset()..);
+    let g_v = g_sl.slice(g_l.start_offset()..);
+    let beta_v = beta_sl.slice(beta_l.start_offset()..);
+    let state_v = state_sl.slice(state_l.start_offset()..);
+
+    let y_buf = unsafe { dev.alloc::<f32>(bh * s * vdim) }?;
+    let state_out_buf = unsafe { dev.alloc::<f32>(bh * kdim * vdim) }?;
+
+    let func = dev.get_or_load_custom_func("gdn_recurrence_f32", MODULE_NAME, ptx::GDN)?;
+    let cfg = LaunchConfig {
+        grid_dim: (bh as u32, 1, 1),
+        block_dim: (vdim as u32, 1, 1),
+        shared_mem_bytes: (2 * kdim * std::mem::size_of::<f32>()) as u32,
+    };
+
+    let (bh_i, s_i, k_i, v_i) = (bh as i32, s as i32, kdim as i32, vdim as i32);
+    let mut builder = func.builder();
+    builder.arg(&q_v);
+    builder.arg(&k_v);
+    builder.arg(&v_v);
+    builder.arg(&g_v);
+    builder.arg(&beta_v);
+    builder.arg(&state_v);
+    builder.arg(&state_out_buf);
+    builder.arg(&y_buf);
+    builder.arg(&bh_i);
+    builder.arg(&s_i);
+    builder.arg(&k_i);
+    builder.arg(&v_i);
+    unsafe { builder.launch(cfg) }.w()?;
+
+    let y = Tensor::from_storage(
+        Storage::Cuda(CudaStorage::wrap_cuda_slice(y_buf, dev.clone())),
+        (bh, s, vdim),
+        BackpropOp::none(),
+        false,
+    );
+    let state_out = Tensor::from_storage(
+        Storage::Cuda(CudaStorage::wrap_cuda_slice(state_out_buf, dev.clone())),
+        (bh, kdim, vdim),
+        BackpropOp::none(),
+        false,
+    );
+    Ok((y, state_out))
+}

--- a/crane-core/src/gdn/layer.rs
+++ b/crane-core/src/gdn/layer.rs
@@ -1,0 +1,173 @@
+//! Top-level `GatedDeltaNet` layer: orchestrates input projection, causal
+//! Conv1D, gated delta rule recurrence, gated RMSNorm, and output projection.
+
+use candle_core::{Module, Result, Tensor};
+use candle_nn::{linear_no_bias, Linear, VarBuilder};
+
+use super::backend::{apply_recurrence, causal_conv1d, compute_beta_g, l2_norm};
+use super::cache::GdnLayerCache;
+use super::config::{GdnConfig, GdnDims};
+use super::norm::RmsNormGated;
+use super::projection::{GdnInputProjection, GdnInputProjectionKind};
+
+/// One linear-attention layer as used by Qwen 3.5 (and similar hybrid models).
+///
+/// Field names follow the HF safetensors layout (`linear_attn.in_proj_qkv.weight`,
+/// `linear_attn.conv1d.weight`, `linear_attn.A_log`, …).
+pub struct GatedDeltaNet {
+    pub input_proj: GdnInputProjection,
+    pub conv1d_weight: Tensor,
+    pub dt_bias: Tensor,
+    pub a_log: Tensor,
+    pub norm: RmsNormGated,
+    pub out_proj: Linear,
+}
+
+impl GatedDeltaNet {
+/// Load weights from `vb.pp("linear_attn")`.
+///
+/// `cfg` supplies the dimensions; `projection_kind` selects the QKV/Z/B/A
+/// weight layout (Qwen 3.5 uses [`GdnInputProjectionKind::Split`]).
+pub fn load(
+        vb: VarBuilder,
+        cfg: &dyn GdnConfig,
+        projection_kind: GdnInputProjectionKind,
+) -> Result<Self> {
+        let dims = GdnDims::new(cfg);
+        let vb_la = vb.pp("linear_attn");
+
+        let input_proj = GdnInputProjection::load(vb_la.clone(), &dims, projection_kind)?;
+        let conv1d_weight = vb_la.get(
+            (dims.conv_dim, 1, dims.conv_kernel_size),
+            "conv1d.weight",
+        )?;
+        let dt_bias = vb_la.get(dims.num_v_heads, "dt_bias")?;
+        let a_log = vb_la.get(dims.num_v_heads, "A_log")?;
+
+        let norm = RmsNormGated::new(dims.head_v_dim, cfg.rms_norm_eps(), vb_la.pp("norm"))?;
+        let out_proj = linear_no_bias(dims.value_dim, dims.hidden_size, vb_la.pp("out_proj"))?;
+
+        Ok(Self {
+            input_proj,
+            conv1d_weight,
+            dt_bias,
+            a_log,
+            norm,
+            out_proj,
+        })
+    }
+
+    /// Forward pass over a sequence (prefill or single decode step).
+    ///
+    /// `x: [B, S, hidden_size]`. `cache` is updated in place. Returns
+    /// `[B, S, hidden_size]`.
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        dims: &GdnDims,
+        cache: &mut GdnLayerCache,
+        is_decode_step: bool,
+    ) -> Result<Tensor> {
+        let (batch_size, seq_len, _) = x.dims3()?;
+        let dtype = x.dtype();
+
+        // 1. Input projections → Q, K, V, Z, B, A.
+        let projected = self.input_proj.forward(x, dims, batch_size, seq_len)?;
+
+        // 2. Causal Conv1D over [Q|K|V].
+        let mixed_qkv = projected.conv_input(dims, batch_size, seq_len)?;
+        let mixed_qkv = causal_conv1d(
+            &mixed_qkv,
+            &self.conv1d_weight,
+            dims,
+            cache,
+            is_decode_step,
+        )?;
+
+        // 3. Split → per-head Q, K, V; expand K from num_k_heads → num_v_heads.
+        let (q, k, v) = split_qkv(&mixed_qkv, dims, batch_size, seq_len)?;
+        let (q, k) = repeat_kv_heads(&q, &k, dims)?;
+
+        // 4. L2-normalize Q and K (Qwen 3.5 uses QK-norm = L2).
+        let q = l2_norm(&q, 1e-6)?;
+        let k = l2_norm(&k, 1e-6)?;
+
+        // 5. Compute β (write strength) and g (decay) from B, A, A_log, dt_bias.
+        let (beta, g) =
+            compute_beta_g(&projected.b, &projected.a, &self.a_log, &self.dt_bias, dtype)?;
+
+        // 6. Run the gated delta rule recurrence.
+        let y = apply_recurrence(
+            &q, &k, &v, &g, &beta, dims, batch_size, seq_len, cache, dtype,
+        )?;
+
+        // 7. Gated RMSNorm + output projection.
+        self.finish_forward(y, projected.z, batch_size, seq_len)
+    }
+
+    fn finish_forward(
+        &self,
+        y: Tensor,
+        z: Tensor,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<Tensor> {
+        // y comes out of the recurrence as `[B, S, num_v_heads, head_v_dim]`.
+        // Flatten the head + head_v dims, gated-RMSNorm along head_v, then
+        // reshape back to `[B, S, value_dim]`.
+        let head_v_dim = self.norm_head_dim();
+        let value_dim = y.dim(2)? * head_v_dim;
+        let y_2d = y.reshape(((), head_v_dim))?;
+        let z_2d = z.reshape(((), head_v_dim))?;
+        let y_2d = self.norm.forward(&y_2d, &z_2d)?;
+        let y = y_2d.reshape((batch_size, seq_len, value_dim))?;
+        self.out_proj.forward(&y)
+    }
+
+    fn norm_head_dim(&self) -> usize {
+        // out_proj.weight shape is [value_dim, hidden_size]; head_v_dim is
+        // stored indirectly as value_dim / num_v_heads. We recover it from
+        // the norm's RmsNorm weight length.
+        self.norm.weight_len()
+    }
+}
+
+/// Split the conv1d output `[B, S, conv_dim]` into Q, K, V along the last
+/// dim, then reshape each into `[B, S, num_heads, head_dim]`.
+fn split_qkv(
+    mixed_qkv: &Tensor,
+    dims: &GdnDims,
+    batch_size: usize,
+    seq_len: usize,
+) -> Result<(Tensor, Tensor, Tensor)> {
+    use candle_core::D;
+    let q = mixed_qkv.narrow(D::Minus1, 0, dims.key_dim)?;
+    let k = mixed_qkv.narrow(D::Minus1, dims.key_dim, dims.key_dim)?;
+    let v = mixed_qkv.narrow(D::Minus1, dims.key_dim * 2, dims.value_dim)?;
+    let q = q.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?;
+    let k = k.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?;
+    let v = v.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?;
+    Ok((q, k, v))
+}
+
+/// Expand K (and Q, for symmetry) from `num_k_heads` to `num_v_heads` by
+/// repeating each key head `v_per_group` times (GQA-style expansion for
+/// linear attention).
+///
+/// When `num_k_heads == num_v_heads` (`v_per_group == 1`) this is a no-op.
+fn repeat_kv_heads(q: &Tensor, k: &Tensor, dims: &GdnDims) -> Result<(Tensor, Tensor)> {
+    if dims.v_per_group == 1 {
+        return Ok((q.clone(), k.clone()));
+    }
+    let q = q
+        .unsqueeze(3)?
+        .repeat((1, 1, 1, dims.v_per_group, 1))?
+        .contiguous()?
+        .reshape((q.dim(0)?, q.dim(1)?, dims.num_v_heads, dims.head_k_dim))?;
+    let k = k
+        .unsqueeze(3)?
+        .repeat((1, 1, 1, dims.v_per_group, 1))?
+        .contiguous()?
+        .reshape((k.dim(0)?, k.dim(1)?, dims.num_v_heads, dims.head_k_dim))?;
+    Ok((q, k))
+}

--- a/crane-core/src/gdn/mod.rs
+++ b/crane-core/src/gdn/mod.rs
@@ -1,0 +1,54 @@
+//! Gated Delta Net (GDN) implementation for hybrid attention models.
+//!
+//! Used by Qwen 3.5 (and other hybrid Mamba/Transformer architectures) for the
+//! `linear_attention` layers that interleave with standard `full_attention`
+//! layers.
+//!
+//! # Algorithm
+//!
+//! Given per-timestep Q, K, V, g (decay), β (write strength), and a learned
+//! negative-exponent A_log used to derive per-head decay, the recurrence is:
+//!
+//! ```text
+//! S = S * exp(g)                  // decay state by head-dependent factor
+//! kv_mem = sum(S * k, d_state)    // retrieve current memory at this k
+//! delta = (v - kv_mem) * beta     // delta-rule residual
+//! S = S + outer(k, delta)         // write update
+//! y = sum(S * q, d_state)         // output via q-projection of state
+//! ```
+//!
+//! State shape: `[batch, num_v_heads, head_k_dim, head_v_dim]`, kept in f32
+//! regardless of model dtype (`mamba_ssm_dtype: float32` in the HF config).
+//!
+//! The QKV input also passes through a causal Conv1D with kernel width 4
+//! (`linear_conv_kernel_dim`) before the recurrence; the conv state is
+//! maintained alongside the recurrent state for decode-step inference.
+//!
+//! # Origin
+//!
+//! Algorithm inspired by [mistral.rs](https://github.com/EricLBuehler/mistral.rs)
+//! (MIT licensed); Crane's implementation uses plain `candle_nn::Linear`
+//! without that project's tensor-parallel / quantization abstractions.
+//!
+//! See also the [Gated Delta Net paper](https://arxiv.org/abs/2412.06464)
+//! (Yang et al., 2024) for the original formulation.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+mod backend;
+mod cache;
+mod config;
+#[cfg(feature = "cuda")]
+mod cuda_backend;
+mod layer;
+mod norm;
+mod projection;
+
+pub use backend::{
+    causal_conv1d, gated_delta_rule_recurrence, l2_norm, softplus, apply_recurrence,
+};
+pub use cache::GdnLayerCache;
+pub use config::{defaults, GdnConfig, GdnDims};
+pub use layer::GatedDeltaNet;
+pub use norm::RmsNormGated;
+pub use projection::{GdnInputProjection, GdnInputProjectionKind, GdnProjection};

--- a/crane-core/src/gdn/norm.rs
+++ b/crane-core/src/gdn/norm.rs
@@ -1,0 +1,48 @@
+//! RMSNorm with a SiLU-gated output: `y = (x / rms(x)) * weight * silu(gate)`.
+//!
+//! This is the output-side normalization used by every Gated Delta Net layer in
+//! Qwen 3.5 — the `z` projection (silu-gate) modulates the normalized
+//! recurrence output before it goes through `out_proj`.
+//!
+//! The normalization is computed manually in f32 (rather than via candle's
+//! fused `RmsNorm` op) so it is robust across devices and dtypes: the fused
+//! CUDA op requires `x` and `weight` to share a dtype, but the gated norm runs
+//! in f32 while the model weights may be f16/bf16 on GPU.
+
+use candle_core::{DType, Result, Tensor, D};
+use candle_nn::VarBuilder;
+
+/// `RmsNorm(x) * silu(z)` with a learned per-channel weight (plain `weight`,
+/// no unit offset — matches HF's `Qwen3_5RMSNormGated`).
+pub struct RmsNormGated {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl RmsNormGated {
+    pub fn new(size: usize, eps: f64, vb: VarBuilder) -> Result<Self> {
+        let weight = vb.get(size, "weight")?;
+        Ok(Self { weight, eps })
+    }
+
+    /// Forward pass. `x` and `gate` must share shape `[..., size]`.
+    pub fn forward(&self, x: &Tensor, gate: &Tensor) -> Result<Tensor> {
+        let dtype = x.dtype();
+        let x = x.to_dtype(DType::F32)?;
+        let gate = gate.to_dtype(DType::F32)?;
+        let weight = self.weight.to_dtype(DType::F32)?;
+        // Norm before gate (HF order): normalize, scale by weight, then * silu(gate).
+        let var = x.sqr()?.mean_keepdim(D::Minus1)?;
+        let x_normed = x.broadcast_div(&(var + self.eps)?.sqrt()?)?;
+        let normalized = x_normed.broadcast_mul(&weight)?;
+        let silu_gate = candle_nn::ops::silu(&gate)?;
+        normalized.broadcast_mul(&silu_gate)?.to_dtype(dtype)
+    }
+
+    /// Length of the learned per-channel weight vector. Exposed so that
+    /// callers (e.g. `GatedDeltaNet`) can recover the per-head value dim
+    /// without a separate config field.
+    pub fn weight_len(&self) -> usize {
+        self.weight.dim(0).unwrap_or(0)
+    }
+}

--- a/crane-core/src/gdn/projection.rs
+++ b/crane-core/src/gdn/projection.rs
@@ -1,0 +1,203 @@
+//! Input projections for a Gated Delta Net layer.
+//!
+//! Two linear projections from hidden_size:
+//! 1. `in_proj_qkv` projects to `[Q | K | V]` (concatenated, length `conv_dim`).
+//! 2. `in_proj_z` projects to the gate `Z` (length `value_dim`).
+//! 3. `in_proj_b` projects to the per-head write strength `β` (length
+//!    `num_v_heads`).
+//! 4. `in_proj_a` projects to the per-head A-log (length `num_v_heads`).
+//!
+//! Qwen 3.5 ships the weights as four separate matrices (`Split`); other hybrid
+//! architectures may fuse Q/K/V/Z into one matrix and B/A into another
+//! (`Grouped`). Both layouts are supported; the dispatch is in
+//! [`GdnInputProjection::forward`].
+
+use candle_core::{Module, Result, Tensor, D};
+use candle_nn::{linear_no_bias, Linear, VarBuilder};
+
+/// Whether the source checkpoint stores projections as 4 separate matrices
+/// (`Split`, used by Qwen 3.5) or 2 fused matrices (`Grouped`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GdnInputProjectionKind {
+    /// `in_proj_qkvz` and `in_proj_ba` — two fused matrices.
+    Grouped,
+    /// `in_proj_qkv`, `in_proj_z`, `in_proj_b`, `in_proj_a` — four matrices.
+    Split,
+}
+
+/// Holds the four (or two, in `Grouped` mode) linear projections.
+pub enum GdnInputProjection {
+    Grouped {
+        in_proj_qkvz: Linear,
+        in_proj_ba: Linear,
+    },
+    Split {
+        in_proj_qkv: Linear,
+        in_proj_z: Linear,
+        in_proj_b: Linear,
+        in_proj_a: Linear,
+    },
+}
+
+impl GdnInputProjection {
+    pub fn load(
+        vb: VarBuilder,
+        dims: &super::config::GdnDims,
+        kind: GdnInputProjectionKind,
+    ) -> Result<Self> {
+        match kind {
+            GdnInputProjectionKind::Grouped => {
+                let in_proj_qkvz = linear_no_bias(
+                    dims.hidden_size,
+                    dims.qkvz_out_dim(),
+                    vb.pp("in_proj_qkvz"),
+                )?;
+                let in_proj_ba = linear_no_bias(
+                    dims.hidden_size,
+                    dims.ba_out_dim(),
+                    vb.pp("in_proj_ba"),
+                )?;
+                Ok(Self::Grouped {
+                    in_proj_qkvz,
+                    in_proj_ba,
+                })
+            }
+            GdnInputProjectionKind::Split => {
+                let in_proj_qkv = linear_no_bias(dims.hidden_size, dims.conv_dim, vb.pp("in_proj_qkv"))?;
+                let in_proj_z = linear_no_bias(dims.hidden_size, dims.value_dim, vb.pp("in_proj_z"))?;
+                let in_proj_b = linear_no_bias(dims.hidden_size, dims.num_v_heads, vb.pp("in_proj_b"))?;
+                let in_proj_a = linear_no_bias(dims.hidden_size, dims.num_v_heads, vb.pp("in_proj_a"))?;
+                Ok(Self::Split {
+                    in_proj_qkv,
+                    in_proj_z,
+                    in_proj_b,
+                    in_proj_a,
+                })
+            }
+        }
+    }
+
+    /// Project `x: [B, S, H]` through all four projections and slice into the
+    /// per-tensor Q, K, V, Z, B, A views needed by the recurrence.
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        dims: &super::config::GdnDims,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<GdnProjection> {
+        match self {
+            Self::Grouped {
+                in_proj_qkvz,
+                in_proj_ba,
+            } => GdnProjection::from_grouped(
+                in_proj_qkvz.forward(x)?,
+                in_proj_ba.forward(x)?,
+                dims,
+                batch_size,
+                seq_len,
+            ),
+            Self::Split {
+                in_proj_qkv,
+                in_proj_z,
+                in_proj_b,
+                in_proj_a,
+            } => GdnProjection::from_split(
+                in_proj_qkv.forward(x)?,
+                in_proj_z.forward(x)?,
+                in_proj_b.forward(x)?,
+                in_proj_a.forward(x)?,
+                dims,
+                batch_size,
+                seq_len,
+            ),
+        }
+    }
+}
+
+/// Sliced views produced by [`GdnInputProjection::forward`].
+///
+/// Shapes:
+/// - `q, k`: `[B, S, num_k_heads, head_k_dim]`
+/// - `v, z`: `[B, S, num_v_heads, head_v_dim]`
+/// - `b, a`: `[B, S, num_v_heads]`
+pub struct GdnProjection {
+    pub q: Tensor,
+    pub k: Tensor,
+    pub v: Tensor,
+    pub z: Tensor,
+    pub b: Tensor,
+    pub a: Tensor,
+}
+
+impl GdnProjection {
+    fn from_grouped(
+        mixed_qkvz: Tensor,
+        mixed_ba: Tensor,
+        dims: &super::config::GdnDims,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<Self> {
+        let group_size_qkvz = 2 * dims.head_k_dim + 2 * dims.v_per_group * dims.head_v_dim;
+        let mixed_qkvz = mixed_qkvz.reshape((batch_size, seq_len, dims.num_k_heads, group_size_qkvz))?;
+        let mixed_ba = mixed_ba.reshape((batch_size, seq_len, dims.num_k_heads, 2 * dims.v_per_group))?;
+
+        let mut offset = 0;
+        let q = mixed_qkvz.narrow(D::Minus1, offset, dims.head_k_dim)?;
+        offset += dims.head_k_dim;
+        let k = mixed_qkvz.narrow(D::Minus1, offset, dims.head_k_dim)?;
+        offset += dims.head_k_dim;
+        let v = mixed_qkvz.narrow(D::Minus1, offset, dims.v_per_group * dims.head_v_dim)?;
+        offset += dims.v_per_group * dims.head_v_dim;
+        let z = mixed_qkvz.narrow(D::Minus1, offset, dims.v_per_group * dims.head_v_dim)?;
+
+        let b = mixed_ba.narrow(D::Minus1, 0, dims.v_per_group)?;
+        let a = mixed_ba.narrow(D::Minus1, dims.v_per_group, dims.v_per_group)?;
+
+        Ok(Self {
+            q,
+            k,
+            v: v.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
+            z: z.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
+            b: b.reshape((batch_size, seq_len, dims.num_v_heads))?,
+            a: a.reshape((batch_size, seq_len, dims.num_v_heads))?,
+        })
+    }
+
+    fn from_split(
+        mixed_qkv: Tensor,
+        mixed_z: Tensor,
+        mixed_b: Tensor,
+        mixed_a: Tensor,
+        dims: &super::config::GdnDims,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<Self> {
+        let q = mixed_qkv.narrow(D::Minus1, 0, dims.key_dim)?;
+        let k = mixed_qkv.narrow(D::Minus1, dims.key_dim, dims.key_dim)?;
+        let v = mixed_qkv.narrow(D::Minus1, dims.key_dim * 2, dims.value_dim)?;
+
+        Ok(Self {
+            q: q.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?,
+            k: k.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?,
+            v: v.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
+            z: mixed_z.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
+            b: mixed_b.reshape((batch_size, seq_len, dims.num_v_heads))?,
+            a: mixed_a.reshape((batch_size, seq_len, dims.num_v_heads))?,
+        })
+    }
+
+    /// Reassemble the Q|K|V channels into a single `[B, S, conv_dim]` tensor —
+    /// the input the causal Conv1D expects.
+    pub fn conv_input(
+        &self,
+        dims: &super::config::GdnDims,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<Tensor> {
+        let q = self.q.reshape((batch_size, seq_len, dims.key_dim))?;
+        let k = self.k.reshape((batch_size, seq_len, dims.key_dim))?;
+        let v = self.v.reshape((batch_size, seq_len, dims.value_dim))?;
+        Tensor::cat(&[&q, &k, &v], D::Minus1)
+    }
+}

--- a/crane-core/src/lib.rs
+++ b/crane-core/src/lib.rs
@@ -8,7 +8,8 @@
 //!
 //! | Module | Purpose |
 //! |---|---|
-//! | [`fused_ops`] | Custom CUDA kernels (silu-mul, argmax, top-k, HtoD/DtoD copies) |
+//! | [`fused_ops`] | Custom CUDA kernels (silu-mul, argmax, top-k, HtoD/DtoH copies) |
+//! | [`gdn`] | Gated Delta Net — linear attention layer for hybrid models (Qwen 3.5) |
 //! | [`models`] | Transformer model implementations (Qwen3, HunyuanDense, Qwen2.5, multimodal) |
 //! | [`generation`] | Token generation utilities (sampling, stopping criteria, logit processors) |
 //! | [`autotokenizer`] | HuggingFace-compatible tokenizer loader |
@@ -25,6 +26,7 @@
 //! | `mkl` | Link against Intel MKL for CPU BLAS |
 
 pub mod fused_ops;
+pub mod gdn;
 pub mod generation;
 pub mod models;
 pub mod utils;

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -40,7 +40,7 @@ struct EventTrackingGuard;
 #[cfg(feature = "cuda")]
 impl EventTrackingGuard {
     fn disable(device: &candle_core::Device) -> Self {
-        if let candle_core::Device::Cuda(ref dev) = device {
+        if let candle_core::Device::Cuda(dev) = device {
             if dev.is_event_tracking() {
                 unsafe { dev.disable_event_tracking() };
             }

--- a/crane-core/src/models/hunyuan_dense/modeling.rs
+++ b/crane-core/src/models/hunyuan_dense/modeling.rs
@@ -171,7 +171,7 @@ struct EventTrackingGuard;
 #[cfg(feature = "cuda")]
 impl EventTrackingGuard {
     fn disable(device: &candle_core::Device) -> Self {
-        if let candle_core::Device::Cuda(ref dev) = device {
+        if let candle_core::Device::Cuda(dev) = device {
             if dev.is_event_tracking() {
                 unsafe { dev.disable_event_tracking() };
             }

--- a/crane-core/src/models/mod.rs
+++ b/crane-core/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod paddleocr_vl;
 pub mod qwen25;
 pub mod qwen25_vit;
 pub mod qwen3;
+pub mod qwen3_5;
 pub mod qwen3_tts;
 // pub mod qwen3_vl;
 pub mod gemma4;

--- a/crane-core/src/models/qwen3/modeling.rs
+++ b/crane-core/src/models/qwen3/modeling.rs
@@ -48,7 +48,7 @@ struct EventTrackingGuard;
 #[cfg(feature = "cuda")]
 impl EventTrackingGuard {
     fn disable(device: &candle_core::Device) -> Self {
-        if let candle_core::Device::Cuda(ref dev) = device {
+        if let candle_core::Device::Cuda(dev) = device {
             if dev.is_event_tracking() {
                 // Safety: we ensure sequential use of a single CUDA stream.
                 unsafe { dev.disable_event_tracking() };

--- a/crane-core/src/models/qwen3_5/config.rs
+++ b/crane-core/src/models/qwen3_5/config.rs
@@ -1,0 +1,195 @@
+//! HF-compatible config types for Qwen 3.5 text-only inference.
+//!
+//! Qwen 3.5 ships as `Qwen3_5ForConditionalGeneration` (multimodal class) but
+//! the dense text-only checkpoints have no vision weights — we deserialize the
+//! nested `text_config` and ignore the vision block when loading weights.
+
+use candle_core::Result;
+use serde::Deserialize;
+
+use crate::gdn::{defaults, GdnConfig};
+
+/// Whether a transformer block at layer index `i` is full (softmax) attention
+/// or linear (Gated Delta Net) attention.
+///
+/// Layer indices run 0..num_hidden_layers. With `full_attention_interval = 4`
+/// the layout is `[linear, linear, linear, full, linear, linear, linear, full, …]`,
+/// so `full_attention_interval - 1` linear layers precede every full layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerType {
+    FullAttention,
+    LinearAttention,
+}
+
+/// `RopeParameters` block nested under `text_config.rope_parameters` in HF
+/// `config.json`. `mrope_interleaved: true` is the Qwen 3.5 variant (vs the
+/// non-interleaved MRoPE used by Qwen 3 VL).
+#[derive(Debug, Clone, Deserialize)]
+pub struct RopeParameters {
+    #[serde(default = "defaults::rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default)]
+    pub mrope_section: Vec<usize>,
+    #[serde(default = "defaults::partial_rotary_factor")]
+    pub partial_rotary_factor: f64,
+    /// Default false (i.e. standard MRoPE). Qwen 3.5 sets this to `true`.
+    #[serde(default)]
+    pub mrope_interleaved: bool,
+}
+
+/// Text-only model config. Mirrors HF's `text_config` block under
+/// `Qwen3_5ForConditionalGeneration`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TextConfig {
+    pub head_dim: usize,
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub hidden_act: HiddenAct,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f64,
+    pub rope_parameters: RopeParameters,
+
+    // Hybrid-attention parameters.
+    #[serde(default = "defaults::full_attention_interval")]
+    pub full_attention_interval: usize,
+    #[serde(default = "defaults::conv_kernel")]
+    pub linear_conv_kernel_dim: usize,
+    pub linear_key_head_dim: usize,
+    pub linear_value_head_dim: usize,
+    pub linear_num_key_heads: usize,
+    pub linear_num_value_heads: usize,
+
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+
+    // Qwen 3.5 attention uses gated output (sigmoid gate on softmax attention).
+    #[serde(default = "default_true")]
+    pub attn_output_gate: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Top-level config. `text_config` holds the language model; `vision_config`
+/// exists for the multimodal class but is ignored by the text-only path.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    pub text_config: TextConfig,
+    #[serde(default)]
+    pub vision_config: Option<serde_json::Value>,
+    #[serde(default)]
+    pub image_token_id: Option<u32>,
+    #[serde(default)]
+    pub video_token_id: Option<u32>,
+    #[serde(default)]
+    pub vision_start_token_id: Option<u32>,
+    #[serde(default)]
+    pub vision_end_token_id: Option<u32>,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+}
+
+impl Config {
+    pub fn text(&self) -> &TextConfig {
+        &self.text_config
+    }
+}
+
+/// Hidden activation. Qwen 3.5 uses `silu` for the MLP.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum HiddenAct {
+    Silu,
+    #[serde(other)]
+    Other,
+}
+
+impl TextConfig {
+    pub fn rope_theta(&self) -> f64 {
+        self.rope_parameters.rope_theta
+    }
+
+    pub fn partial_rotary_factor(&self) -> f64 {
+        self.rope_parameters.partial_rotary_factor
+    }
+
+    pub fn mrope_section(&self) -> &[usize] {
+        &self.rope_parameters.mrope_section
+    }
+
+    pub fn mrope_interleaved(&self) -> bool {
+        self.rope_parameters.mrope_interleaved
+    }
+
+    /// `head_dim * partial_rotary_factor` — the slice of the head dim that
+    /// actually receives rotary embeddings.
+    pub fn rot_dim(&self) -> usize {
+        (self.head_dim as f64 * self.partial_rotary_factor()) as usize
+    }
+
+    /// Layer-type sequence, indexed by transformer-block position.
+    pub fn layer_types(&self) -> Vec<LayerType> {
+        (0..self.num_hidden_layers)
+            .map(|i| {
+                if (i + 1) % self.full_attention_interval == 0 {
+                    LayerType::FullAttention
+                } else {
+                    LayerType::LinearAttention
+                }
+            })
+            .collect()
+    }
+
+    pub fn linear_key_dim(&self) -> usize {
+        self.linear_num_key_heads * self.linear_key_head_dim
+    }
+
+    pub fn linear_value_dim(&self) -> usize {
+        self.linear_num_value_heads * self.linear_value_head_dim
+    }
+
+    pub fn linear_conv_dim(&self) -> usize {
+        2 * self.linear_key_dim() + self.linear_value_dim()
+    }
+}
+
+impl GdnConfig for TextConfig {
+    fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+    fn rms_norm_eps(&self) -> f64 {
+        self.rms_norm_eps
+    }
+    fn linear_conv_kernel_dim(&self) -> usize {
+        self.linear_conv_kernel_dim
+    }
+    fn linear_key_head_dim(&self) -> usize {
+        self.linear_key_head_dim
+    }
+    fn linear_value_head_dim(&self) -> usize {
+        self.linear_value_head_dim
+    }
+    fn linear_num_key_heads(&self) -> usize {
+        self.linear_num_key_heads
+    }
+    fn linear_num_value_heads(&self) -> usize {
+        self.linear_num_value_heads
+    }
+}
+
+/// Load a HF `config.json` for a Qwen 3.5 (text-only) checkpoint.
+///
+/// Vision config is deserialized into a generic JSON value since the text path
+/// never reads it; the caller's responsibility is to gate vision processing.
+pub fn load_config(path: &str) -> Result<Config> {
+    let data = std::fs::read(path)
+        .map_err(|e| candle_core::Error::Msg(format!("read config {path}: {e}")))?;
+    let cfg: Config = serde_json::from_slice(&data)
+        .map_err(|e| candle_core::Error::Msg(format!("parse config {path}: {e}")))?;
+    Ok(cfg)
+}

--- a/crane-core/src/models/qwen3_5/kv_cache.rs
+++ b/crane-core/src/models/qwen3_5/kv_cache.rs
@@ -1,0 +1,122 @@
+//! K/V cache for the full-attention layers of Qwen 3.5.
+//!
+//! The hybrid model only needs this for the 1-in-4 full-attention blocks; the
+//! linear-attention (GDN) blocks carry a constant-size recurrent state instead
+//! (see [`crate::gdn::GdnLayerCache`]), so the context-growing part of the
+//! cache lives in just these layers.
+//!
+//! # The swap seam
+//!
+//! This is a lossless fp store. It is the single place a quantized K/V backend
+//! (e.g. rotation + scalar quant for long-context local setups) would slot in:
+//! a future variant only has to honor the same contract —
+//!
+//! - [`KvCache::append`] takes the new post-RoPE `k`/`v` for the current step
+//!   (`[B, num_kv_heads, S, head_dim]`) and returns the *full* `k`/`v` spanning
+//!   all cached positions, ready for attention.
+//! - [`KvCache::reset`] clears it between unrelated requests.
+//!
+//! Attention logic never touches the storage representation, so swapping fp for
+//! a quantized backend won't reach into the attention math.
+
+use candle_core::{Result, Tensor};
+
+/// Pre-allocated, append-in-place K/V cache for one full-attention layer.
+///
+/// Mirrors the `qwen3` model's cache: a buffer that may be larger than the
+/// filled length, written with `slice_set` (O(new tokens), not `cat`), grown
+/// with a small fixed headroom only when it overflows.
+#[derive(Debug)]
+pub struct KvCache {
+    /// `(k, v)` buffers of shape `[B, num_kv_heads, capacity, head_dim]`.
+    buffers: Option<(Tensor, Tensor)>,
+    /// Number of valid (filled) positions in the buffers.
+    seq_len: usize,
+}
+
+/// Headroom (in positions) added when (re)allocating, to amortize growth.
+const ROOM: usize = 256;
+
+impl Default for KvCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KvCache {
+    pub fn new() -> Self {
+        Self {
+            buffers: None,
+            seq_len: 0,
+        }
+    }
+
+    /// Filled length (number of cached positions).
+    pub fn len(&self) -> usize {
+        self.seq_len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.seq_len == 0
+    }
+
+    /// Drop all cached state (between unrelated requests).
+    pub fn reset(&mut self) {
+        self.buffers = None;
+        self.seq_len = 0;
+    }
+
+    /// Append `k`/`v` for the current step and return the full cached `(k, v)`.
+    ///
+    /// `k`/`v` are `[B, num_kv_heads, S, head_dim]` (post-RoPE, pre-GQA-expand).
+    /// The returned tensors span `[B, num_kv_heads, seq_len + S, head_dim]`.
+    pub fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        let k = k.contiguous()?;
+        let v = v.contiguous()?;
+        let new_seq_len = k.dim(2)?;
+        let filled = self.seq_len;
+
+        match self.buffers.take() {
+            None => {
+                // First write — allocate with headroom.
+                let (b, h, s, d) = k.dims4()?;
+                let buf_k = Tensor::zeros((b, h, s + ROOM, d), k.dtype(), k.device())?;
+                let buf_v = Tensor::zeros((b, h, s + ROOM, d), v.dtype(), v.device())?;
+                buf_k.slice_set(&k, 2, 0)?;
+                buf_v.slice_set(&v, 2, 0)?;
+                self.buffers = Some((buf_k, buf_v));
+                self.seq_len = s;
+                Ok((k, v))
+            }
+            Some((buf_k, buf_v)) => {
+                let capacity = buf_k.dim(2)?;
+                let new_total = filled + new_seq_len;
+
+                if new_total <= capacity {
+                    // Fits — in-place write, O(new_seq_len).
+                    buf_k.slice_set(&k, 2, filled)?;
+                    buf_v.slice_set(&v, 2, filled)?;
+                    let k_view = buf_k.narrow(2, 0, new_total)?;
+                    let v_view = buf_v.narrow(2, 0, new_total)?;
+                    self.buffers = Some((buf_k, buf_v));
+                    self.seq_len = new_total;
+                    Ok((k_view, v_view))
+                } else {
+                    // Overflow — concat then reallocate with headroom.
+                    let cur_k = buf_k.narrow(2, 0, filled)?;
+                    let cur_v = buf_v.narrow(2, 0, filled)?;
+                    let full_k = Tensor::cat(&[&cur_k, &k], 2)?;
+                    let full_v = Tensor::cat(&[&cur_v, &v], 2)?;
+                    let (b, h, total, d) = full_k.dims4()?;
+                    let new_buf_k = Tensor::zeros((b, h, total + ROOM, d), k.dtype(), k.device())?;
+                    let new_buf_v = Tensor::zeros((b, h, total + ROOM, d), v.dtype(), v.device())?;
+                    new_buf_k.slice_set(&full_k, 2, 0)?;
+                    new_buf_v.slice_set(&full_v, 2, 0)?;
+                    self.buffers = Some((new_buf_k, new_buf_v));
+                    self.seq_len = total;
+                    Ok((full_k, full_v))
+                }
+            }
+        }
+    }
+}

--- a/crane-core/src/models/qwen3_5/mod.rs
+++ b/crane-core/src/models/qwen3_5/mod.rs
@@ -1,0 +1,22 @@
+//! Qwen 3.5 dense text-only model.
+//!
+//! Hybrid Mamba/Transformer: every 4th layer is full (softmax) attention,
+//! the other 3 are linear attention via [`crate::gdn::GatedDeltaNet`].
+//!
+//! See [`config::TextConfig`] for the HF schema mapping and
+//! [`model::Qwen3_5TextModel`] for the high-level entry point.
+//!
+//! Only dense text-only checkpoints are supported; the
+//! `Qwen3_5ForConditionalGeneration` multimodal class is recognized for
+//! weight loading (the `model.language_model.*` prefix is handled), but
+//! vision weights are ignored.
+
+mod config;
+mod kv_cache;
+mod model;
+mod modeling;
+
+pub use config::{load_config, Config, LayerType, TextConfig};
+pub use kv_cache::KvCache;
+pub use model::{Model, ModelFormat, Qwen3_5TextModel};
+pub use modeling::{apply_mrope, DecoderLayer, FullAttention, Mlp, MRotaryEmbedding, Qwen35RmsNorm};

--- a/crane-core/src/models/qwen3_5/model.rs
+++ b/crane-core/src/models/qwen3_5/model.rs
@@ -1,0 +1,417 @@
+//! Top-level Qwen 3.5 text-only transformer + the high-level `Model`
+//! wrapper used by the engine (config + weights + tokenizer).
+
+use std::io::Write;
+
+use anyhow::{Context, Error as E, Result};
+use candle_core::{DType, Device, Module, Tensor};
+use candle_nn::{embedding, Embedding, VarBuilder};
+use candle_transformers::generation::LogitsProcessor;
+use tokenizers::Tokenizer;
+
+use super::config::{load_config, Config, TextConfig};
+use super::kv_cache::KvCache;
+use super::modeling::{resolve_tied, DecoderLayer, MRotaryEmbedding, Qwen35RmsNorm};
+use crate::generation::based::ModelForCausalLM;
+use crate::generation::GenerationConfig;
+use crate::utils::token_output_stream::TokenOutputStream;
+use crate::utils::utils;
+
+/// Text-only Qwen 3.5 transformer.
+///
+/// `gdn_caches` is indexed by layer; `None` for full-attention blocks, `Some`
+/// for linear-attention blocks. The engine is responsible for cloning/saving
+/// these caches across context switches (continuous batching).
+pub struct Qwen3_5TextModel {
+    cfg: TextConfig,
+    embed_tokens: Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: Qwen35RmsNorm,
+    lm_head: Tensor,
+    rotary: MRotaryEmbedding,
+    gdn_caches: Vec<Option<crate::gdn::GdnLayerCache>>,
+    /// Per-layer K/V cache; `Some` for full-attention blocks, `None` for GDN.
+    attn_caches: Vec<Option<KvCache>>,
+    device: Device,
+    dtype: DType,
+}
+
+impl Qwen3_5TextModel {
+    /// Load a text-only Qwen 3.5 model from a HF checkpoint directory.
+    ///
+    /// The HF layout has a top-level `language_model.*` prefix when the model
+    /// was saved with `Qwen3_5ForConditionalGeneration`. We probe for that
+    /// prefix and fall back to a flat layout.
+    pub fn new(cfg: &Config, vb: VarBuilder, device: &Device, dtype: DType) -> Result<Self> {
+        let text_cfg = cfg.text().clone();
+        // HF saves Qwen 3.5 weights with the prefix
+        //   model.language_model.layers.{i}.{linear_attn,self_attn}.*
+        // (the `model.` is the inner multimodal `Qwen3_5Model`, of which
+        // `language_model` is the text component). Older checkpoints and
+        // standalone text exports may drop the leading `model.`.
+        let vb_lm = if vb.contains_tensor("model.language_model.embed_tokens.weight") {
+            vb.pp("model").pp("language_model")
+        } else if vb.contains_tensor("language_model.embed_tokens.weight") {
+            vb.pp("language_model")
+        } else if vb.contains_tensor("model.embed_tokens.weight") {
+            vb.pp("model")
+        } else {
+            // Last-resort: assume a flat layout, no prefix.
+            vb.clone()
+        };
+
+        let embed_tokens = embedding(text_cfg.vocab_size, text_cfg.hidden_size, vb_lm.pp("embed_tokens"))?;
+
+        let layer_types = text_cfg.layer_types();
+        let mut layers = Vec::with_capacity(text_cfg.num_hidden_layers);
+        for (idx, &layer_type) in layer_types.iter().enumerate() {
+            layers.push(DecoderLayer::load(&text_cfg, layer_type, vb_lm.pp("layers").pp(idx))?);
+        }
+
+        let norm = Qwen35RmsNorm::load(text_cfg.hidden_size, text_cfg.rms_norm_eps, vb_lm.pp("norm"))?;
+
+        let embed_weight = embed_tokens.embeddings().clone();
+        let lm_head_weight = vb_lm.get(text_cfg.vocab_size, "lm_head").ok();
+        // Store `lm_head` already transposed (`[H, V]`) so the per-step matmul
+        // doesn't have to. `resolve_tied` returns either the dedicated lm_head
+        // weight or — when `tie_word_embeddings: true` — the embed table.
+        let lm_head_raw = resolve_tied(cfg.tie_word_embeddings, embed_weight, lm_head_weight);
+        let lm_head = lm_head_raw.t()?.contiguous()?.clone();
+
+        let rotary = MRotaryEmbedding::new(&text_cfg, device)?;
+
+        // Pre-allocate per-layer caches: GDN recurrent state for linear blocks,
+        // K/V cache for full-attention blocks (mutually exclusive per layer).
+        let mut gdn_caches = Vec::with_capacity(layers.len());
+        let mut attn_caches = Vec::with_capacity(layers.len());
+        for layer in &layers {
+            if layer.is_linear() {
+                gdn_caches.push(Some(crate::gdn::GdnLayerCache::new(
+                    &text_cfg, dtype, device,
+                )?));
+                attn_caches.push(None);
+            } else {
+                gdn_caches.push(None);
+                attn_caches.push(Some(KvCache::new()));
+            }
+        }
+
+        Ok(Self {
+            cfg: text_cfg,
+            embed_tokens,
+            layers,
+            norm,
+            lm_head,
+            rotary,
+            gdn_caches,
+            attn_caches,
+            device: device.clone(),
+            dtype,
+        })
+    }
+
+    pub fn config(&self) -> &TextConfig {
+        &self.cfg
+    }
+
+    pub fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    pub fn lm_head(&self) -> &Tensor {
+        &self.lm_head
+    }
+
+    /// Reset all per-layer GDN caches. Called between unrelated requests
+    /// sharing the same pre-allocated layer set.
+    pub fn reset_gdn_caches(&mut self) -> Result<()> {
+        for slot in self.gdn_caches.iter_mut().flatten() {
+            slot.reset()?;
+        }
+        for slot in self.attn_caches.iter_mut().flatten() {
+            slot.reset();
+        }
+        Ok(())
+    }
+
+    /// Forward pass over `input_ids` of shape `[B, S]`. `start_pos` is the
+    /// absolute position of the first token (used for rotary slicing).
+    /// `attention_mask` is broadcastable to `[B, 1, S, S_total]` (or `None`).
+    ///
+    /// Returns logits of shape `[B, S, vocab_size]`.
+    pub fn forward(
+        &mut self,
+        input_ids: &Tensor,
+        start_pos: usize,
+        attention_mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let (_b, seq_len) = input_ids.dims2()?;
+        let is_decode_step = seq_len == 1;
+
+        let mut xs = self.embed_tokens.forward(input_ids)?;
+
+        // If no mask was supplied, build a causal mask so prefill doesn't
+        // leak future tokens into past positions. (Decode is `seq_len==1`,
+        // where every position trivially attends only to itself — the mask is
+        // a no-op there.)
+        let mask = match attention_mask {
+            Some(m) => Some(m.clone()),
+            None if !is_decode_step => {
+                let total = start_pos + seq_len;
+                Some(build_causal_mask(seq_len, total, xs.device(), xs.dtype())?)
+            }
+            None => None,
+        };
+        let mask_ref = mask.as_ref();
+
+        let (cos, sin) = self.rotary.cos_sin(start_pos, seq_len)?;
+        let rot_dim = self.rotary.rot_dim();
+
+        for i in 0..self.layers.len() {
+            let layer = &self.layers[i];
+            let gdn_slot = self.gdn_caches[i].as_mut();
+            let attn_slot = self.attn_caches[i].as_mut();
+            xs = layer.forward(
+                &xs,
+                &cos,
+                &sin,
+                rot_dim,
+                mask_ref,
+                gdn_slot,
+                attn_slot,
+                is_decode_step,
+            )?;
+        }
+
+        let xs = self.norm.forward(&xs)?;
+        // Matmul with lm_head on the LAST position only. The engine's
+        // sampling step expects `[B, V]` (1D logits for the next token).
+        let (b, s, _) = xs.dims3()?;
+        let last = xs.narrow(1, s - 1, 1)?.reshape((b, ()))?;
+        let logits = last.matmul(&self.lm_head)?;
+        Ok(logits)
+    }
+}
+
+/// Build a causal mask of shape `[1, 1, S_q, S_k]` where row `i` has `-inf`
+/// for columns `j > start_pos + i` (future tokens). Returned as f32 cast to
+/// the model's dtype.
+fn build_causal_mask(
+    seq_q: usize,
+    total_k: usize,
+    device: &candle_core::Device,
+    dtype: candle_core::DType,
+) -> candle_core::Result<candle_core::Tensor> {
+    let mut data: Vec<f32> = Vec::with_capacity(total_k * total_k);
+    for q in 0..total_k {
+        for k in 0..total_k {
+            data.push(if k > q { f32::NEG_INFINITY } else { 0.0 });
+        }
+    }
+    let full = candle_core::Tensor::from_vec(data, (total_k, total_k), device)?
+        .to_dtype(dtype)?;
+    Ok(full.narrow(0, 0, seq_q)?.unsqueeze(0)?.unsqueeze(0)?)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  High-level Model wrapper (used by crane-serve's engine)
+// ─────────────────────────────────────────────────────────────────────
+
+/// Format of model weights on disk. Qwen 3.5 currently only ships
+/// safetensors; GGUF support is left for a future PR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelFormat {
+    Auto,
+    Safetensors,
+}
+
+/// Public-facing `Model` for Qwen 3.5 text-only inference.
+///
+/// Mirrors the structure of `crane_core::models::qwen3::Model`:
+/// holds a tokenizer, device, dtype, and the inner [`Qwen3_5TextModel`].
+pub struct Model {
+    pub tokenizer: TokenOutputStream,
+    pub device: Device,
+    pub dtype: DType,
+    inner: Qwen3_5TextModel,
+}
+
+impl Model {
+    /// Load a Qwen 3.5 model from a HF checkpoint directory.
+    ///
+    /// Only the safetensors path is wired. GGUF support is left as a
+    /// follow-up.
+    pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
+        Self::new_with_format(model_path, device, dtype, ModelFormat::Auto)
+    }
+
+    pub fn new_with_format(
+        model_path: &str,
+        device: &Device,
+        dtype: &DType,
+        format: ModelFormat,
+    ) -> Result<Self> {
+        let format = match format {
+            ModelFormat::Auto => ModelFormat::Safetensors,
+            other => other,
+        };
+        match format {
+            ModelFormat::Safetensors => Self::from_pretrained(model_path, device, dtype),
+            ModelFormat::Auto => unreachable!("Auto resolves to Safetensors above"),
+        }
+    }
+
+    fn from_pretrained(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
+        let tokenizer_path = std::path::Path::new(model_path).join("tokenizer.json");
+        if !tokenizer_path.exists() {
+            anyhow::bail!("Tokenizer not found at {}", tokenizer_path.display());
+        }
+        let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(E::msg)?;
+
+        let filenames = utils::get_safetensors_files(model_path)?;
+        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, *dtype, device) }?;
+
+        let config_path = std::path::Path::new(model_path).join("config.json");
+        let cfg = load_config(config_path.to_str().context("non-UTF8 model path")?)?;
+
+        let inner = Qwen3_5TextModel::new(&cfg, vb, device, *dtype)?;
+
+        Ok(Self {
+            tokenizer: TokenOutputStream::new(tokenizer),
+            device: device.clone(),
+            dtype: *dtype,
+            inner,
+        })
+    }
+
+    /// Tokenize a prompt string into input IDs (mirrors `qwen3::Model`).
+    pub fn prepare_inputs(&self, inputs: &str) -> Result<Vec<u32>> {
+        let input_ids = self
+            .tokenizer
+            .tokenizer
+            .encode(inputs, true)
+            .map_err(E::msg)?
+            .get_ids()
+            .to_vec();
+        Ok(input_ids)
+    }
+
+    /// Run a single forward step, returning raw logits `[1, S, vocab]`.
+    pub fn forward_step(
+        &mut self,
+        input_ids: &[u32],
+        start_pos: usize,
+    ) -> Result<Tensor> {
+        let input = Tensor::new(input_ids, &self.device)?.unsqueeze(0)?;
+        Ok(self.inner.forward(&input, start_pos, None)?)
+    }
+
+    /// Reset all per-layer GDN caches (between unrelated requests).
+    pub fn clear_kv_cache(&mut self) {
+        self.inner
+            .reset_gdn_caches()
+            .expect("GDN cache reset failed");
+    }
+
+    pub fn num_layers(&self) -> usize {
+        self.inner.num_layers()
+    }
+
+    /// Warm up the model with a small forward pass.
+    pub fn warmup(&mut self) {
+        // Run a tiny decode-only forward (single token) so warmup succeeds
+        // regardless of how the generate loop is implemented.
+        if let Err(e) = self.generate(
+            &[45],
+            &GenerationConfig::with_max_tokens(5),
+            None,
+        ) {
+            eprintln!("warmup failed (non-fatal): {e}");
+        }
+        self.clear_kv_cache();
+    }
+}
+
+impl ModelForCausalLM for Model {
+    fn device(&self) -> &Device {
+        &self.device
+    }
+
+    fn generate(
+        &mut self,
+        input_ids: &[u32],
+        config: &GenerationConfig,
+        mut streamer: Option<&mut dyn crate::generation::streamer::TokenStreamer>,
+    ) -> Result<Vec<u32>> {
+        self.tokenizer.clear();
+        self.clear_kv_cache();
+
+        let mut logits_processor =
+            LogitsProcessor::new(1024, config.temperature, config.top_p);
+
+        let mut tokens = input_ids.to_vec();
+        std::io::stdout().flush()?;
+
+        let mut generated_tokens = 0usize;
+        let eos_token: Option<u32> = config
+            .eos_token_id
+            .or_else(|| self.tokenizer.get_token(""))
+            .or_else(|| self.tokenizer.get_token(""));
+
+        let start_gen = std::time::Instant::now();
+        for index in 0..config.max_new_tokens {
+            // After the first step, only feed the freshly decoded token — GDN
+            // layers carry recurrent state and full-attention layers carry a
+            // K/V cache, so incremental decode is correct.
+            let context_size = if index > 0 { 1 } else { tokens.len() };
+            let start_pos = tokens.len().saturating_sub(context_size);
+            let ctxt = &tokens[start_pos..];
+
+            let logits = self.forward_step(ctxt, start_pos)?;
+            let logits = logits.squeeze(0)?.to_dtype(DType::F32)?;
+
+            let logits = if config.repetition_penalty == 1. {
+                logits
+            } else {
+                let start_at = tokens.len().saturating_sub(config.repeat_last_n);
+                candle_transformers::utils::apply_repeat_penalty(
+                    &logits,
+                    config.repetition_penalty,
+                    &tokens[start_at..],
+                )?
+            };
+
+            let next_token = logits_processor.sample(&logits)?;
+            tokens.push(next_token);
+            generated_tokens += 1;
+
+            if eos_token == Some(next_token) {
+                if let Some(ref mut s) = streamer {
+                    s.finalize()?;
+                }
+                break;
+            }
+
+            if let Some(ref mut s) = streamer {
+                s.append(next_token)?;
+            }
+        }
+
+        let dt = start_gen.elapsed();
+        if config.report_speed {
+            println!(
+                "\n{generated_tokens} tokens generated ({:.2} token/s)\n",
+                generated_tokens as f64 / dt.as_secs_f64(),
+            );
+        }
+        Ok(tokens)
+    }
+}

--- a/crane-core/src/models/qwen3_5/modeling.rs
+++ b/crane-core/src/models/qwen3_5/modeling.rs
@@ -1,0 +1,471 @@
+//! Qwen 3.5 transformer layer: hybrid full-attention + linear-attention stack.
+//!
+//! Layout (per layer):
+//!   residual = input_layernorm(x)
+//!   attn_or_gdn_out = full_or_linear(residual, …)   // dispatched by layer_types
+//!   x = x + attn_or_gdn_out
+//!   residual2 = post_attention_layernorm(x)
+//!   x = x + mlp(residual2)
+//!
+//! The full-attention path uses MRoPE-interleaved rotary embeddings and gated
+//! output (`attn_output_gate: true` in the config). The linear-attention path
+//! uses [`crate::gdn::GatedDeltaNet`].
+//!
+//! Per-layer GDN state is held by [`super::Qwen3_5TextModel`] (not by the
+//! layer), so that continuous-batching can save/restore state per request.
+
+use candle_core::{DType, Device, Module, Result, Tensor, D};
+use candle_nn::{linear_no_bias, VarBuilder};
+
+// ── Qwen 3.5 RMSNorm (unit-offset) ───────────────────────────────────────
+
+/// RMSNorm as used by Qwen 3.5: `x / rms(x) * (1 + weight)`.
+///
+/// Unlike the standard (Llama/Qwen3) RMSNorm — which scales by `weight` — Qwen
+/// 3.5 adds a unit offset (`1 + weight`, Gemma-style). HF source:
+/// `output = self._norm(x.float()) * (1.0 + self.weight.float())`. The stored
+/// weights have mean ~0.24, so omitting the `+1` shrinks every normalized
+/// activation ~5x and compounds across layers. Computed in f32 then cast back.
+///
+/// This is NOT used by the GDN gated norm ([`crate::gdn::RmsNormGated`]), which
+/// scales by plain `weight` in HF.
+#[derive(Clone)]
+pub struct Qwen35RmsNorm {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl Qwen35RmsNorm {
+    pub fn load(size: usize, eps: f64, vb: VarBuilder) -> Result<Self> {
+        let weight = vb.get(size, "weight")?;
+        Ok(Self { weight, eps })
+    }
+
+    pub fn weight(&self) -> &Tensor {
+        &self.weight
+    }
+}
+
+impl Module for Qwen35RmsNorm {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let dtype = x.dtype();
+        let x = x.to_dtype(DType::F32)?;
+        let var = x.sqr()?.mean_keepdim(D::Minus1)?;
+        let x_normed = x.broadcast_div(&(var + self.eps)?.sqrt()?)?;
+        // `1 + weight` (unit offset), in f32.
+        let scale = self.weight.to_dtype(DType::F32)?.affine(1.0, 1.0)?;
+        x_normed.broadcast_mul(&scale)?.to_dtype(dtype)
+    }
+}
+
+use super::config::{LayerType, TextConfig};
+use super::kv_cache::KvCache;
+use crate::gdn::{GatedDeltaNet, GdnDims, GdnInputProjectionKind, GdnLayerCache};
+
+// ── MRoPE rotary embedding ─────────────────────────────────────────────
+
+/// Multimodal Rotary Position Embedding (interleaved variant, used by Qwen 3.5).
+///
+/// For text-only inference the position_ids are identical across all three
+/// sections, so this reduces to standard RoPE applied to the first
+/// `rot_dim = head_dim * partial_rotary_factor` components of each head.
+///
+/// Precomputes `cos` and `sin` tables of shape `[max_pos, rot_dim/2]`. Use
+/// [`apply_mrope`] to rotate a query/key tensor.
+pub struct MRotaryEmbedding {
+    cos_table: Tensor,
+    sin_table: Tensor,
+    rot_dim: usize,
+}
+
+impl MRotaryEmbedding {
+    pub fn new(cfg: &TextConfig, device: &Device) -> Result<Self> {
+        let rot_dim = cfg.rot_dim();
+        let base = cfg.rope_theta() as f32;
+        let max_pos = cfg.max_position_embeddings;
+
+        // cos/sin tables have shape `[S, rot_dim/2]` — exactly the slice of the
+        // head that receives rotary embeddings. `apply_mrope` rotates only the
+        // first `rot_dim` components of each head (HF's partial-rotary scheme:
+        // `q_rot = q[..., :rot_dim]`), so the tables must NOT be padded to
+        // `head_dim/2`. Padding them to the full head and rotating the whole
+        // head (the previous approach) pairs dim `i` with dim `i+head_dim/2`,
+        // whereas HF pairs `i` with `i+rot_dim/2` inside the rotary slice — a
+        // different rotation entirely.
+        let half_rot = rot_dim / 2;
+        let inv: Vec<f32> = (0..half_rot)
+            .map(|i| 1.0 / base.powf(i as f32 * 2.0 / rot_dim as f32))
+            .collect();
+        let inv_freq = Tensor::new(inv.as_slice(), device)?;
+
+        let positions: Vec<f32> = (0..max_pos).map(|i| i as f32).collect();
+        let positions = Tensor::new(positions.as_slice(), device)?;
+        let freqs = positions.unsqueeze(1)?.matmul(&inv_freq.unsqueeze(0)?)?; // [max_pos, half_rot]
+
+        let cos_table = freqs.cos()?.contiguous()?;
+        let sin_table = freqs.sin()?.contiguous()?;
+
+        Ok(Self {
+            cos_table,
+            sin_table,
+            rot_dim,
+        })
+    }
+
+    /// Slice cos/sin for positions `[start, start+seq_len)`.
+    pub fn cos_sin(&self, start: usize, seq_len: usize) -> Result<(Tensor, Tensor)> {
+        let cos = self.cos_table.narrow(0, start, seq_len)?;
+        let sin = self.sin_table.narrow(0, start, seq_len)?;
+        Ok((cos, sin))
+    }
+
+    pub fn rot_dim(&self) -> usize {
+        self.rot_dim
+    }
+}
+
+/// Apply rotary embeddings to a query/key tensor `[B, H, S, D]`.
+///
+/// Only the first `rot_dim` components of each head are rotated; the remaining
+/// `D - rot_dim` components are passed through unchanged. This mirrors HF's
+/// partial-rotary scheme (`q_rot = q[..., :rot_dim]`, `q_pass = q[..., rot_dim:]`).
+/// `cos`/`sin` tables have shape `[S, rot_dim/2]`.
+///
+/// `candle_nn::rotary_emb::rope` is the rotate-half (non-interleaved / GPT-NeoX)
+/// variant — it pairs component `i` with `i + rot_dim/2` *within the slice we
+/// hand it*, which matches HF's `rotate_half` over the rotary slice. We must
+/// slice first; rotating the full head would pair `i` with `i + head_dim/2`.
+pub fn apply_mrope(
+    x: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    rot_dim: usize,
+) -> Result<Tensor> {
+    let (_b, _h, _seq_len, head_dim) = x.dims4()?;
+    let dtype = x.dtype();
+    // `cos`/`sin` are kept in f32; the rope op requires its inputs to share a
+    // dtype, so for half-precision activations (F16/BF16 on GPU) we rotate in
+    // f32 and cast back. This also matches HF, which applies RoPE in float.
+    let rope_f32 = |t: &Tensor| -> Result<Tensor> {
+        let r = candle_nn::rotary_emb::rope(&t.to_dtype(DType::F32)?.contiguous()?, cos, sin)?;
+        r.to_dtype(dtype)
+    };
+    if rot_dim == head_dim {
+        return rope_f32(x);
+    }
+    let x_rot = rope_f32(&x.narrow(D::Minus1, 0, rot_dim)?)?;
+    let x_pass = x.narrow(D::Minus1, rot_dim, head_dim - rot_dim)?;
+    Tensor::cat(&[&x_rot, &x_pass], D::Minus1)?.contiguous()
+}
+
+// ── Full-attention layer ────────────────────────────────────────────────
+
+/// Standard softmax attention layer for Qwen 3.5's `full_attention` blocks.
+///
+/// Differences from the regular Qwen 3 attention:
+/// - `q_proj` outputs `num_heads * head_dim * 2`; the second half is a sigmoid
+///   gate applied to the attention output.
+/// - Per-head QK-norm is always present (`q_norm`, `k_norm` of size `head_dim`).
+/// - RoPE is MRoPE-interleaved applied only to the first `rot_dim` components.
+pub struct FullAttention {
+    q_proj: candle_nn::Linear,
+    k_proj: candle_nn::Linear,
+    v_proj: candle_nn::Linear,
+    o_proj: candle_nn::Linear,
+    q_norm: Qwen35RmsNorm,
+    k_norm: Qwen35RmsNorm,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    has_output_gate: bool,
+}
+
+impl FullAttention {
+    pub fn load(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+        let head_dim = cfg.head_dim;
+
+        let q_out = if cfg.attn_output_gate {
+            num_heads * head_dim * 2
+        } else {
+            num_heads * head_dim
+        };
+        let q_proj = linear_no_bias(cfg.hidden_size, q_out, vb.pp("q_proj"))?;
+        let k_proj = linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj = linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let o_proj = linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
+
+        let q_norm = Qwen35RmsNorm::load(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
+        let k_norm = Qwen35RmsNorm::load(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            has_output_gate: cfg.attn_output_gate,
+        })
+    }
+
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        rot_dim: usize,
+        attention_mask: Option<&Tensor>,
+        kv_cache: Option<&mut KvCache>,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, _) = x.dims3()?;
+
+        let q_out = self.q_proj.forward(x)?;
+        let k_proj_out = self.k_proj.forward(x)?;
+        let v_proj_out = self.v_proj.forward(x)?;
+        let k = k_proj_out;
+        let v = v_proj_out;
+
+        let (q, gate) = if self.has_output_gate {
+            // HF splits `[query | gate]` PER HEAD, not on the flat axis:
+            //   q_proj(x).view(B, S, num_heads, head_dim*2).chunk(2, dim=-1)
+            // so for each head the first `head_dim` is the query and the next
+            // `head_dim` is the gate. Splitting the flat 4096 in half instead
+            // interleaves heads' query/gate and scrambles q_norm. Re-flatten
+            // both back to `[B, S, num_heads*head_dim]` in head order.
+            let flat = self.num_heads * self.head_dim;
+            let qh = q_out.reshape((b_sz, seq_len, self.num_heads, self.head_dim * 2))?;
+            let q = qh
+                .narrow(D::Minus1, 0, self.head_dim)?
+                .contiguous()?
+                .reshape((b_sz, seq_len, flat))?;
+            let gate = qh
+                .narrow(D::Minus1, self.head_dim, self.head_dim)?
+                .contiguous()?
+                .reshape((b_sz, seq_len, flat))?;
+            (q, Some(gate))
+        } else {
+            (q_out, None)
+        };
+
+        let q = q
+            .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = k
+            .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = v
+            .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        let q = self.q_norm.forward(&q)?;
+        let k = self.k_norm.forward(&k)?;
+
+        let q = apply_mrope(&q, cos, sin, rot_dim)?;
+        let k = apply_mrope(&k, cos, sin, rot_dim)?;
+
+        // Append this step's K/V to the cache (post-RoPE, pre-GQA-expand) and
+        // continue with the full cached K/V. During incremental decode this is
+        // what lets the attention see the whole context from a single token.
+        let (k, v) = match kv_cache {
+            Some(cache) => cache.append(&k, &v)?,
+            None => (k, v),
+        };
+
+        let n_rep = self.num_heads / self.num_kv_heads;
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+
+        let k_rep = if n_rep > 1 {
+            let (b, kv_heads, s, d) = k.dims4()?;
+            k.unsqueeze(2)?
+                .expand((b, kv_heads, n_rep, s, d))?
+                .contiguous()?
+                .reshape((b, self.num_heads, s, d))?
+        } else {
+            k
+        };
+        let v_rep = if n_rep > 1 {
+            let (b, kv_heads, s, d) = v.dims4()?;
+            v.unsqueeze(2)?
+                .expand((b, kv_heads, n_rep, s, d))?
+                .contiguous()?
+                .reshape((b, self.num_heads, s, d))?
+        } else {
+            v
+        };
+        let k_t = k_rep.transpose(D::Minus2, D::Minus1)?.contiguous()?;
+        let attn_logits = (q.matmul(&k_t)? * scale)?;
+        let attn_weights = match attention_mask {
+            Some(mask) => attn_weights_with_mask(&attn_logits, mask)?,
+            None => attn_logits,
+        };
+        let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+        let y = attn_weights.matmul(&v_rep)?;
+
+        let y = y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?;
+
+        let y = if let Some(g) = gate {
+            let gate = candle_nn::ops::sigmoid(&g.to_dtype(y.dtype())?)?;
+            y.broadcast_mul(&gate)?
+        } else {
+            y
+        };
+
+        self.o_proj.forward(&y)
+    }
+}
+
+fn attn_weights_with_mask(
+    attn_logits: &Tensor,
+    mask: &Tensor,
+) -> Result<Tensor> {
+    // HF applies the mask (shape `[B, 1, S_q, S_k]` for additive causal mask)
+    // via `attn_weights + mask` and softmax. We do the same.
+    Ok(attn_logits.broadcast_add(mask)?)
+}
+
+// ── MLP ────────────────────────────────────────────────────────────────
+
+/// Standard SwiGLU MLP: `down(silu(gate(x)) * up(x))`.
+pub struct Mlp {
+    gate_proj: candle_nn::Linear,
+    up_proj: candle_nn::Linear,
+    down_proj: candle_nn::Linear,
+}
+
+impl Mlp {
+    pub fn load(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let gate_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))?;
+        let up_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?;
+        let down_proj = linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))?;
+        Ok(Self { gate_proj, up_proj, down_proj })
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let gate = candle_nn::ops::silu(&self.gate_proj.forward(x)?)?;
+        let up = self.up_proj.forward(x)?;
+        let h = gate.broadcast_mul(&up)?;
+        let out = self.down_proj.forward(&h)?;
+        Ok(out)
+    }
+}
+
+// ── DecoderLayer ────────────────────────────────────────────────────────
+
+/// One transformer block. `LayerImpl` selects which attention path runs.
+///
+/// Per-layer GDN state is passed in via the [`DecoderLayer::forward`] signature
+/// (a `&mut Option<GdnLayerCache>`); the model holds the canonical cache array.
+pub struct DecoderLayer {
+    layer_impl: LayerImpl,
+    input_layernorm: Qwen35RmsNorm,
+    post_attention_layernorm: Qwen35RmsNorm,
+    mlp: Mlp,
+    /// Pre-computed dims for the GDN path. `None` for full-attention blocks.
+    gdn_dims: Option<GdnDims>,
+}
+
+enum LayerImpl {
+    FullAttention(FullAttention),
+    LinearAttention(GatedDeltaNet),
+}
+
+impl DecoderLayer {
+    pub fn load(
+        cfg: &TextConfig,
+        layer_type: LayerType,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let input_layernorm = Qwen35RmsNorm::load(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
+        let post_attention_layernorm = Qwen35RmsNorm::load(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            vb.pp("post_attention_layernorm"),
+        )?;
+        let mlp = Mlp::load(cfg, vb.pp("mlp"))?;
+
+        let (layer_impl, gdn_dims) = match layer_type {
+            LayerType::FullAttention => (
+                LayerImpl::FullAttention(FullAttention::load(cfg, vb.pp("self_attn"))?),
+                None,
+            ),
+            LayerType::LinearAttention => {
+                let dims = GdnDims::new(cfg);
+                let gdn = GatedDeltaNet::load(vb, cfg, GdnInputProjectionKind::Split)?;
+                (LayerImpl::LinearAttention(gdn), Some(dims))
+            }
+        };
+
+        Ok(Self {
+            layer_impl,
+            input_layernorm,
+            post_attention_layernorm,
+            mlp,
+            gdn_dims,
+        })
+    }
+
+    pub fn is_linear(&self) -> bool {
+        matches!(self.layer_impl, LayerImpl::LinearAttention(_))
+    }
+
+    /// Forward pass. For `LinearAttention` blocks pass `Some(gdn_cache)` and
+    /// `None` for `attn_cache`; for `FullAttention` blocks pass `Some(attn_cache)`
+    /// and `None` for `gdn_cache`.
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        rot_dim: usize,
+        attention_mask: Option<&Tensor>,
+        gdn_cache: Option<&mut GdnLayerCache>,
+        attn_cache: Option<&mut KvCache>,
+        is_decode_step: bool,
+    ) -> Result<Tensor> {
+        let residual = x;
+        let normed = self.input_layernorm.forward(x)?;
+
+        let attn_out = match &self.layer_impl {
+            LayerImpl::FullAttention(attn) => {
+                debug_assert!(gdn_cache.is_none(), "full-attention layer should not receive a GDN cache");
+                attn.forward(&normed, cos, sin, rot_dim, attention_mask, attn_cache)?
+            }
+            LayerImpl::LinearAttention(gdn) => {
+                debug_assert!(attn_cache.is_none(), "linear-attention layer should not receive a KV cache");
+                let cache = gdn_cache.ok_or_else(|| {
+                    candle_core::Error::Msg("GDN cache missing for linear-attention layer".into())
+                })?;
+                let dims = self.gdn_dims.as_ref().ok_or_else(|| {
+                    candle_core::Error::Msg("GDN dims missing for linear-attention layer".into())
+                })?;
+                gdn.forward(&normed, dims, cache, is_decode_step)?
+            }
+        };
+
+        let x = (residual + attn_out)?;
+
+        let residual2 = &x;
+        let normed2 = self.post_attention_layernorm.forward(&x)?;
+
+        let mlp_out = self.mlp.forward(&normed2)?;
+
+        residual2 + mlp_out
+    }
+}
+
+/// Choose between a dedicated `lm_head` weight and the tied `embed_tokens`
+/// weight, based on `tie_word_embeddings`.
+pub fn resolve_tied(tie: bool, embed_weight: Tensor, lm_head_weight: Option<Tensor>) -> Tensor {
+    match lm_head_weight {
+        Some(w) => w,
+        None if tie => embed_weight,
+        None => embed_weight,
+    }
+}

--- a/crane-serve/README.md
+++ b/crane-serve/README.md
@@ -1,4 +1,4 @@
-# crane-oai
+# crane-serve
 
 An OpenAI & SGLang compatible inference API server built on the [Crane](../README.md) framework, with continuous batching support.
 
@@ -7,7 +7,7 @@ An OpenAI & SGLang compatible inference API server built on the [Crane](../READM
 - **OpenAI-compatible API** — Chat Completions, Text Completions, Text-to-Speech, Models, Tokenize/Detokenize
 - **SGLang native API** — `/generate`, `/model_info`, `/server_info` and related endpoints
 - **Continuous batching** — Dedicated inference thread with prefill-priority scheduling, dynamic KV memory budget, and automatic sequence eviction/recovery
-- **Multi-model support** — Auto-detects and loads Hunyuan Dense, Qwen 2.5, Qwen 3, Qwen3-TTS architectures
+- **Multi-model support** — Auto-detects and loads Hunyuan Dense, Qwen 2.5, Qwen 3, Qwen 3.5 (hybrid GDN + softmax), Qwen3-TTS
 - **Qwen3-TTS** — Full two-level TTS inference (Talker + Code Predictor) with native Candle speech-tokenizer decoder (ONNX optional fallback); exposes OpenAI-compatible `/v1/audio/speech`
 - **Streaming** — SSE (Server-Sent Events) token streaming
 - **Cross-platform acceleration** — CPU / CUDA / Apple Metal, selected automatically
@@ -18,29 +18,29 @@ An OpenAI & SGLang compatible inference API server built on the [Crane](../READM
 
 ```bash
 # CPU only
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 
 # CUDA (NVIDIA GPU)
-cargo build -p crane-oai --release --features cuda
+cargo build -p crane-serve --release --features cuda
 ```
 
 ### Run
 
 ```bash
 # Auto-detect model type and device
-crane-oai --model-path /path/to/model
+crane --model-path /path/to/model
 
 # Specify model type and port
-crane-oai --model-path /path/to/Qwen2.5-7B-Instruct \
+crane --model-path /path/to/Qwen2.5-7B-Instruct \
     --model-type qwen25 \
     --port 8000
 
 # GGUF weights
-crane-oai --model-path /path/to/model.gguf \
+crane --model-path /path/to/model.gguf \
     --format gguf
 
 # Force CPU
-crane-oai --model-path /path/to/model --cpu
+crane --model-path /path/to/model --cpu
 ```
 
 ### Qwen3-TTS Quick Start
@@ -75,16 +75,16 @@ python scripts/export_qwen_tts_tokenizer_onnx.py \
 
 ```bash
 # CPU (always available)
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 
 # CUDA
-cargo build -p crane-oai --release --features "cuda"
+cargo build -p crane-serve --release --features "cuda"
 
 # macOS Metal (auto-enabled by target)
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 
 # Start the TTS server (auto-detected from config.json)
-./target/release/crane-oai \
+./target/release/crane \
     --model-path checkpoints/Qwen3-TTS-12Hz-0.6B-Base \
     --model-type qwen3_tts \
     --port 8080
@@ -187,19 +187,19 @@ python scripts/export_qwen_tts_tokenizer_onnx.py \
 
 ```bash
 # CPU
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 
 # CUDA
-cargo build -p crane-oai --release --features "cuda"
+cargo build -p crane-serve --release --features "cuda"
 
 # macOS Metal (auto-enabled by target)
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 ```
 
 **3. Start the server:**
 
 ```bash
-./target/release/crane-oai \
+./target/release/crane \
     --model-path checkpoints/Qwen3-TTS-12Hz-0.6B-Base \
     --model-type qwen3_tts \
     --port 8080
@@ -283,7 +283,7 @@ Built-in speakers for the CustomVoice model include: `Serena`, `Vivian`, `Uncle_
 ### Basic CUDA inference
 
 ```bash
-crane-oai --model-path /path/to/Qwen3-8B-Instruct
+crane-serve --model-path /path/to/Qwen3-8B-Instruct
 ```
 
 On CUDA, `model_info` will report the device as `Cuda(0)` (or `Cuda(1)`, etc.).
@@ -294,18 +294,18 @@ GPU memory grows as KV caches accumulate. Use `--gpu-memory-limit` to keep usage
 
 ```bash
 # Hard cap at 8 GB — recommended starting point for a 12 GB GPU
-crane-oai --model-path /path/to/model \
+crane-serve --model-path /path/to/model \
     --gpu-memory-limit 8G \
     --max-seq-len 4096
 
 # Cap at 5 GB for 8 GB VRAM cards
-crane-oai --model-path /path/to/model \
+crane-serve --model-path /path/to/model \
     --gpu-memory-limit 5G \
     --max-seq-len 2048 \
     --max-concurrent 4
 
 # Use 75% of total VRAM
-crane-oai --model-path /path/to/model \
+crane-serve --model-path /path/to/model \
     --gpu-memory-limit 0.75
 ```
 
@@ -325,21 +325,21 @@ When the KV memory budget is exceeded, the engine evicts the longest-output sequ
 GGUF quantization roughly halves VRAM usage compared to FP16:
 
 ```bash
-crane-oai --model-path /path/to/Qwen3-8B-Q4_K_M.gguf \
+crane-serve --model-path /path/to/Qwen3-8B-Q4_K_M.gguf \
     --format gguf \
     --gpu-memory-limit 8G
 ```
 
 ### Multi-GPU note
 
-Currently crane-oai runs on a single CUDA device (device 0). Multi-GPU tensor parallelism is not yet supported.
+Currently crane-serve runs on a single CUDA device (device 0). Multi-GPU tensor parallelism is not yet supported.
 
 ## CLI Parameters
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--model-path` | *(required)* | Path to model directory or GGUF file |
-| `--model-type` | `auto` | Architecture: `auto`, `hunyuan`, `qwen25`, `qwen3`, `qwen3_tts` |
+| `--model-type` | `auto` | Architecture: `auto`, `hunyuan`, `qwen25`, `qwen3`, `qwen3_5`, `qwen3_tts` |
 | `--model-name` | directory name | Model name shown in API responses |
 | `--host` | `0.0.0.0` | Bind address |
 | `--port` | `8080` | Bind port |
@@ -639,7 +639,7 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="http://localhost:8080/v1",
-    api_key="not-needed",  # crane-oai does not require an API key
+    api_key="not-needed",  # crane-serve does not require an API key
 )
 
 response = client.chat.completions.create(
@@ -662,7 +662,7 @@ for chunk in stream:
 
 ### Text-to-Speech (Qwen3-TTS)
 
-> Start crane-oai with `--model-type qwen3_tts` and a Qwen3-TTS checkpoint.
+> Start crane-serve with `--model-type qwen3_tts` and a Qwen3-TTS checkpoint.
 
 **CustomVoice model (predefined speakers):**
 
@@ -759,7 +759,7 @@ pathlib.Path("voice_clone.wav").write_bytes(r.content)
 ## Source Structure
 
 ```
-crane-oai/src/
+crane-serve/src/
 ├── main.rs              # CLI entry point, AppState, route registration
 ├── openai_api.rs        # OpenAI request/response types (incl. SpeechRequest)
 ├── sglang_api.rs        # SGLang native API types
@@ -788,6 +788,7 @@ crane-oai/src/
 |-------|-------------|---------|---------|-------|
 | Hunyuan Dense | ✅ | ✅ | Safetensors / GGUF | KV pre-alloc, GQA 4D matmul, RoPE cache growth |
 | Qwen 3 | ✅ | ✅ | Safetensors / GGUF | + QK Norm 4D, GGUF quantization |
+| Qwen 3.5 | ❌ | ❌ | Safetensors | Hybrid GDN + softmax attention; CUDA fused recurrence kernel; `max_concurrent=1` |
 | Qwen 2.5 | sequential | ❌ | Safetensors | — |
 | **Qwen3-TTS** | N/A | N/A | Safetensors (ONNX fallback optional) | Dedicated thread; no continuous batching |
 
@@ -804,7 +805,7 @@ Model type is auto-detected from `config.json` (`model_type` / `architectures`) 
 
 ## Notes
 
-- **No API key required** — crane-oai does not authenticate requests.
+- **No API key required** — crane-serve does not authenticate requests.
 - **Single CUDA device** — The server uses CUDA device 0. Multi-GPU tensor parallelism is not yet supported.
 - **KV eviction is lossless** — Evicted sequences preserve their full state and resume automatically; in-flight requests are not dropped or errored.
 - **`--max-seq-len 0`** means no limit. On constrained hardware, always set an explicit value to avoid runaway memory growth.
@@ -817,14 +818,14 @@ Model type is auto-detected from `config.json` (`model_type` / `architectures`) 
 ## Testing
 
 ```bash
-# All unit tests (125 crane-oai + 11 crane-core)
-cargo test -p crane-oai
+# All unit tests
+cargo test -p crane-serve
 cargo test -p crane-core
 
 # Specific modules
-cargo test -p crane-oai engine::scheduler
-cargo test -p crane-oai openai_api::tests
-cargo test -p crane-oai sglang_api::tests
+cargo test -p crane-serve engine::scheduler
+cargo test -p crane-serve openai_api::tests
+cargo test -p crane-serve sglang_api::tests
 cargo test -p crane-core autotokenizer
 ```
 

--- a/crane-serve/src/engine/backend.rs
+++ b/crane-serve/src/engine/backend.rs
@@ -382,6 +382,86 @@ impl ModelBackend for Qwen25Backend {
 }
 
 // ─────────────────────────────────────────────────────────────
+//  Qwen 3.5 Backend
+// ─────────────────────────────────────────────────────────────
+
+/// Engine wrapper around `crane_core::models::qwen3_5::Model`.
+///
+/// Only single-sequence forward is supported (no KV swap, no batch decode).
+/// The hybrid full-attention / GDN layers share a single set of caches; the
+/// engine treats them as opaque per-request state.
+pub struct Qwen3_5Backend {
+    pub model: crane_core::models::qwen3_5::Model,
+    #[allow(dead_code)]
+    dtype: DType,
+}
+
+impl Qwen3_5Backend {
+    pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
+        let model = crane_core::models::qwen3_5::Model::new(model_path, device, dtype)?;
+        Ok(Self {
+            model,
+            dtype: *dtype,
+        })
+    }
+}
+
+impl ModelBackend for Qwen3_5Backend {
+    fn forward_step(&mut self, input_ids: &[u32], start_pos: usize) -> Result<Tensor> {
+        self.model
+            .forward_step(input_ids, start_pos)
+            .map_err(Into::into)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.model.clear_kv_cache();
+    }
+
+    fn num_layers(&self) -> usize {
+        // The KV-cache vector sizing is a no-op for this backend — we always
+        // reset full-attention state implicitly via GDN-cache reset, and the
+        // engine caps `max_concurrent` to 1 since `supports_kv_swap` is false.
+        self.model.num_layers()
+    }
+
+    fn device(&self) -> &Device {
+        &self.model.device
+    }
+
+    fn dtype(&self) -> DType {
+        self.model.dtype
+    }
+
+    fn tokenizer(&self) -> &tokenizers::Tokenizer {
+        &self.model.tokenizer.tokenizer
+    }
+
+    fn eos_token_id(&self) -> Vec<u32> {
+        // Qwen 3 / 3.5 chat models stop at 151645 () and 151643 ().
+        let tok = &self.model.tokenizer.tokenizer;
+        let mut ids = Vec::new();
+        if let Some(id) = tok.token_to_id("") {
+            ids.push(id);
+        }
+        if let Some(id) = tok.token_to_id("") {
+            ids.push(id);
+        }
+        if ids.is_empty() {
+            ids.push(151645);
+            ids.push(151643);
+        }
+        ids
+    }
+
+    fn warmup(&mut self) {
+        self.model.warmup();
+    }
+
+    // supports_kv_swap defaults to false → engine caps max_concurrent to 1.
+    // Batch decode is not yet implemented for hybrid layer types.
+}
+
+// ─────────────────────────────────────────────────────────────
 //  Qwen 3 Backend
 // ─────────────────────────────────────────────────────────────
 

--- a/crane-serve/src/engine/model_factory.rs
+++ b/crane-serve/src/engine/model_factory.rs
@@ -8,7 +8,9 @@ use candle_core::{DType, Device};
 use serde::Deserialize;
 use std::path::Path;
 
-use super::backend::{Gemma4Backend, HunyuanBackend, ModelBackend, Qwen25Backend, Qwen3Backend};
+use super::backend::{
+    Gemma4Backend, HunyuanBackend, ModelBackend, Qwen25Backend, Qwen3Backend, Qwen3_5Backend,
+};
 use crate::chat_template::{AutoChatTemplate, ChatTemplateProcessor, HunyuanChatTemplate};
 
 // ─────────────────────────────────────────────────────────────
@@ -24,6 +26,7 @@ pub enum ModelType {
     HunyuanDense,
     Qwen25,
     Qwen3,
+    Qwen3_5,
     Qwen3TTS,
     PaddleOcrVl,
 }
@@ -36,6 +39,7 @@ impl ModelType {
             "hunyuan" | "hunyuan_dense" | "hunyuandense" => Self::HunyuanDense,
             "qwen25" | "qwen2.5" | "qwen2" => Self::Qwen25,
             "qwen3" => Self::Qwen3,
+            "qwen3_5" | "qwen3.5" | "qwen35" | "qwen3_5_dense" => Self::Qwen3_5,
             "qwen3_tts" | "qwen3tts" | "qwen3-tts" | "tts" => Self::Qwen3TTS,
             "paddleocr_vl" | "paddleocrv" | "paddleocr" | "paddle_ocr_vl" | "paddleocrvl" => Self::PaddleOcrVl,
             _ => Self::Auto,
@@ -50,6 +54,7 @@ impl ModelType {
             Self::HunyuanDense => "hunyuan",
             Self::Qwen25 => "qwen25",
             Self::Qwen3 => "qwen3",
+            Self::Qwen3_5 => "qwen3_5",
             Self::Qwen3TTS => "qwen3_tts",
             Self::PaddleOcrVl => "paddleocr_vl",
         }
@@ -122,6 +127,7 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
                         }
                         "qwen2" | "qwen2.5" => return ModelType::Qwen25,
                         "qwen3" => return ModelType::Qwen3,
+                        "qwen3_5" | "qwen3.5" => return ModelType::Qwen3_5,
                         "qwen3_tts" | "qwen3tts" => return ModelType::Qwen3TTS,
                         m if m.contains("hunyuan") => return ModelType::HunyuanDense,
                         m if m.contains("paddleocr") => return ModelType::PaddleOcrVl,
@@ -144,6 +150,9 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
                         }
                         if a.contains("qwen3ttsforconditional") || a.contains("qwen3_tts") {
                             return ModelType::Qwen3TTS;
+                        }
+                        if a.contains("qwen3_5") || a.contains("qwen3.5") {
+                            return ModelType::Qwen3_5;
                         }
                         if a.contains("qwen3") {
                             return ModelType::Qwen3;
@@ -222,6 +231,7 @@ pub fn create_backend(
         }
         ModelType::Qwen25 => Ok(Box::new(Qwen25Backend::new(model_path, device, dtype)?)),
         ModelType::Qwen3 => Ok(Box::new(Qwen3Backend::new(model_path, device, dtype)?)),
+        ModelType::Qwen3_5 => Ok(Box::new(Qwen3_5Backend::new(model_path, device, dtype)?)),
         ModelType::PaddleOcrVl => {
             anyhow::bail!("PaddleOCR-VL is a VLM model — use create_vlm_model() instead of create_backend()")
         }

--- a/crane/src/llm/client.rs
+++ b/crane/src/llm/client.rs
@@ -15,6 +15,10 @@ enum LoadedModel {
         model: crane_core::models::qwen3::Model,
         tokenizer: crane_core::autotokenizer::AutoTokenizer,
     },
+    Qwen35 {
+        model: crane_core::models::qwen3_5::Model,
+        tokenizer: crane_core::autotokenizer::AutoTokenizer,
+    },
     HunyuanDense {
         model: crane_core::models::hunyuan_dense::Model,
     },
@@ -89,6 +93,21 @@ impl LlmClient {
                     .map_err(|e| CraneError::ModelError(e.to_string()))?;
                 model.warmup();
                 LoadedModel::Qwen3 { model, tokenizer }
+            }
+            LlmModelType::Qwen35 => {
+                // Runs on CPU/CUDA/Metal. The Gated Delta Net recurrence uses
+                // the device-portable Candle path on GPU (functional; a fused
+                // kernel is the throughput follow-up).
+                let tokenizer = crane_core::autotokenizer::AutoTokenizer::from_pretrained(
+                    &config.model_path,
+                    None,
+                )
+                .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
+
+                let mut model = crane_core::models::qwen3_5::Model::new(&config.model_path, &device, &dtype)
+                    .map_err(|e| CraneError::ModelError(e.to_string()))?;
+                model.warmup();
+                LoadedModel::Qwen35 { model, tokenizer }
             }
             _ => {
                 return Err(CraneError::ConfigError(
@@ -182,6 +201,24 @@ impl LlmClient {
                     .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
                 Ok(result)
             }
+            LoadedModel::Qwen35 { model, tokenizer } => {
+                let prompt = tokenizer
+                    .apply_chat_template(messages, true)
+                    .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
+                let input_ids = model
+                    .prepare_inputs(&prompt)
+                    .map_err(|e| CraneError::ModelError(e.to_string()))?;
+
+                let output_ids = model
+                    .generate(&input_ids, &gen_config, None)
+                    .map_err(|e| CraneError::ModelError(e.to_string()))?;
+
+                let generated_ids = output_ids.get(input_ids.len()..).unwrap_or(&[]);
+                let result = tokenizer
+                    .decode(generated_ids, true)
+                    .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
+                Ok(result)
+            }
             LoadedModel::HunyuanDense { model } => {
                 let prompt = hunyuan_apply_chat_template(messages);
                 let input_ids = model
@@ -250,6 +287,15 @@ impl LlmClient {
                     .map_err(|e| CraneError::ModelError(e.to_string()))?;
                 (input_ids, StreamTokenizer::Auto(tokenizer.clone()))
             }
+            LoadedModel::Qwen35 { tokenizer, model } => {
+                let prompt = tokenizer
+                    .apply_chat_template(messages, true)
+                    .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
+                let input_ids = model
+                    .prepare_inputs(&prompt)
+                    .map_err(|e| CraneError::ModelError(e.to_string()))?;
+                (input_ids, StreamTokenizer::Auto(tokenizer.clone()))
+            }
             LoadedModel::HunyuanDense { model } => {
                 gen_config.eos_token_id = gen_config.eos_token_id.or(Some(120020));
                 let prompt = hunyuan_apply_chat_template(messages);
@@ -270,6 +316,7 @@ impl LlmClient {
             let gen_handle = scope.spawn(|| match &mut self.model {
                 LoadedModel::Qwen25 { model, .. } => model.generate(&input_ids, &gen_config, Some(&mut streamer)),
                 LoadedModel::Qwen3 { model, .. } => model.generate(&input_ids, &gen_config, Some(&mut streamer)),
+                LoadedModel::Qwen35 { model, .. } => model.generate(&input_ids, &gen_config, Some(&mut streamer)),
                 LoadedModel::HunyuanDense { model } => model.generate(&input_ids, &gen_config, Some(&mut streamer)),
             });
 

--- a/crane/src/llm/types.rs
+++ b/crane/src/llm/types.rs
@@ -44,6 +44,7 @@ impl GenerationConfig {
 pub enum LlmModelType {
     Qwen25,
     Qwen3,
+    Qwen35,
     Qwen3VL,
     DeepSeek,
     HunyuanDense,

--- a/example/README.md
+++ b/example/README.md
@@ -105,6 +105,6 @@ The Crane SDK provides a high-level interface for various AI capabilities:
 - **Audio**: ASR, TTS (with ONNX feature)
 - **Multimodal**: Vision-language models
 
-For API server usage (OpenAI / SGLang compatible), see [crane-oai/README.md](../crane-oai/README.md).
+For API server usage (OpenAI / SGLang compatible), see [crane-serve/README.md](../crane-serve/README.md).
 
 For more advanced usage, check the documentation in the main `crane` crate.

--- a/example/src/chat_simple.rs
+++ b/example/src/chat_simple.rs
@@ -7,22 +7,34 @@ use crane::llm::{GenerationConfig, LlmModelType};
 use crane::prelude::*;
 
 fn main() -> CraneResult<()> {
-    // Create a simple chat configuration
+    // Create a simple chat configuration.
+    //
+    // Qwen 3.5 (hybrid Gated Delta Net + attention) runs on CPU/CUDA/Metal.
+    // Picks the best available target: CUDA (F16) when built `--features cuda`,
+    // Metal (F16) on macOS, otherwise CPU (F32).
+    #[cfg(feature = "cuda")]
+    let (device, dtype) = (DeviceConfig::Cuda(0), DataType::F16);
+    #[cfg(all(not(feature = "cuda"), target_os = "macos"))]
+    let (device, dtype) = (DeviceConfig::Metal, DataType::F16);
+    #[cfg(all(not(feature = "cuda"), not(target_os = "macos")))]
+    let (device, dtype) = (DeviceConfig::Cpu, DataType::F32);
+
     let config = ChatConfig {
         common: CommonConfig {
-            model_path: "checkpoints/Qwen3-0.6B-Instruct".to_string(), // Update this path to your model
-            model_type: LlmModelType::Qwen3,
-            device: DeviceConfig::Metal, // Use DeviceConfig::Cuda(0) for GPU
-            dtype: DataType::F16,
+            // Update this path to your local Qwen 3.5 checkpoint.
+            model_path: "checkpoints/Qwen3.5-0.8B".to_string(),
+            model_type: LlmModelType::Qwen35,
+            device,
+            dtype,
             max_memory: None,
         },
         generation: GenerationConfig {
-            max_new_tokens: 100, // Keep responses short for demo
+            max_new_tokens: 128,
             temperature: Some(0.7),
             ..Default::default()
         },
         max_history_turns: 4,
-        enable_streaming: true, // Enable streaming for real-time responses
+        enable_streaming: true,
     };
 
     // Create a new chat client


### PR DESCRIPTION
Ports Qwen 3.5 (hybrid Mamba/Transformer: Gated Delta Net linear attention
+ softmax attention) into Crane on CPU, NVIDIA CUDA, and Apple Metal. Verified end-to-end against Qwen3.5-0.8B — prefill argmax matches HF Transformers bit-exactly in f32/f16/bf16 (token 283 " =" on a 512-token prefill) and generation is coherent. CUDA additionally pulls in a fused single-launch recurrence kernel; CPU and Metal use a device-portable op-by-op path. Set CRANE_GDN_PORTABLE=1 to force the portable path on CUDA for cross-checking.

Backend wiring:
- ModelType::Qwen3_5 added to model_factory (auto-detect from model_type=qwen3_5 / qwen3.5 in config.json or architectures containing Qwen3_5).
- Qwen3_5Backend wrapping crane_core::models::qwen3_5::Model, mirroring the qwen3 backend.
- crane-core/src/gdn: Gated Delta Net module (backend, cache, config, cuda_backend, layer, mod, norm, projection) — device-portable recurrence, causal Conv1D, gated RMSNorm, projection helpers.
- Qwen3_5TextModel + Model wrapper: text-only transformer with hybrid full-attention + linear-attention stack; MRoPE-interleaved rotary, gated softmax attention (q_proj split per-head, attn_output_gate honored); per-layer GDN and K/V caches.
- Per-layer K/V cache for full-attention blocks (mirrors qwen3's pre-allocated buffer + slice_set), so incremental decode (one token per step) is correct and ~23x faster than full-recompute on CPU.
- chat_simple example points at Qwen 3.5 with relative checkpoints/Qwen3.5-0.8B path.
- Model exposed through the high-level SDK (LlmModelType::Qwen35, LoadedModel::Qwen35).

Numerics: prefill output is bit-exact vs HF (cos=1.0 across all 24 layers). Three device-independent bugs had to be fixed during the port: (1) Qwen 3.5's RMSNorm scales by (1 + weight) (Gemma-style), not weight — candle's plain RmsNorm shrank every normalized activation ~5x and compounded across layers; (2) the GDN query scale query *= 1/sqrt(K) inside the recurrence — without it, recurrence output is sqrt(K) too large and not washed out downstream; (3) full-attention q/gate split per head (view-per-head then chunk(2,-1)), not on the flat axis, otherwise q_norm gets scrambled. Partial-rotary MRoPE rotates only the first rot_dim components, matching HF's apply_rotary_pos_emb. Causal mask is auto-built during prefill when the caller doesn't supply one.

Build fixes (transitive): three pre-existing Device::Cuda(ref dev) patterns (qwen3, gemma4, hunyuan_dense) that the current nightly rejects as hard errors under the 2024 edition.

CUDA kernel (crane-core/kernels/gdn.cu): one thread block per (batch*value-head), one thread per value column. Each thread owns its state column S[:,vcol] across the sequence and steps through time with k_t/q_t staged in shared memory. State is read once at entry and written once at exit. f32 throughout; launcher upcasts f16/bf16 inputs and casts the result back. head_k_dim <= 256 (0.8B/4B use 128); larger falls back to the portable path. Verified on RTX 3090: bit-identical logits to the portable path (same argmax + top-k), ~1.8x faster 512-token prefill wall-clock (3x on the recurrence itself), and the gap widens with context length.

README  updated with the new model and the implementation notes (GDN Q-scale, causal mask, hybrid cache management, gated RMSNorm ordering, unit-offset RMSNorm). Stale crane-oai references in the README/AGENTS replaced with crane-serve.

The qwen3_5 backend caps max_concurrent=1 since KV swap and batch decode aren't implemented yet (hybrid layer types complicate a generic GPU-batched implementation).