### PR TITLE
 Qwen3.5 / Ornith: CUDA kernel opt, K/V cache quant, tool-calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A high-performance inference framework leveraging Rust's Candle for maximum spee
 
 - [x] Qwen3 (0.6B ~ 30B+)
 - [x] Qwen 2.5 (0.5B ~ 72B)
+- [x] Qwen 3.5 (0.8B; hybrid Gated Delta Net + softmax attention, CPU/CUDA/Metal)
 - [x] Hunyuan Dense
 - [x] Gemma 4 (text and vision; no audio)
 - [x] Qwen3 VL (2B, 4B)
@@ -56,8 +57,10 @@ We include:
 
 ## 🔥 Updates
 
+- **`2026.06.30`**: 🚀 Qwen 3.5 / Ornith follow-up — K=128 register-resident CUDA recurrence kernel (~5× prefill, ~7.8× recurrence-only on RTX 3090), per-token int8 / int4 K/V cache backends (~2× / ~4× smaller via `CRANE_KV_QUANT`), and Ornith tool-calling support (HF-byte-identical chat template via `AutoTokenizer::apply_chat_template_with_tools`, end-to-end `ornith_tools` example).
+- **`2026.06.29`**: 🌀 Qwen 3.5 support — hybrid Mamba/Transformer (Gated Delta Net + softmax attention), runs on CPU, NVIDIA CUDA, and Apple Metal. New `crane-core/src/ops/gdn/` module with a fused CUDA recurrence kernel for the linear-attention path.
 - **`2026.05.04`**: Gemma 4 support added for text and vision models (audio is not supported);
-- **`2026.02.23`**: 🎙️ Qwen3-TTS support added — full Talker + Code Predictor transformer in Candle, native speech-tokenizer decoder (ONNX fallback), voice cloning (Base model ICL), OpenAI `/v1/audio/speech` endpoint in crane-oai;
+- **`2026.02.23`**: 🎙️ Qwen3-TTS support added — full Talker + Code Predictor transformer in Candle, native speech-tokenizer decoder (ONNX fallback), voice cloning (Base model ICL), OpenAI `/v1/audio/speech` endpoint in crane-serve;
 - **`2026.02.18`**: ⚡ Qwen3 & Hunyuan Dense inference optimization: pre-allocated KV cache, GQA 4D matmul, fused RoPE with cache pre-growth, GGUF quantization, batched decode, smart sampling fallback for large vocabularies;
 - **`2026.01.30`**: PaddleOCR-VL-1.5 supported now! model: https://huggingface.co/PaddlePaddle/PaddleOCR-VL-1.5/;
 - **`2025.03.21`**: 🔥 Qwen2.5 a more transformers liked Rust interface were supported, you now use Crane just like in your python;
@@ -181,7 +184,7 @@ To use `crane`, here are some notes:
 
 - `crane-core`: All models comes into core, this is a lib;
 - `crane`: All Apps (runnable AI pipelines, such as Qwen2-Chat, Spark-TTS, Qwen2.5-VL etc), you can build your apps inside it, each app is a binary for demonstration purpose;
-- `crane-oai`: OpenAI & SGLang compatible API server with continuous batching, see [crane-oai/README.md](crane-oai/README.md) for full documentation;
+- `crane-serve`: OpenAI & SGLang compatible API server with continuous batching, see [crane-serve/README.md](crane-serve/README.md) for full documentation;
 
 1. Make sure latest Rust were installed;
 2. Build (choose based on your hardware):
@@ -203,15 +206,15 @@ Start a server compatible with OpenAI SDK and SGLang client:
 ```bash
 # Build
 # CPU
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 # CUDA
-cargo build -p crane-oai --release --features cuda
+cargo build -p crane-serve --release --features cuda
 
 # Start (auto-detect model type and device)
-./target/release/crane-oai --model-path /path/to/Qwen2.5-7B-Instruct
+./target/release/crane --model-path /path/to/Qwen2.5-7B-Instruct
 
 # Or run directly
-cargo run -p crane-oai --release -- --model-path /path/to/model --port 8000
+cargo run -p crane-serve --release -- --model-path /path/to/model --port 8000
 ```
 
 Then use it with any OpenAI-compatible client:
@@ -244,7 +247,7 @@ Supported endpoints:
 | Mgmt   | `GET /health` | Health check |
 | Mgmt   | `GET /v1/stats` | Engine statistics |
 
-✨ **Text-to-Speech (Qwen3-TTS)**: For TTS models, the server adds a `/v1/audio/speech` endpoint (OpenAI-compatible). Both **CustomVoice** (predefined speakers) and **Base** (voice cloning via reference audio) models are supported. `response_format` currently supports `wav` and `pcm` (other formats return `400`). See [crane-oai/README.md](crane-oai/README.md) for full TTS API documentation.
+✨ **Text-to-Speech (Qwen3-TTS)**: For TTS models, the server adds a `/v1/audio/speech` endpoint (OpenAI-compatible). Both **CustomVoice** (predefined speakers) and **Base** (voice cloning via reference audio) models are supported. `response_format` currently supports `wav` and `pcm` (other formats return `400`). See [crane-serve/README.md](crane-serve/README.md) for full TTS API documentation.
 
 ### TTS Examples
 
@@ -266,7 +269,7 @@ All TTS examples save generated audio files to `data/audio/output`.
 - Base (voice clone): [vc1_base.wav](data/audio/output/vc1_base.wav), [vc2_base.wav](data/audio/output/vc2_base.wav)
 - CustomVoice: [custom_voice_zh.wav](data/audio/output/custom_voice_zh.wav), [custom_voice_en.wav](data/audio/output/custom_voice_en.wav), [custom_voice_ja.wav](data/audio/output/custom_voice_ja.wav)
 
-✨ **Multimodal & Vision support**: For models like PaddleOCR-VL, the endpoints accept OpenAI's structured `messages.[]content.[{type: "image_url", image_url: {url: "..."}}]` payload or SGLang's `image_url` field. See [crane-oai/README.md](crane-oai/README.md) for full API documentation with request/response examples.
+✨ **Multimodal & Vision support**: For models like PaddleOCR-VL, the endpoints accept OpenAI's structured `messages.[]content.[{type: "image_url", image_url: {url: "..."}}]` payload or SGLang's `image_url` field. See [crane-serve/README.md](crane-serve/README.md) for full API documentation with request/response examples.
 
 Now you can run LLM extremly fast (about 6x faster than vanilla transformers on M1)!
 
@@ -275,9 +278,14 @@ Now you can run LLM extremly fast (about 6x faster than vanilla transformers on 
 ```
 Crane/
 ├── crane-core/          # Core library: model implementations, tokenizer, generation
-│   └── src/models/      # Model architectures (Qwen 2.5, Qwen 3, Hunyuan, etc.)
+<<<<<<< HEAD
+│   └── src/models/      # Model architectures (Qwen 2.5, Qwen 3, Qwen 3.5, Hunyuan, etc.)
+=======
+│   ├── src/models/      # Model architectures (Qwen 2.5, Qwen 3, Qwen 3.5, Hunyuan, etc.)
+│   └── src/ops/gdn/     # Gated Delta Net (Qwen 3.5 linear-attention path) + fused CUDA kernel
+>>>>>>> 495f6b1 (fixup! Add Qwen 3.5 hybrid GDN/attention support)
 ├── crane/               # High-level SDK: Chat, Vision, Audio, Multimodal clients
-├── crane-oai/           # OpenAI & SGLang compatible API server
+├── crane-serve/         # OpenAI & SGLang compatible API server
 │   └── src/
 │       ├── engine/      # Continuous batching inference engine
 │       ├── handlers/    # HTTP request handlers (OpenAI, SGLang, common)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A high-performance inference framework leveraging Rust's Candle for maximum spee
 
 - [x] Qwen3 (0.6B ~ 30B+)
 - [x] Qwen 2.5 (0.5B ~ 72B)
-- [x] Qwen 3.5 (0.8B; hybrid Gated Delta Net + softmax attention, CPU/CUDA/Metal)
+- [x] Qwen 3.5 (0.8B; hybrid Gated Delta Net + softmax attention, CPU/CUDA/Metal) + Ornith-1.0-9B (agentic, tool calling)
 - [x] Hunyuan Dense
 - [x] Gemma 4 (text and vision; no audio)
 - [x] Qwen3 VL (2B, 4B)
@@ -269,6 +269,64 @@ All TTS examples save generated audio files to `data/audio/output`.
 - Base (voice clone): [vc1_base.wav](data/audio/output/vc1_base.wav), [vc2_base.wav](data/audio/output/vc2_base.wav)
 - CustomVoice: [custom_voice_zh.wav](data/audio/output/custom_voice_zh.wav), [custom_voice_en.wav](data/audio/output/custom_voice_en.wav), [custom_voice_ja.wav](data/audio/output/custom_voice_ja.wav)
 
+### Qwen 3.5 / Ornith (hybrid Gated Delta Net + softmax attention)
+
+Qwen 3.5 is a hybrid architecture: most layers are Gated Delta Net linear
+attention (recurrent, constant-size state per layer), every 4th layer is
+softmax attention (cumulative K/V cache). On RTX 3090 with `Qwen3.5-0.8B`,
+prefill argmax matches HuggingFace Transformers bit-exactly in f32/f16/bf16
+(`token 283 " ="` on a 512-token prefill); decoding is coherent on CPU,
+CUDA, and Metal.
+
+**Run:**
+
+```bash
+cargo run --bin chat_simple --release   # auto-targets Qwen 3.5
+# Point chat_simple.rs at your local Qwen3.5-0.8B or Ornith-1.0-9B path
+```
+
+**Tool calling (Ornith-1.0-9B):** Ornith is an agentic variant of the
+Qwen3.5 architecture with a `# Tools` system block and a `<tool_call>…/tool`
+turn protocol. `AutoTokenizer::apply_chat_template_with_tools` renders this
+with byte-identical output to HuggingFace's tokenizer (Python-style
+`tojson`, `raise_exception`, `serde_json` with `preserve_order`).
+See `example/src/ornith_tools.rs` for an end-to-end agentic loop
+(reason → tool_call → run tool → tool turn → answer):
+
+```bash
+cargo run -p crane-examples --bin ornith_tools --release --features cuda \
+  -- --model-path /path/to/Ornith-1.0-9B
+# or:  MODEL_PATH=/path/to/Ornith-1.0-9B cargo run --bin ornith_tools ...
+```
+
+**K/V cache compression (CUDA):** the full-attention K/V cache dominates
+memory at long context (the GDN layers carry a constant recurrent state).
+Pick the representation per-model-load via `CRANE_KV_QUANT`:
+
+| `CRANE_KV_QUANT` | Storage              | vs fp16 | Notes                                    |
+|------------------|----------------------|--------:|------------------------------------------|
+| unset (default)  | fp16 / bf16          |    1.0× | lossless                                 |
+| `int8`           | per-token symmetric  |  ~0.56× | ~2× smaller, dequantized on read         |
+| `int4`           | nibble-packed        |  ~0.31× | ~4× smaller; requires even `head_dim`    |
+
+Measured at 4 K tokens, full-attention K+V across all layers of the
+Qwen3.5-0.8B architecture (24 layers, full-attention every 4th). At
+Ornith-9B's full 262K-token window, int4 is what lets a single agent
+hold the whole window locally on a 24 GB GPU.
+
+**Other toggles:**
+
+- `CRANE_GDN_PORTABLE=1` — force the op-by-op GDN recurrence path on CUDA
+  instead of the fused kernel (cross-check numerics).
+- `CRANE_FULL_RECOMPUTE=1` — force the O(n²) reset-and-reprocess decode
+  path (debugging cross-check for the incremental path).
+- `cargo run -p crane-core --release --features cuda --bin gdn_bench` —
+  micro-benchmark for the fused GDN recurrence in isolation.
+
+**Limitation:** the Qwen 3.5 backend caps `max_concurrent=1` — KV swap
+and batched decode aren't implemented yet (hybrid layer types complicate
+a generic GPU-batched implementation).
+
 ✨ **Multimodal & Vision support**: For models like PaddleOCR-VL, the endpoints accept OpenAI's structured `messages.[]content.[{type: "image_url", image_url: {url: "..."}}]` payload or SGLang's `image_url` field. See [crane-serve/README.md](crane-serve/README.md) for full API documentation with request/response examples.
 
 Now you can run LLM extremly fast (about 6x faster than vanilla transformers on M1)!
@@ -278,12 +336,8 @@ Now you can run LLM extremly fast (about 6x faster than vanilla transformers on 
 ```
 Crane/
 ├── crane-core/          # Core library: model implementations, tokenizer, generation
-<<<<<<< HEAD
-│   └── src/models/      # Model architectures (Qwen 2.5, Qwen 3, Qwen 3.5, Hunyuan, etc.)
-=======
 │   ├── src/models/      # Model architectures (Qwen 2.5, Qwen 3, Qwen 3.5, Hunyuan, etc.)
 │   └── src/ops/gdn/     # Gated Delta Net (Qwen 3.5 linear-attention path) + fused CUDA kernel
->>>>>>> 495f6b1 (fixup! Add Qwen 3.5 hybrid GDN/attention support)
 ├── crane/               # High-level SDK: Chat, Vision, Audio, Multimodal clients
 ├── crane-serve/         # OpenAI & SGLang compatible API server
 │   └── src/
@@ -292,7 +346,7 @@ Crane/
 │       ├── openai_api.rs # OpenAI request/response types
 │       ├── sglang_api.rs # SGLang API types
 │       └── main.rs      # CLI entry point & router
-├── example/             # Example binaries (chat, ASR, vision, OCR, TTS)
+├── example/             # Example binaries (chat, ASR, vision, OCR, TTS, ornith_tools)
 ├── vendor/              # Vendored references (llama.cpp, sglang, vllm)
 └── scripts/             # Utility scripts
 ```
@@ -316,9 +370,10 @@ One can reference to `crane-core/src/models/namo2.rs` for new arch add, which us
 
 ## ⚡ Inference Optimizations
 
-Crane implements production-grade inference optimizations for both **Qwen3** and **Hunyuan Dense**.
+Crane implements production-grade inference optimizations for **Qwen3**,
+**Hunyuan Dense**, and **Qwen 3.5 / Ornith**.
 
-Environment variables for tuning:
+Sampling-related environment variables:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -326,6 +381,17 @@ Environment variables for tuning:
 | `CRANE_TOPP_FALLBACK_TOPK` | `64` | Top-k size when top_p is active and GPU path is used |
 | `CRANE_TOPK_SAMPLE_ON_CPU` | `0` | Force CPU sampling after GPU topk |
 | `CRANE_SAMPLE_TRACE` | `0` | Enable detailed sampling timing logs |
+
+Qwen 3.5 / Ornith environment variables (see the
+[Qwen 3.5 / Ornith section](#qwen-35--ornith-hybrid-gated-delta-net--softmax-attention)
+above for context):
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CRANE_GDN_PORTABLE` | unset | Force the portable op-by-op GDN recurrence path on CUDA (skip the fused kernel) |
+| `CRANE_KV_QUANT` | unset | K/V cache representation: `int8` (≈2× smaller) or `int4` (≈4× smaller); unset = fp |
+| `CRANE_FULL_RECOMPUTE` | unset | Force the O(n²) reset-and-reprocess decode path (debugging cross-check) |
+| `CRANE_GDN_VTILE` | unset | V-column tile size for the fused CUDA GDN kernel (advanced tuning) |
 
 ## ⚡️ Speed
 

--- a/crane-core/Cargo.toml
+++ b/crane-core/Cargo.toml
@@ -6,6 +6,11 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+# CUDA-only micro-benchmark for the fused GDN recurrence kernel.
+[[bin]]
+name = "gdn_bench"
+required-features = ["cuda"]
+
 [dependencies]
 anyhow = "1.0.97"
 
@@ -14,10 +19,12 @@ candle-transformers = { workspace = true }
 candle-onnx = { workspace = true, optional = true }
 clap = { version = "4.5.32", features = ["derive"] }
 hf-hub = "0.5.0"
-minijinja = { version = "2.15.1", features = ["builtins"] }
+minijinja = { version = "2.15.1", features = ["builtins", "preserve_order"] }
 minijinja-contrib = { version = "2.15.1", features = ["pycompat"] }
 serde = "1.0.219"
-serde_json = "1.0.140"
+# preserve_order: JSON object keys keep insertion order (matches Python's
+# json.dumps / HF chat templates — needed for byte-identical tool rendering).
+serde_json = { version = "1.0.140", features = ["preserve_order"] }
 tokenizers = "0.23.1"
 ribo = "0.1.3"
 

--- a/crane-core/kernels/gdn.cu
+++ b/crane-core/kernels/gdn.cu
@@ -1,9 +1,22 @@
 // Fused Gated Delta Net recurrence (CUDA), f32.
 //
-// One thread block per (batch * value-head); one thread per value column.
-// Each thread owns state column S[:, vcol] (K elements) in a per-thread array,
-// and steps through the whole sequence — collapsing the per-timestep Candle op
+// Each value column of each (batch*head) is an INDEPENDENT sequential
+// recurrence (no coupling across V). One thread owns its state column
+// S[:, vcol] (K elements) and steps through the whole sequence, staging
+// k_t/q_t in shared memory per step. This collapses the per-timestep Candle op
 // graph (thousands of tiny launches) into a single kernel launch.
+//
+// Two variants:
+//   * gdn_recurrence_f32_k<K>  — K is a compile-time constant, so the state
+//     column lives in REGISTERS (fully unrolled). Used for the common head
+//     dims (128). This is the fast path: the inner loop is the serial
+//     bottleneck and registers remove the local-memory traffic.
+//   * gdn_recurrence_f32       — runtime K fallback (state column in local
+//     memory) for head dims without a specialization.
+//
+// V columns may be tiled across blocks (V_TILE) but for these shapes one block
+// per head (V_TILE == V, ~4 warps) hides latency best, so the launcher defaults
+// there; the tiling knob is kept for other shapes.
 //
 // Layouts (all contiguous, f32):
 //   q, k     : [BH, S, K]   (q already pre-scaled by 1/sqrt(K) by the caller)
@@ -22,7 +35,9 @@
 
 #define GDN_MAX_K 256
 
-extern "C" __global__ void gdn_recurrence_f32(
+// Shared logic; K is either a compile-time constant (registers) or runtime.
+template <int KT>
+__device__ __forceinline__ void gdn_run(
     const float* __restrict__ q,
     const float* __restrict__ k,
     const float* __restrict__ v,
@@ -31,18 +46,23 @@ extern "C" __global__ void gdn_recurrence_f32(
     const float* __restrict__ state_in,
     float* __restrict__ state_out,
     float* __restrict__ y,
-    int BH, int S, int K, int V)
+    int BH, int S, int Kr, int V, int V_TILE)
 {
-    const int bh = blockIdx.x;
-    const int vcol = threadIdx.x;
-    if (bh >= BH || vcol >= V) return;
+    const int K = (KT > 0) ? KT : Kr;
+    const int tiles = (V + V_TILE - 1) / V_TILE;
+    const int bh = blockIdx.x / tiles;
+    const int tile = blockIdx.x % tiles;
+    const int vcol = tile * V_TILE + threadIdx.x;
+    if (bh >= BH) return;
+    const bool active = vcol < V;
 
-    // Per-thread state column S[:, vcol].
-    float Scol[GDN_MAX_K];
+    float Scol[(KT > 0) ? KT : GDN_MAX_K];
     const float* st_in = state_in + (long long)bh * K * V;
-    for (int kk = 0; kk < K; ++kk) Scol[kk] = st_in[kk * V + vcol];
+    if (active) {
+        #pragma unroll
+        for (int kk = 0; kk < K; ++kk) Scol[kk] = st_in[kk * V + vcol];
+    }
 
-    // Shared k_t / q_t for the current timestep (2*K floats).
     extern __shared__ float sh[];
     float* k_sh = sh;
     float* q_sh = sh + K;
@@ -61,28 +81,67 @@ extern "C" __global__ void gdn_recurrence_f32(
         }
         __syncthreads();
 
-        const float decay = expf(gb[t]);
-        const float beta_t = bb[t];
-        const float v_t = vb[t * V + vcol];
+        if (active) {
+            const float decay = expf(gb[t]);
+            const float beta_t = bb[t];
+            const float v_t = vb[t * V + vcol];
 
-        float kv_mem = 0.f;
-        #pragma unroll 4
-        for (int kk = 0; kk < K; ++kk) {
-            Scol[kk] *= decay;
-            kv_mem += Scol[kk] * k_sh[kk];
-        }
-        const float delta = (v_t - kv_mem) * beta_t;
+            // 4 independent accumulators break the 128-long reduction
+            // dependency chain (more ILP to hide FMA latency). Element-wise
+            // Scol updates are independent and stay in registers.
+            float kv0 = 0.f, kv1 = 0.f, kv2 = 0.f, kv3 = 0.f;
+            int kk = 0;
+            #pragma unroll
+            for (; kk + 3 < K; kk += 4) {
+                Scol[kk] *= decay;     kv0 += Scol[kk] * k_sh[kk];
+                Scol[kk + 1] *= decay; kv1 += Scol[kk + 1] * k_sh[kk + 1];
+                Scol[kk + 2] *= decay; kv2 += Scol[kk + 2] * k_sh[kk + 2];
+                Scol[kk + 3] *= decay; kv3 += Scol[kk + 3] * k_sh[kk + 3];
+            }
+            for (; kk < K; ++kk) { Scol[kk] *= decay; kv0 += Scol[kk] * k_sh[kk]; }
+            const float kv_mem = (kv0 + kv1) + (kv2 + kv3);
+            const float delta = (v_t - kv_mem) * beta_t;
 
-        float y_t = 0.f;
-        #pragma unroll 4
-        for (int kk = 0; kk < K; ++kk) {
-            Scol[kk] += k_sh[kk] * delta;
-            y_t += Scol[kk] * q_sh[kk];
+            float y0 = 0.f, y1 = 0.f, y2 = 0.f, y3 = 0.f;
+            kk = 0;
+            #pragma unroll
+            for (; kk + 3 < K; kk += 4) {
+                Scol[kk] += k_sh[kk] * delta;         y0 += Scol[kk] * q_sh[kk];
+                Scol[kk + 1] += k_sh[kk + 1] * delta; y1 += Scol[kk + 1] * q_sh[kk + 1];
+                Scol[kk + 2] += k_sh[kk + 2] * delta; y2 += Scol[kk + 2] * q_sh[kk + 2];
+                Scol[kk + 3] += k_sh[kk + 3] * delta; y3 += Scol[kk + 3] * q_sh[kk + 3];
+            }
+            for (; kk < K; ++kk) { Scol[kk] += k_sh[kk] * delta; y0 += Scol[kk] * q_sh[kk]; }
+            yb[t * V + vcol] = (y0 + y1) + (y2 + y3);
         }
-        yb[t * V + vcol] = y_t;
         __syncthreads();
     }
 
-    float* st_out = state_out + (long long)bh * K * V;
-    for (int kk = 0; kk < K; ++kk) st_out[kk * V + vcol] = Scol[kk];
+    if (active) {
+        float* st_out = state_out + (long long)bh * K * V;
+        #pragma unroll
+        for (int kk = 0; kk < K; ++kk) st_out[kk * V + vcol] = Scol[kk];
+    }
+}
+
+// Compile-time-K fast path: state column in registers.
+extern "C" __global__ void gdn_recurrence_f32_k128(
+    const float* __restrict__ q, const float* __restrict__ k,
+    const float* __restrict__ v, const float* __restrict__ g,
+    const float* __restrict__ beta, const float* __restrict__ state_in,
+    float* __restrict__ state_out, float* __restrict__ y,
+    int BH, int S, int V, int V_TILE)
+{
+    gdn_run<128>(q, k, v, g, beta, state_in, state_out, y, BH, S, 128, V, V_TILE);
+}
+
+// Runtime-K fallback: state column in local memory.
+extern "C" __global__ void gdn_recurrence_f32(
+    const float* __restrict__ q, const float* __restrict__ k,
+    const float* __restrict__ v, const float* __restrict__ g,
+    const float* __restrict__ beta, const float* __restrict__ state_in,
+    float* __restrict__ state_out, float* __restrict__ y,
+    int BH, int S, int K, int V, int V_TILE)
+{
+    gdn_run<0>(q, k, v, g, beta, state_in, state_out, y, BH, S, K, V, V_TILE);
 }

--- a/crane-core/kernels/gdn.cu
+++ b/crane-core/kernels/gdn.cu
@@ -1,0 +1,88 @@
+// Fused Gated Delta Net recurrence (CUDA), f32.
+//
+// One thread block per (batch * value-head); one thread per value column.
+// Each thread owns state column S[:, vcol] (K elements) in a per-thread array,
+// and steps through the whole sequence — collapsing the per-timestep Candle op
+// graph (thousands of tiny launches) into a single kernel launch.
+//
+// Layouts (all contiguous, f32):
+//   q, k     : [BH, S, K]   (q already pre-scaled by 1/sqrt(K) by the caller)
+//   v, y     : [BH, S, V]
+//   g, beta  : [BH, S]      (g is the log-decay; decay = exp(g))
+//   state    : [BH, K, V]   (state_in read once, state_out written once)
+//
+// Recurrence per timestep t (matches the CPU reference exactly):
+//   S      *= exp(g_t)
+//   kv_mem  = sum_k S[k,:] * k_t[k]
+//   delta   = (v_t - kv_mem) * beta_t
+//   S[k,:] += k_t[k] * delta
+//   y_t     = sum_k S[k,:] * q_t[k]
+
+#include <cuda_runtime.h>
+
+#define GDN_MAX_K 256
+
+extern "C" __global__ void gdn_recurrence_f32(
+    const float* __restrict__ q,
+    const float* __restrict__ k,
+    const float* __restrict__ v,
+    const float* __restrict__ g,
+    const float* __restrict__ beta,
+    const float* __restrict__ state_in,
+    float* __restrict__ state_out,
+    float* __restrict__ y,
+    int BH, int S, int K, int V)
+{
+    const int bh = blockIdx.x;
+    const int vcol = threadIdx.x;
+    if (bh >= BH || vcol >= V) return;
+
+    // Per-thread state column S[:, vcol].
+    float Scol[GDN_MAX_K];
+    const float* st_in = state_in + (long long)bh * K * V;
+    for (int kk = 0; kk < K; ++kk) Scol[kk] = st_in[kk * V + vcol];
+
+    // Shared k_t / q_t for the current timestep (2*K floats).
+    extern __shared__ float sh[];
+    float* k_sh = sh;
+    float* q_sh = sh + K;
+
+    const float* qb = q + (long long)bh * S * K;
+    const float* kb = k + (long long)bh * S * K;
+    const float* vb = v + (long long)bh * S * V;
+    const float* gb = g + (long long)bh * S;
+    const float* bb = beta + (long long)bh * S;
+    float* yb = y + (long long)bh * S * V;
+
+    for (int t = 0; t < S; ++t) {
+        for (int kk = threadIdx.x; kk < K; kk += blockDim.x) {
+            k_sh[kk] = kb[t * K + kk];
+            q_sh[kk] = qb[t * K + kk];
+        }
+        __syncthreads();
+
+        const float decay = expf(gb[t]);
+        const float beta_t = bb[t];
+        const float v_t = vb[t * V + vcol];
+
+        float kv_mem = 0.f;
+        #pragma unroll 4
+        for (int kk = 0; kk < K; ++kk) {
+            Scol[kk] *= decay;
+            kv_mem += Scol[kk] * k_sh[kk];
+        }
+        const float delta = (v_t - kv_mem) * beta_t;
+
+        float y_t = 0.f;
+        #pragma unroll 4
+        for (int kk = 0; kk < K; ++kk) {
+            Scol[kk] += k_sh[kk] * delta;
+            y_t += Scol[kk] * q_sh[kk];
+        }
+        yb[t * V + vcol] = y_t;
+        __syncthreads();
+    }
+
+    float* st_out = state_out + (long long)bh * K * V;
+    for (int kk = 0; kk < K; ++kk) st_out[kk * V + vcol] = Scol[kk];
+}

--- a/crane-core/src/autotokenizer.rs
+++ b/crane-core/src/autotokenizer.rs
@@ -259,9 +259,22 @@ fn find_matching_paren(s: &str) -> Option<usize> {
 }
 
 impl AutoTokenizer {
+    /// Render the chat template for `messages` (no tools).
     pub fn apply_chat_template<S: serde::Serialize>(
         &self,
         ctx: S,
+        add_generation_prompt: bool,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        self.apply_chat_template_with_tools(ctx, Option::<&serde_json::Value>::None, add_generation_prompt)
+    }
+
+    /// Render the chat template for `messages`, exposing `tools` to the template
+    /// (OpenAI-style function specs). Needed for agentic models like Ornith
+    /// whose template emits a `# Tools` system block and `<tool_call>` format.
+    pub fn apply_chat_template_with_tools<S: serde::Serialize, T: serde::Serialize>(
+        &self,
+        ctx: S,
+        tools: Option<T>,
         add_generation_prompt: bool,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let template_str = self.config.chat_template.as_deref().ok_or_else(|| {
@@ -306,6 +319,48 @@ impl AutoTokenizer {
             }
         });
 
+        // HF chat templates call `raise_exception(msg)` to abort rendering on
+        // malformed input (e.g. Qwen/Ornith: "System message must be at the
+        // beginning."). Surface it as a render error with the template's message.
+        env.add_function("raise_exception", |msg: String| -> Result<String, minijinja::Error> {
+            Err(minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, msg))
+        });
+
+        // `tojson` (used by tool-calling templates, e.g. `tool | tojson`).
+        // minijinja's built-in needs the `json` feature AND uses compact
+        // separators; HF/Jinja2 emit Python `json.dumps` defaults — `", "` /
+        // `": "` — plus HTML-safe escaping. Match that for byte-parity.
+        env.add_filter("tojson", |v: minijinja::Value| -> Result<minijinja::Value, minijinja::Error> {
+            struct Py;
+            impl serde_json::ser::Formatter for Py {
+                fn begin_array_value<W: ?Sized + std::io::Write>(&mut self, w: &mut W, first: bool) -> std::io::Result<()> {
+                    if first { Ok(()) } else { w.write_all(b", ") }
+                }
+                fn begin_object_key<W: ?Sized + std::io::Write>(&mut self, w: &mut W, first: bool) -> std::io::Result<()> {
+                    if first { Ok(()) } else { w.write_all(b", ") }
+                }
+                fn begin_object_value<W: ?Sized + std::io::Write>(&mut self, w: &mut W) -> std::io::Result<()> {
+                    w.write_all(b": ")
+                }
+            }
+            let mut out = Vec::new();
+            let mut ser = serde_json::Serializer::with_formatter(&mut out, Py);
+            serde::Serialize::serialize(&v, &mut ser)
+                .map_err(|e| minijinja::Error::new(minijinja::ErrorKind::InvalidOperation, format!("tojson: {e}")))?;
+            let s = String::from_utf8(out).unwrap_or_default();
+            let mut rv = String::with_capacity(s.len());
+            for c in s.chars() {
+                match c {
+                    '<' => rv.push_str("\\u003c"),
+                    '>' => rv.push_str("\\u003e"),
+                    '&' => rv.push_str("\\u0026"),
+                    '\'' => rv.push_str("\\u0027"),
+                    _ => rv.push(c),
+                }
+            }
+            Ok(minijinja::Value::from_safe_string(rv))
+        });
+
         env.add_template("default", &template_str).unwrap();
         let tmpl = env.get_template("default").unwrap();
         let eos = if let Some(eos) = &self.config.eos_token {
@@ -343,6 +398,7 @@ impl AutoTokenizer {
 
         match tmpl.render(context! {
             messages=> ctx,
+            tools=> tools,
             unk_token=> *unk,
             pad_token=> *pad,
             bos_token=> *bos,

--- a/crane-core/src/bin/gdn_bench.rs
+++ b/crane-core/src/bin/gdn_bench.rs
@@ -1,0 +1,54 @@
+//! Micro-benchmark for the fused GDN recurrence CUDA kernel.
+//!
+//! Isolates the kernel from the rest of the model so kernel changes can be
+//! measured directly. Usage:
+//!   gdn_bench [BH] [S] [K] [V] [iters]
+//! Defaults model Qwen3.5-0.8B single-sequence prefill: BH=16 S=512 K=128 V=128.
+
+use candle_core::{DType, Device, Tensor};
+use crane_core::ops::gdn::gdn_recurrence_cuda;
+use std::time::Instant;
+
+fn arg(i: usize, default: usize) -> usize {
+    std::env::args()
+        .nth(i)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(default)
+}
+
+fn main() -> anyhow::Result<()> {
+    let bh = arg(1, 16);
+    let s = arg(2, 512);
+    let k = arg(3, 128);
+    let v = arg(4, 128);
+    let iters = arg(5, 100);
+
+    let dev = Device::new_cuda(0)?;
+    let q = Tensor::randn(0f32, 1.0, (bh, s, k), &dev)?;
+    let kt = Tensor::randn(0f32, 1.0, (bh, s, k), &dev)?;
+    let vt = Tensor::randn(0f32, 1.0, (bh, s, v), &dev)?;
+    // g: small negative log-decay; beta in (0,1).
+    let g = Tensor::randn(0f32, 1.0, (bh, s), &dev)?.affine(0.01, -0.05)?;
+    let beta = candle_nn::ops::sigmoid(&Tensor::randn(0f32, 1.0, (bh, s), &dev)?)?;
+    let state = Tensor::zeros((bh, k, v), DType::F32, &dev)?;
+
+    for _ in 0..10 {
+        let _ = gdn_recurrence_cuda(&q, &kt, &vt, &g, &beta, &state)?;
+    }
+    dev.synchronize()?;
+
+    let t = Instant::now();
+    for _ in 0..iters {
+        let (y, _st) = gdn_recurrence_cuda(&q, &kt, &vt, &g, &beta, &state)?;
+        std::hint::black_box(&y);
+    }
+    dev.synchronize()?;
+    let ms = t.elapsed().as_secs_f64() * 1000.0 / iters as f64;
+
+    // FLOPs: per timestep per (bh,v) column ~ 4*K (two fused loops). Total
+    // ~ bh * s * v * 4 * k.
+    let flops = (bh * s * v * 4 * k) as f64;
+    let gflops = flops / (ms / 1000.0) / 1e9;
+    println!("GDN recurrence  BH={bh} S={s} K={k} V={v}  ->  {ms:.3} ms/iter   ({gflops:.0} GFLOP/s)");
+    Ok(())
+}

--- a/crane-core/src/lib.rs
+++ b/crane-core/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! | Module | Purpose |
 //! |---|---|
-//! | [`ops`] | Custom CUDA kernels and other core ops |
+//! | [`ops`] | Custom CUDA kernels and other core ops (fused ops, Gated Delta Net) |
 //! | [`models`] | Transformer model implementations (Qwen3, HunyuanDense, Qwen2.5, multimodal) |
 //! | [`generation`] | Token generation utilities (sampling, stopping criteria, logit processors) |
 //! | [`autotokenizer`] | HuggingFace-compatible tokenizer loader |
@@ -19,7 +19,7 @@
 //! ## Feature flags
 //!
 //! | Flag | Effect |
-//! |---|---|
+//! |---|
 //! | `cuda` | Enable CUDA device and custom PTX kernels (requires CUDA toolkit) |
 //! | `accelerate` | Link against Apple Accelerate for CPU BLAS |
 //! | `mkl` | Link against Intel MKL for CPU BLAS |

--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -41,7 +41,7 @@ struct EventTrackingGuard;
 #[cfg(feature = "cuda")]
 impl EventTrackingGuard {
     fn disable(device: &candle_core::Device) -> Self {
-        if let candle_core::Device::Cuda(ref dev) = device {
+        if let candle_core::Device::Cuda(dev) = device {
             if dev.is_event_tracking() {
                 unsafe { dev.disable_event_tracking() };
             }

--- a/crane-core/src/models/hunyuan_dense/modeling.rs
+++ b/crane-core/src/models/hunyuan_dense/modeling.rs
@@ -172,7 +172,7 @@ struct EventTrackingGuard;
 #[cfg(feature = "cuda")]
 impl EventTrackingGuard {
     fn disable(device: &candle_core::Device) -> Self {
-        if let candle_core::Device::Cuda(ref dev) = device {
+        if let candle_core::Device::Cuda(dev) = device {
             if dev.is_event_tracking() {
                 unsafe { dev.disable_event_tracking() };
             }

--- a/crane-core/src/models/mod.rs
+++ b/crane-core/src/models/mod.rs
@@ -6,6 +6,7 @@ pub mod paddleocr_vl;
 pub mod qwen25;
 pub mod qwen25_vit;
 pub mod qwen3;
+pub mod qwen3_5;
 pub mod qwen3_tts;
 // pub mod qwen3_vl;
 pub mod gemma4;

--- a/crane-core/src/models/qwen3/modeling.rs
+++ b/crane-core/src/models/qwen3/modeling.rs
@@ -50,7 +50,7 @@ struct EventTrackingGuard;
 #[cfg(feature = "cuda")]
 impl EventTrackingGuard {
     fn disable(device: &candle_core::Device) -> Self {
-        if let candle_core::Device::Cuda(ref dev) = device {
+        if let candle_core::Device::Cuda(dev) = device {
             if dev.is_event_tracking() {
                 // Safety: we ensure sequential use of a single CUDA stream.
                 unsafe { dev.disable_event_tracking() };

--- a/crane-core/src/models/qwen3_5/config.rs
+++ b/crane-core/src/models/qwen3_5/config.rs
@@ -1,0 +1,195 @@
+//! HF-compatible config types for Qwen 3.5 text-only inference.
+//!
+//! Qwen 3.5 ships as `Qwen3_5ForConditionalGeneration` (multimodal class) but
+//! the dense text-only checkpoints have no vision weights — we deserialize the
+//! nested `text_config` and ignore the vision block when loading weights.
+
+use candle_core::Result;
+use serde::Deserialize;
+
+use crate::ops::gdn::{defaults, GdnConfig};
+
+/// Whether a transformer block at layer index `i` is full (softmax) attention
+/// or linear (Gated Delta Net) attention.
+///
+/// Layer indices run 0..num_hidden_layers. With `full_attention_interval = 4`
+/// the layout is `[linear, linear, linear, full, linear, linear, linear, full, …]`,
+/// so `full_attention_interval - 1` linear layers precede every full layer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerType {
+    FullAttention,
+    LinearAttention,
+}
+
+/// `RopeParameters` block nested under `text_config.rope_parameters` in HF
+/// `config.json`. `mrope_interleaved: true` is the Qwen 3.5 variant (vs the
+/// non-interleaved MRoPE used by Qwen 3 VL).
+#[derive(Debug, Clone, Deserialize)]
+pub struct RopeParameters {
+    #[serde(default = "defaults::rope_theta")]
+    pub rope_theta: f64,
+    #[serde(default)]
+    pub mrope_section: Vec<usize>,
+    #[serde(default = "defaults::partial_rotary_factor")]
+    pub partial_rotary_factor: f64,
+    /// Default false (i.e. standard MRoPE). Qwen 3.5 sets this to `true`.
+    #[serde(default)]
+    pub mrope_interleaved: bool,
+}
+
+/// Text-only model config. Mirrors HF's `text_config` block under
+/// `Qwen3_5ForConditionalGeneration`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TextConfig {
+    pub head_dim: usize,
+    pub vocab_size: usize,
+    pub hidden_size: usize,
+    pub intermediate_size: usize,
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub hidden_act: HiddenAct,
+    pub max_position_embeddings: usize,
+    pub rms_norm_eps: f64,
+    pub rope_parameters: RopeParameters,
+
+    // Hybrid-attention parameters.
+    #[serde(default = "defaults::full_attention_interval")]
+    pub full_attention_interval: usize,
+    #[serde(default = "defaults::conv_kernel")]
+    pub linear_conv_kernel_dim: usize,
+    pub linear_key_head_dim: usize,
+    pub linear_value_head_dim: usize,
+    pub linear_num_key_heads: usize,
+    pub linear_num_value_heads: usize,
+
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+
+    // Qwen 3.5 attention uses gated output (sigmoid gate on softmax attention).
+    #[serde(default = "default_true")]
+    pub attn_output_gate: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// Top-level config. `text_config` holds the language model; `vision_config`
+/// exists for the multimodal class but is ignored by the text-only path.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    pub text_config: TextConfig,
+    #[serde(default)]
+    pub vision_config: Option<serde_json::Value>,
+    #[serde(default)]
+    pub image_token_id: Option<u32>,
+    #[serde(default)]
+    pub video_token_id: Option<u32>,
+    #[serde(default)]
+    pub vision_start_token_id: Option<u32>,
+    #[serde(default)]
+    pub vision_end_token_id: Option<u32>,
+    #[serde(default)]
+    pub tie_word_embeddings: bool,
+}
+
+impl Config {
+    pub fn text(&self) -> &TextConfig {
+        &self.text_config
+    }
+}
+
+/// Hidden activation. Qwen 3.5 uses `silu` for the MLP.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum HiddenAct {
+    Silu,
+    #[serde(other)]
+    Other,
+}
+
+impl TextConfig {
+    pub fn rope_theta(&self) -> f64 {
+        self.rope_parameters.rope_theta
+    }
+
+    pub fn partial_rotary_factor(&self) -> f64 {
+        self.rope_parameters.partial_rotary_factor
+    }
+
+    pub fn mrope_section(&self) -> &[usize] {
+        &self.rope_parameters.mrope_section
+    }
+
+    pub fn mrope_interleaved(&self) -> bool {
+        self.rope_parameters.mrope_interleaved
+    }
+
+    /// `head_dim * partial_rotary_factor` — the slice of the head dim that
+    /// actually receives rotary embeddings.
+    pub fn rot_dim(&self) -> usize {
+        (self.head_dim as f64 * self.partial_rotary_factor()) as usize
+    }
+
+    /// Layer-type sequence, indexed by transformer-block position.
+    pub fn layer_types(&self) -> Vec<LayerType> {
+        (0..self.num_hidden_layers)
+            .map(|i| {
+                if (i + 1) % self.full_attention_interval == 0 {
+                    LayerType::FullAttention
+                } else {
+                    LayerType::LinearAttention
+                }
+            })
+            .collect()
+    }
+
+    pub fn linear_key_dim(&self) -> usize {
+        self.linear_num_key_heads * self.linear_key_head_dim
+    }
+
+    pub fn linear_value_dim(&self) -> usize {
+        self.linear_num_value_heads * self.linear_value_head_dim
+    }
+
+    pub fn linear_conv_dim(&self) -> usize {
+        2 * self.linear_key_dim() + self.linear_value_dim()
+    }
+}
+
+impl GdnConfig for TextConfig {
+    fn hidden_size(&self) -> usize {
+        self.hidden_size
+    }
+    fn rms_norm_eps(&self) -> f64 {
+        self.rms_norm_eps
+    }
+    fn linear_conv_kernel_dim(&self) -> usize {
+        self.linear_conv_kernel_dim
+    }
+    fn linear_key_head_dim(&self) -> usize {
+        self.linear_key_head_dim
+    }
+    fn linear_value_head_dim(&self) -> usize {
+        self.linear_value_head_dim
+    }
+    fn linear_num_key_heads(&self) -> usize {
+        self.linear_num_key_heads
+    }
+    fn linear_num_value_heads(&self) -> usize {
+        self.linear_num_value_heads
+    }
+}
+
+/// Load a HF `config.json` for a Qwen 3.5 (text-only) checkpoint.
+///
+/// Vision config is deserialized into a generic JSON value since the text path
+/// never reads it; the caller's responsibility is to gate vision processing.
+pub fn load_config(path: &str) -> Result<Config> {
+    let data = std::fs::read(path)
+        .map_err(|e| candle_core::Error::Msg(format!("read config {path}: {e}")))?;
+    let cfg: Config = serde_json::from_slice(&data)
+        .map_err(|e| candle_core::Error::Msg(format!("parse config {path}: {e}")))?;
+    Ok(cfg)
+}

--- a/crane-core/src/models/qwen3_5/kv_cache.rs
+++ b/crane-core/src/models/qwen3_5/kv_cache.rs
@@ -1,0 +1,125 @@
+//! K/V cache for the full-attention layers of Qwen 3.5.
+//!
+//! The hybrid model only needs this for the 1-in-4 full-attention blocks; the
+//! linear-attention (GDN) blocks carry a constant-size recurrent state instead
+//! (see [`crate::ops::gdn::GdnLayerCache`]), so the context-growing part of the
+//! cache lives in just these layers. At long context that K/V dominates memory,
+//! which is why quantizing it lets a single agent hold much more context
+//! locally (e.g. Ornith-9B's full 262K window on a 24 GB GPU).
+>>>>>>> 495f6b1 (fixup! Add Qwen 3.5 hybrid GDN/attention support)
+//!
+//! # The swap seam
+//!
+//! This is a lossless fp store. It is the single place a quantized K/V backend
+//! (e.g. rotation + scalar quant for long-context local setups) would slot in:
+//! a future variant only has to honor the same contract —
+//!
+//! - [`KvCache::append`] takes the new post-RoPE `k`/`v` for the current step
+//!   (`[B, num_kv_heads, S, head_dim]`) and returns the *full* `k`/`v` spanning
+//!   all cached positions, ready for attention.
+//! - [`KvCache::reset`] clears it between unrelated requests.
+//!
+//! Attention logic never touches the storage representation, so swapping fp for
+//! a quantized backend won't reach into the attention math.
+
+use candle_core::{Result, Tensor};
+
+/// Pre-allocated, append-in-place K/V cache for one full-attention layer.
+///
+/// Mirrors the `qwen3` model's cache: a buffer that may be larger than the
+/// filled length, written with `slice_set` (O(new tokens), not `cat`), grown
+/// with a small fixed headroom only when it overflows.
+#[derive(Debug)]
+pub struct KvCache {
+    /// `(k, v)` buffers of shape `[B, num_kv_heads, capacity, head_dim]`.
+    buffers: Option<(Tensor, Tensor)>,
+    /// Number of valid (filled) positions in the buffers.
+    seq_len: usize,
+}
+
+/// Headroom (in positions) added when (re)allocating, to amortize growth.
+const ROOM: usize = 256;
+
+impl Default for KvCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl KvCache {
+    pub fn new() -> Self {
+        Self {
+            buffers: None,
+            seq_len: 0,
+        }
+    }
+
+    /// Filled length (number of cached positions).
+    pub fn len(&self) -> usize {
+        self.seq_len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.seq_len == 0
+    }
+
+    /// Drop all cached state (between unrelated requests).
+    pub fn reset(&mut self) {
+        self.buffers = None;
+        self.seq_len = 0;
+    }
+
+    /// Append `k`/`v` for the current step and return the full cached `(k, v)`.
+    ///
+    /// `k`/`v` are `[B, num_kv_heads, S, head_dim]` (post-RoPE, pre-GQA-expand).
+    /// The returned tensors span `[B, num_kv_heads, seq_len + S, head_dim]`.
+    pub fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        let k = k.contiguous()?;
+        let v = v.contiguous()?;
+        let new_seq_len = k.dim(2)?;
+        let filled = self.seq_len;
+
+        match self.buffers.take() {
+            None => {
+                // First write — allocate with headroom.
+                let (b, h, s, d) = k.dims4()?;
+                let buf_k = Tensor::zeros((b, h, s + ROOM, d), k.dtype(), k.device())?;
+                let buf_v = Tensor::zeros((b, h, s + ROOM, d), v.dtype(), v.device())?;
+                buf_k.slice_set(&k, 2, 0)?;
+                buf_v.slice_set(&v, 2, 0)?;
+                self.buffers = Some((buf_k, buf_v));
+                self.seq_len = s;
+                Ok((k, v))
+            }
+            Some((buf_k, buf_v)) => {
+                let capacity = buf_k.dim(2)?;
+                let new_total = filled + new_seq_len;
+
+                if new_total <= capacity {
+                    // Fits — in-place write, O(new_seq_len).
+                    buf_k.slice_set(&k, 2, filled)?;
+                    buf_v.slice_set(&v, 2, filled)?;
+                    let k_view = buf_k.narrow(2, 0, new_total)?;
+                    let v_view = buf_v.narrow(2, 0, new_total)?;
+                    self.buffers = Some((buf_k, buf_v));
+                    self.seq_len = new_total;
+                    Ok((k_view, v_view))
+                } else {
+                    // Overflow — concat then reallocate with headroom.
+                    let cur_k = buf_k.narrow(2, 0, filled)?;
+                    let cur_v = buf_v.narrow(2, 0, filled)?;
+                    let full_k = Tensor::cat(&[&cur_k, &k], 2)?;
+                    let full_v = Tensor::cat(&[&cur_v, &v], 2)?;
+                    let (b, h, total, d) = full_k.dims4()?;
+                    let new_buf_k = Tensor::zeros((b, h, total + ROOM, d), k.dtype(), k.device())?;
+                    let new_buf_v = Tensor::zeros((b, h, total + ROOM, d), v.dtype(), v.device())?;
+                    new_buf_k.slice_set(&full_k, 2, 0)?;
+                    new_buf_v.slice_set(&full_v, 2, 0)?;
+                    self.buffers = Some((new_buf_k, new_buf_v));
+                    self.seq_len = total;
+                    Ok((full_k, full_v))
+                }
+            }
+        }
+    }
+}

--- a/crane-core/src/models/qwen3_5/kv_cache.rs
+++ b/crane-core/src/models/qwen3_5/kv_cache.rs
@@ -1,4 +1,4 @@
-//! K/V cache for the full-attention layers of Qwen 3.5.
+//! K/V cache for the full-attention layers of Qwen 3.5 / Ornith.
 //!
 //! The hybrid model only needs this for the 1-in-4 full-attention blocks; the
 //! linear-attention (GDN) blocks carry a constant-size recurrent state instead
@@ -6,120 +6,337 @@
 //! cache lives in just these layers. At long context that K/V dominates memory,
 //! which is why quantizing it lets a single agent hold much more context
 //! locally (e.g. Ornith-9B's full 262K window on a 24 GB GPU).
->>>>>>> 495f6b1 (fixup! Add Qwen 3.5 hybrid GDN/attention support)
 //!
-//! # The swap seam
+//! # Backends behind one contract
 //!
-//! This is a lossless fp store. It is the single place a quantized K/V backend
-//! (e.g. rotation + scalar quant for long-context local setups) would slot in:
-//! a future variant only has to honor the same contract —
+//! [`KvCacheBackend`] is the seam: a backend stores the cache however it likes
+//! but must, on [`append`](KvCacheBackend::append), take the new post-RoPE
+//! `k`/`v` (`[B, num_kv_heads, S, head_dim]`) and return the *full* `k`/`v`
+//! spanning all cached positions, **in the compute dtype**, ready for attention.
+//! Attention logic never sees the storage representation.
 //!
-//! - [`KvCache::append`] takes the new post-RoPE `k`/`v` for the current step
-//!   (`[B, num_kv_heads, S, head_dim]`) and returns the *full* `k`/`v` spanning
-//!   all cached positions, ready for attention.
-//! - [`KvCache::reset`] clears it between unrelated requests.
-//!
-//! Attention logic never touches the storage representation, so swapping fp for
-//! a quantized backend won't reach into the attention math.
+//! - [`FpKvCache`] — lossless f16/bf16 store (default).
+//! - [`Int8KvCache`] — per-token symmetric int8 (~2x smaller), dequantized to
+//!   the compute dtype on read.
+//! - Future: int4-packed (~4x), and rotation-based codecs (rotorquant-style)
+//!   for models whose usable window is much larger (≈1M tokens) where 2-3 bit
+//!   needs the rotation to stay accurate. Each is just another
+//!   `KvCacheBackend` + enum variant.
 
-use candle_core::{Result, Tensor};
-
-/// Pre-allocated, append-in-place K/V cache for one full-attention layer.
-///
-/// Mirrors the `qwen3` model's cache: a buffer that may be larger than the
-/// filled length, written with `slice_set` (O(new tokens), not `cat`), grown
-/// with a small fixed headroom only when it overflows.
-#[derive(Debug)]
-pub struct KvCache {
-    /// `(k, v)` buffers of shape `[B, num_kv_heads, capacity, head_dim]`.
-    buffers: Option<(Tensor, Tensor)>,
-    /// Number of valid (filled) positions in the buffers.
-    seq_len: usize,
-}
+use candle_core::{DType, Result, Tensor, D};
 
 /// Headroom (in positions) added when (re)allocating, to amortize growth.
 const ROOM: usize = 256;
 
-impl Default for KvCache {
-    fn default() -> Self {
-        Self::new()
+/// Contract every K/V cache backend honors. See the module docs.
+pub trait KvCacheBackend {
+    /// Append this step's `k`/`v` and return the full cached `(k, v)` in the
+    /// compute dtype (`[B, num_kv_heads, seq_len + S, head_dim]`).
+    fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)>;
+    /// Drop all cached state (between unrelated requests).
+    fn reset(&mut self);
+    /// Number of cached positions.
+    fn len(&self) -> usize;
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    /// Bytes currently allocated for this layer's K/V (incl. headroom + scales).
+    fn byte_size(&self) -> usize;
+}
+
+fn tensor_bytes(t: &Option<Tensor>) -> usize {
+    t.as_ref()
+        .map(|x| x.elem_count() * x.dtype().size_in_bytes())
+        .unwrap_or(0)
+}
+
+/// Which cache representation to use. Selected once per model load.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KvCacheKind {
+    /// Lossless f16/bf16.
+    Fp,
+    /// Per-token symmetric int8 (~2x smaller).
+    Int8,
+    /// Per-token symmetric int4, nibble-packed (~4x smaller).
+    Int4,
+}
+
+impl KvCacheKind {
+    /// Read from `CRANE_KV_QUANT` (`int8` → Int8, `int4` → Int4, else Fp).
+    pub fn from_env() -> Self {
+        match std::env::var("CRANE_KV_QUANT").as_deref() {
+            Ok("int8") => Self::Int8,
+            Ok("int4") => Self::Int4,
+            _ => Self::Fp,
+        }
     }
 }
 
+/// Per-layer K/V cache. A thin enum dispatcher over the concrete backends so
+/// `FullAttention` holds one type regardless of representation.
+#[derive(Debug)]
+pub enum KvCache {
+    Fp(FpKvCache),
+    Quant(QuantKvCache),
+}
+
 impl KvCache {
-    pub fn new() -> Self {
-        Self {
-            buffers: None,
-            seq_len: 0,
+    pub fn new(kind: KvCacheKind) -> Self {
+        match kind {
+            KvCacheKind::Fp => Self::Fp(FpKvCache::new()),
+            KvCacheKind::Int8 => Self::Quant(QuantKvCache::new(8)),
+            KvCacheKind::Int4 => Self::Quant(QuantKvCache::new(4)),
         }
     }
 
-    /// Filled length (number of cached positions).
+    pub fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        match self {
+            Self::Fp(c) => c.append(k, v),
+            Self::Quant(c) => c.append(k, v),
+        }
+    }
+
+    pub fn reset(&mut self) {
+        match self {
+            Self::Fp(c) => c.reset(),
+            Self::Quant(c) => c.reset(),
+        }
+    }
+
     pub fn len(&self) -> usize {
-        self.seq_len
+        match self {
+            Self::Fp(c) => c.len(),
+            Self::Quant(c) => c.len(),
+        }
     }
 
     pub fn is_empty(&self) -> bool {
-        self.seq_len == 0
+        self.len() == 0
     }
 
-    /// Drop all cached state (between unrelated requests).
-    pub fn reset(&mut self) {
-        self.buffers = None;
+    pub fn byte_size(&self) -> usize {
+        match self {
+            Self::Fp(c) => c.byte_size(),
+            Self::Quant(c) => c.byte_size(),
+        }
+    }
+}
+
+impl Default for KvCache {
+    fn default() -> Self {
+        Self::new(KvCacheKind::Fp)
+    }
+}
+
+// ── Growth helper (shared by all backends) ────────────────────────────────
+
+/// Append `new` along the time dim (2) into a pre-allocated buffer, growing
+/// with `ROOM` headroom on overflow, and return the filled `[.., filled+S, ..]`
+/// view. Works for any rank-4 tensor (codes `[B,H,S,D]` or scales `[B,H,S,1]`).
+fn grow_append(buf: &mut Option<Tensor>, new: &Tensor, filled: usize) -> Result<Tensor> {
+    let new = new.contiguous()?;
+    let add = new.dim(2)?;
+    let total = filled + add;
+    match buf.take() {
+        None => {
+            let (b, h, _s, d) = new.dims4()?;
+            let store = Tensor::zeros((b, h, add + ROOM, d), new.dtype(), new.device())?;
+            store.slice_set(&new, 2, 0)?;
+            let view = store.narrow(2, 0, add)?;
+            *buf = Some(store);
+            Ok(view)
+        }
+        Some(store) => {
+            if total <= store.dim(2)? {
+                store.slice_set(&new, 2, filled)?;
+                let view = store.narrow(2, 0, total)?;
+                *buf = Some(store);
+                Ok(view)
+            } else {
+                let cur = store.narrow(2, 0, filled)?;
+                let full = Tensor::cat(&[&cur, &new], 2)?;
+                let (b, h, t, d) = full.dims4()?;
+                let grown = Tensor::zeros((b, h, t + ROOM, d), new.dtype(), new.device())?;
+                grown.slice_set(&full, 2, 0)?;
+                *buf = Some(grown);
+                Ok(full)
+            }
+        }
+    }
+}
+
+// ── Fp backend (lossless) ─────────────────────────────────────────────────
+
+/// Lossless f16/bf16 cache: pre-allocated buffers written with `slice_set`
+/// (O(new tokens), not `cat`), grown with fixed headroom on overflow.
+#[derive(Debug, Default)]
+pub struct FpKvCache {
+    k: Option<Tensor>,
+    v: Option<Tensor>,
+    seq_len: usize,
+}
+
+impl FpKvCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl KvCacheBackend for FpKvCache {
+    fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        let add = k.dim(2)?;
+        let k_full = grow_append(&mut self.k, k, self.seq_len)?;
+        let v_full = grow_append(&mut self.v, v, self.seq_len)?;
+        self.seq_len += add;
+        Ok((k_full, v_full))
+    }
+
+    fn reset(&mut self) {
+        self.k = None;
+        self.v = None;
         self.seq_len = 0;
     }
 
-    /// Append `k`/`v` for the current step and return the full cached `(k, v)`.
-    ///
-    /// `k`/`v` are `[B, num_kv_heads, S, head_dim]` (post-RoPE, pre-GQA-expand).
-    /// The returned tensors span `[B, num_kv_heads, seq_len + S, head_dim]`.
-    pub fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
-        let k = k.contiguous()?;
-        let v = v.contiguous()?;
-        let new_seq_len = k.dim(2)?;
+    fn len(&self) -> usize {
+        self.seq_len
+    }
+
+    fn byte_size(&self) -> usize {
+        tensor_bytes(&self.k) + tensor_bytes(&self.v)
+    }
+}
+
+// ── Quantized backend (per-token symmetric int8 / int4) ───────────────────
+
+/// Per-token symmetric quantized K/V cache, `bits` ∈ {4, 8}.
+///
+/// Each `[B,H,S,head_dim]` slice is quantized per token (one f32 scale =
+/// `amax / (2^(bits-1)-1)` per position+head) and stored as u8 codes:
+/// - 8-bit: one code per element (`[B,H,S,head_dim]`), ~2x smaller than f16.
+/// - 4-bit: two nibbles packed per byte (`[B,H,S,head_dim/2]`), ~4x smaller.
+///
+/// On read the filled span is dequantized to the compute dtype, so attention is
+/// unchanged. Read dequantizes the whole filled cache each step — trading
+/// decode bandwidth for the memory win that lets long context fit; a fused
+/// dequantize-in-attention kernel is the perf follow-up.
+#[derive(Debug)]
+pub struct QuantKvCache {
+    bits: u32,
+    k_codes: Option<Tensor>,
+    k_scale: Option<Tensor>,
+    v_codes: Option<Tensor>,
+    v_scale: Option<Tensor>,
+    seq_len: usize,
+    /// Compute/return dtype (set on first append).
+    dtype: Option<DType>,
+}
+
+impl QuantKvCache {
+    pub fn new(bits: u32) -> Self {
+        assert!(bits == 4 || bits == 8, "QuantKvCache supports 4 or 8 bits");
+        Self {
+            bits,
+            k_codes: None,
+            k_scale: None,
+            v_codes: None,
+            v_scale: None,
+            seq_len: 0,
+            dtype: None,
+        }
+    }
+}
+
+/// Quantize `[B,H,S,D]` per-token (symmetric) to unsigned codes in
+/// `[1, 2^bits-1]` plus an f32 per-token scale. `scale = amax/qmax (+eps)`
+/// guarantees `|x/scale| <= qmax`, so no clamp is needed. For 4-bit the codes
+/// are nibble-packed into `[B,H,S,D/2]` (requires even D).
+fn quantize_per_token(x: &Tensor, bits: u32) -> Result<(Tensor, Tensor)> {
+    let qmax = ((1u32 << (bits - 1)) - 1) as f64; // 127 or 7
+    let offset = (1u32 << (bits - 1)) as f64; // 128 or 8
+    let x = x.to_dtype(DType::F32)?;
+    let amax = x.abs()?.max_keepdim(D::Minus1)?; // [B,H,S,1]
+    let scale = amax.affine(1.0 / qmax, 1e-8)?;
+    let codes = x.broadcast_div(&scale)?.round()?.affine(1.0, offset)?; // q + offset, in [1, 2*qmax+1]
+    let codes = if bits == 8 {
+        codes.to_dtype(DType::U8)?
+    } else {
+        pack_nibbles(&codes)? // f32 in [1,15] -> u8 [B,H,S,D/2]
+    };
+    Ok((codes, scale))
+}
+
+/// Inverse of [`quantize_per_token`] into `dtype`.
+fn dequantize_per_token(codes: &Tensor, scale: &Tensor, bits: u32, dtype: DType) -> Result<Tensor> {
+    let offset = (1u32 << (bits - 1)) as f64;
+    let q = if bits == 8 {
+        codes.to_dtype(DType::F32)?
+    } else {
+        unpack_nibbles(codes)? // u8 [.., D/2] -> f32 [.., D] in [1,15]
+    };
+    q.affine(1.0, -offset)? // codes - offset
+        .broadcast_mul(scale)?
+        .to_dtype(dtype)
+}
+
+/// Pack an even-length last dim of f32 nibbles `[1,15]` into u8 `[.., D/2]`:
+/// `byte = lo + hi*16` for adjacent (even, odd) pairs.
+fn pack_nibbles(codes: &Tensor) -> Result<Tensor> {
+    let dims = codes.dims4()?;
+    let (b, h, s, d) = dims;
+    debug_assert!(d % 2 == 0, "int4 packing needs even head_dim");
+    let pairs = codes.reshape((b, h, s, d / 2, 2))?;
+    let lo = pairs.narrow(D::Minus1, 0, 1)?.squeeze(D::Minus1)?;
+    let hi = pairs.narrow(D::Minus1, 1, 1)?.squeeze(D::Minus1)?;
+    (lo + hi.affine(16.0, 0.0)?)?.to_dtype(DType::U8)
+}
+
+/// Inverse of [`pack_nibbles`]: u8 `[.., D/2]` -> f32 `[.., D]` of nibbles.
+fn unpack_nibbles(codes: &Tensor) -> Result<Tensor> {
+    let (b, h, s, d2) = codes.dims4()?;
+    let byte = codes.to_dtype(DType::F32)?;
+    let hi = byte.affine(1.0 / 16.0, 0.0)?.floor()?;
+    let lo = (byte - hi.affine(16.0, 0.0)?)?;
+    // Interleave back: stack on a new last axis -> [.., D/2, 2] -> [.., D].
+    Tensor::stack(&[&lo, &hi], D::Minus1)?.reshape((b, h, s, d2 * 2))
+}
+
+impl KvCacheBackend for QuantKvCache {
+    fn append(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        let dtype = *self.dtype.get_or_insert(k.dtype());
+        let add = k.dim(2)?;
         let filled = self.seq_len;
 
-        match self.buffers.take() {
-            None => {
-                // First write — allocate with headroom.
-                let (b, h, s, d) = k.dims4()?;
-                let buf_k = Tensor::zeros((b, h, s + ROOM, d), k.dtype(), k.device())?;
-                let buf_v = Tensor::zeros((b, h, s + ROOM, d), v.dtype(), v.device())?;
-                buf_k.slice_set(&k, 2, 0)?;
-                buf_v.slice_set(&v, 2, 0)?;
-                self.buffers = Some((buf_k, buf_v));
-                self.seq_len = s;
-                Ok((k, v))
-            }
-            Some((buf_k, buf_v)) => {
-                let capacity = buf_k.dim(2)?;
-                let new_total = filled + new_seq_len;
+        let (kc, ks) = quantize_per_token(k, self.bits)?;
+        let (vc, vs) = quantize_per_token(v, self.bits)?;
 
-                if new_total <= capacity {
-                    // Fits — in-place write, O(new_seq_len).
-                    buf_k.slice_set(&k, 2, filled)?;
-                    buf_v.slice_set(&v, 2, filled)?;
-                    let k_view = buf_k.narrow(2, 0, new_total)?;
-                    let v_view = buf_v.narrow(2, 0, new_total)?;
-                    self.buffers = Some((buf_k, buf_v));
-                    self.seq_len = new_total;
-                    Ok((k_view, v_view))
-                } else {
-                    // Overflow — concat then reallocate with headroom.
-                    let cur_k = buf_k.narrow(2, 0, filled)?;
-                    let cur_v = buf_v.narrow(2, 0, filled)?;
-                    let full_k = Tensor::cat(&[&cur_k, &k], 2)?;
-                    let full_v = Tensor::cat(&[&cur_v, &v], 2)?;
-                    let (b, h, total, d) = full_k.dims4()?;
-                    let new_buf_k = Tensor::zeros((b, h, total + ROOM, d), k.dtype(), k.device())?;
-                    let new_buf_v = Tensor::zeros((b, h, total + ROOM, d), v.dtype(), v.device())?;
-                    new_buf_k.slice_set(&full_k, 2, 0)?;
-                    new_buf_v.slice_set(&full_v, 2, 0)?;
-                    self.buffers = Some((new_buf_k, new_buf_v));
-                    self.seq_len = total;
-                    Ok((full_k, full_v))
-                }
-            }
-        }
+        let kc_full = grow_append(&mut self.k_codes, &kc, filled)?;
+        let ks_full = grow_append(&mut self.k_scale, &ks, filled)?;
+        let vc_full = grow_append(&mut self.v_codes, &vc, filled)?;
+        let vs_full = grow_append(&mut self.v_scale, &vs, filled)?;
+        self.seq_len += add;
+
+        let k_full = dequantize_per_token(&kc_full, &ks_full, self.bits, dtype)?;
+        let v_full = dequantize_per_token(&vc_full, &vs_full, self.bits, dtype)?;
+        Ok((k_full, v_full))
+    }
+
+    fn reset(&mut self) {
+        self.k_codes = None;
+        self.k_scale = None;
+        self.v_codes = None;
+        self.v_scale = None;
+        self.seq_len = 0;
+        self.dtype = None;
+    }
+
+    fn len(&self) -> usize {
+        self.seq_len
+    }
+
+    fn byte_size(&self) -> usize {
+        tensor_bytes(&self.k_codes)
+            + tensor_bytes(&self.k_scale)
+            + tensor_bytes(&self.v_codes)
+            + tensor_bytes(&self.v_scale)
     }
 }

--- a/crane-core/src/models/qwen3_5/mod.rs
+++ b/crane-core/src/models/qwen3_5/mod.rs
@@ -17,6 +17,6 @@ mod model;
 mod modeling;
 
 pub use config::{load_config, Config, LayerType, TextConfig};
-pub use kv_cache::KvCache;
+pub use kv_cache::{KvCache, KvCacheBackend, KvCacheKind};
 pub use model::{Model, ModelFormat, Qwen3_5TextModel};
 pub use modeling::{apply_mrope, DecoderLayer, FullAttention, Mlp, MRotaryEmbedding, Qwen35RmsNorm};

--- a/crane-core/src/models/qwen3_5/mod.rs
+++ b/crane-core/src/models/qwen3_5/mod.rs
@@ -1,0 +1,22 @@
+//! Qwen 3.5 dense text-only model.
+//!
+//! Hybrid Mamba/Transformer: every 4th layer is full (softmax) attention,
+//! the other 3 are linear attention via [`crate::ops::gdn::GatedDeltaNet`].
+//!
+//! See [`config::TextConfig`] for the HF schema mapping and
+//! [`model::Qwen3_5TextModel`] for the high-level entry point.
+//!
+//! Only dense text-only checkpoints are supported; the
+//! `Qwen3_5ForConditionalGeneration` multimodal class is recognized for
+//! weight loading (the `model.language_model.*` prefix is handled), but
+//! vision weights are ignored.
+
+mod config;
+mod kv_cache;
+mod model;
+mod modeling;
+
+pub use config::{load_config, Config, LayerType, TextConfig};
+pub use kv_cache::KvCache;
+pub use model::{Model, ModelFormat, Qwen3_5TextModel};
+pub use modeling::{apply_mrope, DecoderLayer, FullAttention, Mlp, MRotaryEmbedding, Qwen35RmsNorm};

--- a/crane-core/src/models/qwen3_5/model.rs
+++ b/crane-core/src/models/qwen3_5/model.rs
@@ -10,8 +10,8 @@ use candle_transformers::generation::LogitsProcessor;
 use tokenizers::Tokenizer;
 
 use super::config::{load_config, Config, TextConfig};
-use super::kv_cache::KvCache;
-use super::modeling::{resolve_tied, DecoderLayer, MRotaryEmbedding, Qwen35RmsNorm};
+use super::kv_cache::{KvCache, KvCacheKind};
+use super::modeling::{DecoderLayer, MRotaryEmbedding, Qwen35RmsNorm};
 use crate::generation::based::ModelForCausalLM;
 use crate::generation::GenerationConfig;
 use crate::utils::token_output_stream::TokenOutputStream;
@@ -70,18 +70,36 @@ impl Qwen3_5TextModel {
 
         let norm = Qwen35RmsNorm::load(text_cfg.hidden_size, text_cfg.rms_norm_eps, vb_lm.pp("norm"))?;
 
+        // Resolve the output projection. With `tie_word_embeddings: true`
+        // (0.8B/4B) it's the embedding table; untied models (e.g. Ornith-9B)
+        // ship a dedicated `lm_head.weight` of shape `[vocab, hidden]`. That
+        // tensor lives at the checkpoint ROOT, not under the `language_model`
+        // prefix, so probe `vb` first and fall back to `vb_lm`.
         let embed_weight = embed_tokens.embeddings().clone();
-        let lm_head_weight = vb_lm.get(text_cfg.vocab_size, "lm_head").ok();
-        // Store `lm_head` already transposed (`[H, V]`) so the per-step matmul
-        // doesn't have to. `resolve_tied` returns either the dedicated lm_head
-        // weight or — when `tie_word_embeddings: true` — the embed table.
-        let lm_head_raw = resolve_tied(cfg.tie_word_embeddings, embed_weight, lm_head_weight);
-        let lm_head = lm_head_raw.t()?.contiguous()?.clone();
+        let lm_head_raw = if cfg.tie_word_embeddings {
+            embed_weight
+        } else {
+            let shape = (text_cfg.vocab_size, text_cfg.hidden_size);
+            vb.get(shape, "lm_head.weight")
+                .or_else(|_| vb_lm.get(shape, "lm_head.weight"))
+                .or_else(|_| {
+                    eprintln!(
+                        "[qwen3_5] tie_word_embeddings=false but no lm_head.weight found; \
+                         falling back to tied embeddings"
+                    );
+                    Ok::<_, candle_core::Error>(embed_weight)
+                })?
+        };
+        // Store `lm_head` already transposed (`[hidden, vocab]`) so the per-step
+        // matmul doesn't have to.
+        let lm_head = lm_head_raw.t()?.contiguous()?;
 
         let rotary = MRotaryEmbedding::new(&text_cfg, device)?;
 
         // Pre-allocate per-layer caches: GDN recurrent state for linear blocks,
         // K/V cache for full-attention blocks (mutually exclusive per layer).
+        // The K/V representation (fp / int8 / …) is chosen once here.
+        let kv_kind = KvCacheKind::from_env();
         let mut gdn_caches = Vec::with_capacity(layers.len());
         let mut attn_caches = Vec::with_capacity(layers.len());
         for layer in &layers {
@@ -92,7 +110,7 @@ impl Qwen3_5TextModel {
                 attn_caches.push(None);
             } else {
                 gdn_caches.push(None);
-                attn_caches.push(Some(KvCache::new()));
+                attn_caches.push(Some(KvCache::new(kv_kind)));
             }
         }
 
@@ -116,6 +134,16 @@ impl Qwen3_5TextModel {
 
     pub fn num_layers(&self) -> usize {
         self.layers.len()
+    }
+
+    /// Total bytes held by the full-attention K/V caches across all layers
+    /// (incl. headroom + quant scales). The context-scaling memory term.
+    pub fn attn_cache_bytes(&self) -> usize {
+        self.attn_caches
+            .iter()
+            .flatten()
+            .map(|c| c.byte_size())
+            .sum()
     }
 
     pub fn device(&self) -> &Device {
@@ -221,10 +249,39 @@ fn build_causal_mask(
     Ok(full.narrow(0, 0, seq_q)?.unsqueeze(0)?.unsqueeze(0)?)
 }
 
-// ─────────────────────────────────────────────────────────────────────
-//  High-level Model wrapper (used by crane-serve's engine)
-// ─────────────────────────────────────────────────────────────────────
+/// Read EOS token id(s) from `generation_config.json` (preferred) then
+/// `config.json`. The field may be a single integer or a list; returns an empty
+/// vec if absent.
+fn read_eos_token_ids(model_path: &str) -> Vec<u32> {
+    fn from_value(v: &serde_json::Value) -> Vec<u32> {
+        match v {
+            serde_json::Value::Number(n) => {
+                n.as_u64().map(|x| vec![x as u32]).unwrap_or_default()
+            }
+            serde_json::Value::Array(a) => {
+                a.iter().filter_map(|e| e.as_u64().map(|x| x as u32)).collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+    for fname in ["generation_config.json", "config.json"] {
+        let path = std::path::Path::new(model_path).join(fname);
+        let Ok(data) = std::fs::read(&path) else { continue };
+        let Ok(json) = serde_json::from_slice::<serde_json::Value>(&data) else { continue };
+        if let Some(eos) = json.get("eos_token_id") {
+            let ids = from_value(eos);
+            if !ids.is_empty() {
+                return ids;
+            }
+        }
+    }
+    Vec::new()
+}
 
+
+/// Public-facing `Model` for Qwen 3.5 text-only inference.
+///
+/// Mirrors the structure of `crane_core::models::qwen3::Model`:
 /// Format of model weights on disk. Qwen 3.5 currently only ships
 /// safetensors; GGUF support is left for a future PR.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -233,22 +290,22 @@ pub enum ModelFormat {
     Safetensors,
 }
 
-/// Public-facing `Model` for Qwen 3.5 text-only inference.
-///
-/// Mirrors the structure of `crane_core::models::qwen3::Model`:
 /// holds a tokenizer, device, dtype, and the inner [`Qwen3_5TextModel`].
 pub struct Model {
     pub tokenizer: TokenOutputStream,
     pub device: Device,
     pub dtype: DType,
+    /// Stop tokens read from `generation_config.json` / `config.json` (Qwen3.5
+    /// and Ornith both use multi-id EOS, e.g. `[248044, 248046]`). Used when the
+    /// caller's `GenerationConfig` doesn't pin its own `eos_token_id`.
+    eos_token_ids: Vec<u32>,
     inner: Qwen3_5TextModel,
 }
 
 impl Model {
     /// Load a Qwen 3.5 model from a HF checkpoint directory.
     ///
-    /// Only the safetensors path is wired. GGUF support is left as a
-    /// follow-up.
+    /// Only the safetensors path is wired. GGUF support is left as a follow-up.
     pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
         Self::new_with_format(model_path, device, dtype, ModelFormat::Auto)
     }
@@ -265,6 +322,9 @@ impl Model {
         };
         match format {
             ModelFormat::Safetensors => Self::from_pretrained(model_path, device, dtype),
+            // GGUF support is a follow-up — the dense checkpoints ship as
+            // safetensors, and the GDN path's lazy-eviction story is enough
+            // complexity for one PR.
             ModelFormat::Auto => unreachable!("Auto resolves to Safetensors above"),
         }
     }
@@ -282,12 +342,15 @@ impl Model {
         let config_path = std::path::Path::new(model_path).join("config.json");
         let cfg = load_config(config_path.to_str().context("non-UTF8 model path")?)?;
 
+        let eos_token_ids = read_eos_token_ids(model_path);
+
         let inner = Qwen3_5TextModel::new(&cfg, vb, device, *dtype)?;
 
         Ok(Self {
             tokenizer: TokenOutputStream::new(tokenizer),
             device: device.clone(),
             dtype: *dtype,
+            eos_token_ids,
             inner,
         })
     }
@@ -323,6 +386,11 @@ impl Model {
 
     pub fn num_layers(&self) -> usize {
         self.inner.num_layers()
+    }
+
+    /// Total bytes held by the full-attention K/V caches (context-scaling term).
+    pub fn attn_cache_bytes(&self) -> usize {
+        self.inner.attn_cache_bytes()
     }
 
     /// Warm up the model with a small forward pass.
@@ -361,20 +429,37 @@ impl ModelForCausalLM for Model {
         std::io::stdout().flush()?;
 
         let mut generated_tokens = 0usize;
-        let eos_token: Option<u32> = config
-            .eos_token_id
-            .or_else(|| self.tokenizer.get_token(""))
-            .or_else(|| self.tokenizer.get_token(""));
+        // Stop tokens: an explicit `eos_token_id` on the request wins; otherwise
+        // use the model's configured EOS set (Qwen3.5/Ornith use multiple, e.g.
+        // [248044, 248046]); last-resort, look up `<|im_end|>` in the tokenizer.
+        let mut stop_ids: Vec<u32> = match config.eos_token_id {
+            Some(e) => vec![e],
+            None if !self.eos_token_ids.is_empty() => self.eos_token_ids.clone(),
+            None => self
+                .tokenizer
+                .get_token("<|im_end|>")
+                .into_iter()
+                .collect(),
+        };
+        stop_ids.sort_unstable();
+        stop_ids.dedup();
+
+        // Incremental decode: GDN layers carry recurrent state and
+        // full-attention layers carry a K/V cache, so feeding one token per
+        // step is correct. `CRANE_FULL_RECOMPUTE=1` forces the O(n²)
+        // reset-and-reprocess path instead (kept as a debugging cross-check
+        // for the incremental path).
+        let full_recompute = std::env::var("CRANE_FULL_RECOMPUTE").is_ok();
 
         let start_gen = std::time::Instant::now();
         for index in 0..config.max_new_tokens {
-            // After the first step, only feed the freshly decoded token — GDN
-            // layers carry recurrent state and full-attention layers carry a
-            // K/V cache, so incremental decode is correct.
-            let context_size = if index > 0 { 1 } else { tokens.len() };
+            let context_size = if index > 0 && !full_recompute { 1 } else { tokens.len() };
             let start_pos = tokens.len().saturating_sub(context_size);
             let ctxt = &tokens[start_pos..];
 
+            if full_recompute {
+                self.clear_kv_cache();
+            }
             let logits = self.forward_step(ctxt, start_pos)?;
             let logits = logits.squeeze(0)?.to_dtype(DType::F32)?;
 
@@ -393,7 +478,7 @@ impl ModelForCausalLM for Model {
             tokens.push(next_token);
             generated_tokens += 1;
 
-            if eos_token == Some(next_token) {
+            if stop_ids.binary_search(&next_token).is_ok() {
                 if let Some(ref mut s) = streamer {
                     s.finalize()?;
                 }
@@ -415,3 +500,4 @@ impl ModelForCausalLM for Model {
         Ok(tokens)
     }
 }
+

--- a/crane-core/src/models/qwen3_5/model.rs
+++ b/crane-core/src/models/qwen3_5/model.rs
@@ -1,0 +1,417 @@
+//! Top-level Qwen 3.5 text-only transformer + the high-level `Model`
+//! wrapper used by the engine (config + weights + tokenizer).
+
+use std::io::Write;
+
+use anyhow::{Context, Error as E, Result};
+use candle_core::{DType, Device, Module, Tensor};
+use candle_nn::{embedding, Embedding, VarBuilder};
+use candle_transformers::generation::LogitsProcessor;
+use tokenizers::Tokenizer;
+
+use super::config::{load_config, Config, TextConfig};
+use super::kv_cache::KvCache;
+use super::modeling::{resolve_tied, DecoderLayer, MRotaryEmbedding, Qwen35RmsNorm};
+use crate::generation::based::ModelForCausalLM;
+use crate::generation::GenerationConfig;
+use crate::utils::token_output_stream::TokenOutputStream;
+use crate::utils::utils;
+
+/// Text-only Qwen 3.5 transformer.
+///
+/// `gdn_caches` is indexed by layer; `None` for full-attention blocks, `Some`
+/// for linear-attention blocks. The engine is responsible for cloning/saving
+/// these caches across context switches (continuous batching).
+pub struct Qwen3_5TextModel {
+    cfg: TextConfig,
+    embed_tokens: Embedding,
+    layers: Vec<DecoderLayer>,
+    norm: Qwen35RmsNorm,
+    lm_head: Tensor,
+    rotary: MRotaryEmbedding,
+    gdn_caches: Vec<Option<crate::ops::gdn::GdnLayerCache>>,
+    /// Per-layer K/V cache; `Some` for full-attention blocks, `None` for GDN.
+    attn_caches: Vec<Option<KvCache>>,
+    device: Device,
+    dtype: DType,
+}
+
+impl Qwen3_5TextModel {
+    /// Load a text-only Qwen 3.5 model from a HF checkpoint directory.
+    ///
+    /// The HF layout has a top-level `language_model.*` prefix when the model
+    /// was saved with `Qwen3_5ForConditionalGeneration`. We probe for that
+    /// prefix and fall back to a flat layout.
+    pub fn new(cfg: &Config, vb: VarBuilder, device: &Device, dtype: DType) -> Result<Self> {
+        let text_cfg = cfg.text().clone();
+        // HF saves Qwen 3.5 weights with the prefix
+        //   model.language_model.layers.{i}.{linear_attn,self_attn}.*
+        // (the `model.` is the inner multimodal `Qwen3_5Model`, of which
+        // `language_model` is the text component). Older checkpoints and
+        // standalone text exports may drop the leading `model.`.
+        let vb_lm = if vb.contains_tensor("model.language_model.embed_tokens.weight") {
+            vb.pp("model").pp("language_model")
+        } else if vb.contains_tensor("language_model.embed_tokens.weight") {
+            vb.pp("language_model")
+        } else if vb.contains_tensor("model.embed_tokens.weight") {
+            vb.pp("model")
+        } else {
+            // Last-resort: assume a flat layout, no prefix.
+            vb.clone()
+        };
+
+        let embed_tokens = embedding(text_cfg.vocab_size, text_cfg.hidden_size, vb_lm.pp("embed_tokens"))?;
+
+        let layer_types = text_cfg.layer_types();
+        let mut layers = Vec::with_capacity(text_cfg.num_hidden_layers);
+        for (idx, &layer_type) in layer_types.iter().enumerate() {
+            layers.push(DecoderLayer::load(&text_cfg, layer_type, vb_lm.pp("layers").pp(idx))?);
+        }
+
+        let norm = Qwen35RmsNorm::load(text_cfg.hidden_size, text_cfg.rms_norm_eps, vb_lm.pp("norm"))?;
+
+        let embed_weight = embed_tokens.embeddings().clone();
+        let lm_head_weight = vb_lm.get(text_cfg.vocab_size, "lm_head").ok();
+        // Store `lm_head` already transposed (`[H, V]`) so the per-step matmul
+        // doesn't have to. `resolve_tied` returns either the dedicated lm_head
+        // weight or — when `tie_word_embeddings: true` — the embed table.
+        let lm_head_raw = resolve_tied(cfg.tie_word_embeddings, embed_weight, lm_head_weight);
+        let lm_head = lm_head_raw.t()?.contiguous()?.clone();
+
+        let rotary = MRotaryEmbedding::new(&text_cfg, device)?;
+
+        // Pre-allocate per-layer caches: GDN recurrent state for linear blocks,
+        // K/V cache for full-attention blocks (mutually exclusive per layer).
+        let mut gdn_caches = Vec::with_capacity(layers.len());
+        let mut attn_caches = Vec::with_capacity(layers.len());
+        for layer in &layers {
+            if layer.is_linear() {
+                gdn_caches.push(Some(crate::ops::gdn::GdnLayerCache::new(
+                    &text_cfg, dtype, device,
+                )?));
+                attn_caches.push(None);
+            } else {
+                gdn_caches.push(None);
+                attn_caches.push(Some(KvCache::new()));
+            }
+        }
+
+        Ok(Self {
+            cfg: text_cfg,
+            embed_tokens,
+            layers,
+            norm,
+            lm_head,
+            rotary,
+            gdn_caches,
+            attn_caches,
+            device: device.clone(),
+            dtype,
+        })
+    }
+
+    pub fn config(&self) -> &TextConfig {
+        &self.cfg
+    }
+
+    pub fn num_layers(&self) -> usize {
+        self.layers.len()
+    }
+
+    pub fn device(&self) -> &Device {
+        &self.device
+    }
+
+    pub fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    pub fn lm_head(&self) -> &Tensor {
+        &self.lm_head
+    }
+
+    /// Reset all per-layer GDN caches. Called between unrelated requests
+    /// sharing the same pre-allocated layer set.
+    pub fn reset_gdn_caches(&mut self) -> Result<()> {
+        for slot in self.gdn_caches.iter_mut().flatten() {
+            slot.reset()?;
+        }
+        for slot in self.attn_caches.iter_mut().flatten() {
+            slot.reset();
+        }
+        Ok(())
+    }
+
+    /// Forward pass over `input_ids` of shape `[B, S]`. `start_pos` is the
+    /// absolute position of the first token (used for rotary slicing).
+    /// `attention_mask` is broadcastable to `[B, 1, S, S_total]` (or `None`).
+    ///
+    /// Returns logits of shape `[B, S, vocab_size]`.
+    pub fn forward(
+        &mut self,
+        input_ids: &Tensor,
+        start_pos: usize,
+        attention_mask: Option<&Tensor>,
+    ) -> Result<Tensor> {
+        let (_b, seq_len) = input_ids.dims2()?;
+        let is_decode_step = seq_len == 1;
+
+        let mut xs = self.embed_tokens.forward(input_ids)?;
+
+        // If no mask was supplied, build a causal mask so prefill doesn't
+        // leak future tokens into past positions. (Decode is `seq_len==1`,
+        // where every position trivially attends only to itself — the mask is
+        // a no-op there.)
+        let mask = match attention_mask {
+            Some(m) => Some(m.clone()),
+            None if !is_decode_step => {
+                let total = start_pos + seq_len;
+                Some(build_causal_mask(seq_len, total, xs.device(), xs.dtype())?)
+            }
+            None => None,
+        };
+        let mask_ref = mask.as_ref();
+
+        let (cos, sin) = self.rotary.cos_sin(start_pos, seq_len)?;
+        let rot_dim = self.rotary.rot_dim();
+
+        for i in 0..self.layers.len() {
+            let layer = &self.layers[i];
+            let gdn_slot = self.gdn_caches[i].as_mut();
+            let attn_slot = self.attn_caches[i].as_mut();
+            xs = layer.forward(
+                &xs,
+                &cos,
+                &sin,
+                rot_dim,
+                mask_ref,
+                gdn_slot,
+                attn_slot,
+                is_decode_step,
+            )?;
+        }
+
+        let xs = self.norm.forward(&xs)?;
+        // Matmul with lm_head on the LAST position only. The engine's
+        // sampling step expects `[B, V]` (1D logits for the next token).
+        let (b, s, _) = xs.dims3()?;
+        let last = xs.narrow(1, s - 1, 1)?.reshape((b, ()))?;
+        let logits = last.matmul(&self.lm_head)?;
+        Ok(logits)
+    }
+}
+
+/// Build a causal mask of shape `[1, 1, S_q, S_k]` where row `i` has `-inf`
+/// for columns `j > start_pos + i` (future tokens). Returned as f32 cast to
+/// the model's dtype.
+fn build_causal_mask(
+    seq_q: usize,
+    total_k: usize,
+    device: &candle_core::Device,
+    dtype: candle_core::DType,
+) -> candle_core::Result<candle_core::Tensor> {
+    let mut data: Vec<f32> = Vec::with_capacity(total_k * total_k);
+    for q in 0..total_k {
+        for k in 0..total_k {
+            data.push(if k > q { f32::NEG_INFINITY } else { 0.0 });
+        }
+    }
+    let full = candle_core::Tensor::from_vec(data, (total_k, total_k), device)?
+        .to_dtype(dtype)?;
+    Ok(full.narrow(0, 0, seq_q)?.unsqueeze(0)?.unsqueeze(0)?)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  High-level Model wrapper (used by crane-serve's engine)
+// ─────────────────────────────────────────────────────────────────────
+
+/// Format of model weights on disk. Qwen 3.5 currently only ships
+/// safetensors; GGUF support is left for a future PR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ModelFormat {
+    Auto,
+    Safetensors,
+}
+
+/// Public-facing `Model` for Qwen 3.5 text-only inference.
+///
+/// Mirrors the structure of `crane_core::models::qwen3::Model`:
+/// holds a tokenizer, device, dtype, and the inner [`Qwen3_5TextModel`].
+pub struct Model {
+    pub tokenizer: TokenOutputStream,
+    pub device: Device,
+    pub dtype: DType,
+    inner: Qwen3_5TextModel,
+}
+
+impl Model {
+    /// Load a Qwen 3.5 model from a HF checkpoint directory.
+    ///
+    /// Only the safetensors path is wired. GGUF support is left as a
+    /// follow-up.
+    pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
+        Self::new_with_format(model_path, device, dtype, ModelFormat::Auto)
+    }
+
+    pub fn new_with_format(
+        model_path: &str,
+        device: &Device,
+        dtype: &DType,
+        format: ModelFormat,
+    ) -> Result<Self> {
+        let format = match format {
+            ModelFormat::Auto => ModelFormat::Safetensors,
+            other => other,
+        };
+        match format {
+            ModelFormat::Safetensors => Self::from_pretrained(model_path, device, dtype),
+            ModelFormat::Auto => unreachable!("Auto resolves to Safetensors above"),
+        }
+    }
+
+    fn from_pretrained(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
+        let tokenizer_path = std::path::Path::new(model_path).join("tokenizer.json");
+        if !tokenizer_path.exists() {
+            anyhow::bail!("Tokenizer not found at {}", tokenizer_path.display());
+        }
+        let tokenizer = Tokenizer::from_file(&tokenizer_path).map_err(E::msg)?;
+
+        let filenames = utils::get_safetensors_files(model_path)?;
+        let vb = unsafe { VarBuilder::from_mmaped_safetensors(&filenames, *dtype, device) }?;
+
+        let config_path = std::path::Path::new(model_path).join("config.json");
+        let cfg = load_config(config_path.to_str().context("non-UTF8 model path")?)?;
+
+        let inner = Qwen3_5TextModel::new(&cfg, vb, device, *dtype)?;
+
+        Ok(Self {
+            tokenizer: TokenOutputStream::new(tokenizer),
+            device: device.clone(),
+            dtype: *dtype,
+            inner,
+        })
+    }
+
+    /// Tokenize a prompt string into input IDs (mirrors `qwen3::Model`).
+    pub fn prepare_inputs(&self, inputs: &str) -> Result<Vec<u32>> {
+        let input_ids = self
+            .tokenizer
+            .tokenizer
+            .encode(inputs, true)
+            .map_err(E::msg)?
+            .get_ids()
+            .to_vec();
+        Ok(input_ids)
+    }
+
+    /// Run a single forward step, returning raw logits `[1, S, vocab]`.
+    pub fn forward_step(
+        &mut self,
+        input_ids: &[u32],
+        start_pos: usize,
+    ) -> Result<Tensor> {
+        let input = Tensor::new(input_ids, &self.device)?.unsqueeze(0)?;
+        Ok(self.inner.forward(&input, start_pos, None)?)
+    }
+
+    /// Reset all per-layer GDN caches (between unrelated requests).
+    pub fn clear_kv_cache(&mut self) {
+        self.inner
+            .reset_gdn_caches()
+            .expect("GDN cache reset failed");
+    }
+
+    pub fn num_layers(&self) -> usize {
+        self.inner.num_layers()
+    }
+
+    /// Warm up the model with a small forward pass.
+    pub fn warmup(&mut self) {
+        // Run a tiny decode-only forward (single token) so warmup succeeds
+        // regardless of how the generate loop is implemented.
+        if let Err(e) = self.generate(
+            &[45],
+            &GenerationConfig::with_max_tokens(5),
+            None,
+        ) {
+            eprintln!("warmup failed (non-fatal): {e}");
+        }
+        self.clear_kv_cache();
+    }
+}
+
+impl ModelForCausalLM for Model {
+    fn device(&self) -> &Device {
+        &self.device
+    }
+
+    fn generate(
+        &mut self,
+        input_ids: &[u32],
+        config: &GenerationConfig,
+        mut streamer: Option<&mut dyn crate::generation::streamer::TokenStreamer>,
+    ) -> Result<Vec<u32>> {
+        self.tokenizer.clear();
+        self.clear_kv_cache();
+
+        let mut logits_processor =
+            LogitsProcessor::new(1024, config.temperature, config.top_p);
+
+        let mut tokens = input_ids.to_vec();
+        std::io::stdout().flush()?;
+
+        let mut generated_tokens = 0usize;
+        let eos_token: Option<u32> = config
+            .eos_token_id
+            .or_else(|| self.tokenizer.get_token(""))
+            .or_else(|| self.tokenizer.get_token(""));
+
+        let start_gen = std::time::Instant::now();
+        for index in 0..config.max_new_tokens {
+            // After the first step, only feed the freshly decoded token — GDN
+            // layers carry recurrent state and full-attention layers carry a
+            // K/V cache, so incremental decode is correct.
+            let context_size = if index > 0 { 1 } else { tokens.len() };
+            let start_pos = tokens.len().saturating_sub(context_size);
+            let ctxt = &tokens[start_pos..];
+
+            let logits = self.forward_step(ctxt, start_pos)?;
+            let logits = logits.squeeze(0)?.to_dtype(DType::F32)?;
+
+            let logits = if config.repetition_penalty == 1. {
+                logits
+            } else {
+                let start_at = tokens.len().saturating_sub(config.repeat_last_n);
+                candle_transformers::utils::apply_repeat_penalty(
+                    &logits,
+                    config.repetition_penalty,
+                    &tokens[start_at..],
+                )?
+            };
+
+            let next_token = logits_processor.sample(&logits)?;
+            tokens.push(next_token);
+            generated_tokens += 1;
+
+            if eos_token == Some(next_token) {
+                if let Some(ref mut s) = streamer {
+                    s.finalize()?;
+                }
+                break;
+            }
+
+            if let Some(ref mut s) = streamer {
+                s.append(next_token)?;
+            }
+        }
+
+        let dt = start_gen.elapsed();
+        if config.report_speed {
+            println!(
+                "\n{generated_tokens} tokens generated ({:.2} token/s)\n",
+                generated_tokens as f64 / dt.as_secs_f64(),
+            );
+        }
+        Ok(tokens)
+    }
+}

--- a/crane-core/src/models/qwen3_5/modeling.rs
+++ b/crane-core/src/models/qwen3_5/modeling.rs
@@ -224,6 +224,7 @@ impl FullAttention {
     ) -> Result<Tensor> {
         let (b_sz, seq_len, _) = x.dims3()?;
 
+
         let q_out = self.q_proj.forward(x)?;
         let k_proj_out = self.k_proj.forward(x)?;
         let v_proj_out = self.v_proj.forward(x)?;
@@ -251,6 +252,7 @@ impl FullAttention {
         } else {
             (q_out, None)
         };
+
 
         let q = q
             .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
@@ -299,6 +301,7 @@ impl FullAttention {
         } else {
             v
         };
+
         let k_t = k_rep.transpose(D::Minus2, D::Minus1)?.contiguous()?;
         let attn_logits = (q.matmul(&k_t)? * scale)?;
         let attn_weights = match attention_mask {
@@ -457,15 +460,5 @@ impl DecoderLayer {
         let mlp_out = self.mlp.forward(&normed2)?;
 
         residual2 + mlp_out
-    }
-}
-
-/// Choose between a dedicated `lm_head` weight and the tied `embed_tokens`
-/// weight, based on `tie_word_embeddings`.
-pub fn resolve_tied(tie: bool, embed_weight: Tensor, lm_head_weight: Option<Tensor>) -> Tensor {
-    match lm_head_weight {
-        Some(w) => w,
-        None if tie => embed_weight,
-        None => embed_weight,
     }
 }

--- a/crane-core/src/models/qwen3_5/modeling.rs
+++ b/crane-core/src/models/qwen3_5/modeling.rs
@@ -1,0 +1,471 @@
+//! Qwen 3.5 transformer layer: hybrid full-attention + linear-attention stack.
+//!
+//! Layout (per layer):
+//!   residual = input_layernorm(x)
+//!   attn_or_gdn_out = full_or_linear(residual, …)   // dispatched by layer_types
+//!   x = x + attn_or_gdn_out
+//!   residual2 = post_attention_layernorm(x)
+//!   x = x + mlp(residual2)
+//!
+//! The full-attention path uses MRoPE-interleaved rotary embeddings and gated
+//! output (`attn_output_gate: true` in the config). The linear-attention path
+//! uses [`crate::ops::gdn::GatedDeltaNet`].
+//!
+//! Per-layer GDN state is held by [`super::Qwen3_5TextModel`] (not by the
+//! layer), so that continuous-batching can save/restore state per request.
+
+use candle_core::{DType, Device, Module, Result, Tensor, D};
+use candle_nn::{linear_no_bias, VarBuilder};
+
+// ── Qwen 3.5 RMSNorm (unit-offset) ───────────────────────────────────────
+
+/// RMSNorm as used by Qwen 3.5: `x / rms(x) * (1 + weight)`.
+///
+/// Unlike the standard (Llama/Qwen3) RMSNorm — which scales by `weight` — Qwen
+/// 3.5 adds a unit offset (`1 + weight`, Gemma-style). HF source:
+/// `output = self._norm(x.float()) * (1.0 + self.weight.float())`. The stored
+/// weights have mean ~0.24, so omitting the `+1` shrinks every normalized
+/// activation ~5x and compounds across layers. Computed in f32 then cast back.
+///
+/// This is NOT used by the GDN gated norm ([`crate::ops::gdn::RmsNormGated`]), which
+/// scales by plain `weight` in HF.
+#[derive(Clone)]
+pub struct Qwen35RmsNorm {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl Qwen35RmsNorm {
+    pub fn load(size: usize, eps: f64, vb: VarBuilder) -> Result<Self> {
+        let weight = vb.get(size, "weight")?;
+        Ok(Self { weight, eps })
+    }
+
+    pub fn weight(&self) -> &Tensor {
+        &self.weight
+    }
+}
+
+impl Module for Qwen35RmsNorm {
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let dtype = x.dtype();
+        let x = x.to_dtype(DType::F32)?;
+        let var = x.sqr()?.mean_keepdim(D::Minus1)?;
+        let x_normed = x.broadcast_div(&(var + self.eps)?.sqrt()?)?;
+        // `1 + weight` (unit offset), in f32.
+        let scale = self.weight.to_dtype(DType::F32)?.affine(1.0, 1.0)?;
+        x_normed.broadcast_mul(&scale)?.to_dtype(dtype)
+    }
+}
+
+use super::config::{LayerType, TextConfig};
+use super::kv_cache::KvCache;
+use crate::ops::gdn::{GatedDeltaNet, GdnDims, GdnInputProjectionKind, GdnLayerCache};
+
+// ── MRoPE rotary embedding ─────────────────────────────────────────────
+
+/// Multimodal Rotary Position Embedding (interleaved variant, used by Qwen 3.5).
+///
+/// For text-only inference the position_ids are identical across all three
+/// sections, so this reduces to standard RoPE applied to the first
+/// `rot_dim = head_dim * partial_rotary_factor` components of each head.
+///
+/// Precomputes `cos` and `sin` tables of shape `[max_pos, rot_dim/2]`. Use
+/// [`apply_mrope`] to rotate a query/key tensor.
+pub struct MRotaryEmbedding {
+    cos_table: Tensor,
+    sin_table: Tensor,
+    rot_dim: usize,
+}
+
+impl MRotaryEmbedding {
+    pub fn new(cfg: &TextConfig, device: &Device) -> Result<Self> {
+        let rot_dim = cfg.rot_dim();
+        let base = cfg.rope_theta() as f32;
+        let max_pos = cfg.max_position_embeddings;
+
+        // cos/sin tables have shape `[S, rot_dim/2]` — exactly the slice of the
+        // head that receives rotary embeddings. `apply_mrope` rotates only the
+        // first `rot_dim` components of each head (HF's partial-rotary scheme:
+        // `q_rot = q[..., :rot_dim]`), so the tables must NOT be padded to
+        // `head_dim/2`. Padding them to the full head and rotating the whole
+        // head (the previous approach) pairs dim `i` with dim `i+head_dim/2`,
+        // whereas HF pairs `i` with `i+rot_dim/2` inside the rotary slice — a
+        // different rotation entirely.
+        let half_rot = rot_dim / 2;
+        let inv: Vec<f32> = (0..half_rot)
+            .map(|i| 1.0 / base.powf(i as f32 * 2.0 / rot_dim as f32))
+            .collect();
+        let inv_freq = Tensor::new(inv.as_slice(), device)?;
+
+        let positions: Vec<f32> = (0..max_pos).map(|i| i as f32).collect();
+        let positions = Tensor::new(positions.as_slice(), device)?;
+        let freqs = positions.unsqueeze(1)?.matmul(&inv_freq.unsqueeze(0)?)?; // [max_pos, half_rot]
+
+        let cos_table = freqs.cos()?.contiguous()?;
+        let sin_table = freqs.sin()?.contiguous()?;
+
+        Ok(Self {
+            cos_table,
+            sin_table,
+            rot_dim,
+        })
+    }
+
+    /// Slice cos/sin for positions `[start, start+seq_len)`.
+    pub fn cos_sin(&self, start: usize, seq_len: usize) -> Result<(Tensor, Tensor)> {
+        let cos = self.cos_table.narrow(0, start, seq_len)?;
+        let sin = self.sin_table.narrow(0, start, seq_len)?;
+        Ok((cos, sin))
+    }
+
+    pub fn rot_dim(&self) -> usize {
+        self.rot_dim
+    }
+}
+
+/// Apply rotary embeddings to a query/key tensor `[B, H, S, D]`.
+///
+/// Only the first `rot_dim` components of each head are rotated; the remaining
+/// `D - rot_dim` components are passed through unchanged. This mirrors HF's
+/// partial-rotary scheme (`q_rot = q[..., :rot_dim]`, `q_pass = q[..., rot_dim:]`).
+/// `cos`/`sin` tables have shape `[S, rot_dim/2]`.
+///
+/// `candle_nn::rotary_emb::rope` is the rotate-half (non-interleaved / GPT-NeoX)
+/// variant — it pairs component `i` with `i + rot_dim/2` *within the slice we
+/// hand it*, which matches HF's `rotate_half` over the rotary slice. We must
+/// slice first; rotating the full head would pair `i` with `i + head_dim/2`.
+pub fn apply_mrope(
+    x: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    rot_dim: usize,
+) -> Result<Tensor> {
+    let (_b, _h, _seq_len, head_dim) = x.dims4()?;
+    let dtype = x.dtype();
+    // `cos`/`sin` are kept in f32; the rope op requires its inputs to share a
+    // dtype, so for half-precision activations (F16/BF16 on GPU) we rotate in
+    // f32 and cast back. This also matches HF, which applies RoPE in float.
+    let rope_f32 = |t: &Tensor| -> Result<Tensor> {
+        let r = candle_nn::rotary_emb::rope(&t.to_dtype(DType::F32)?.contiguous()?, cos, sin)?;
+        r.to_dtype(dtype)
+    };
+    if rot_dim == head_dim {
+        return rope_f32(x);
+    }
+    let x_rot = rope_f32(&x.narrow(D::Minus1, 0, rot_dim)?)?;
+    let x_pass = x.narrow(D::Minus1, rot_dim, head_dim - rot_dim)?;
+    Tensor::cat(&[&x_rot, &x_pass], D::Minus1)?.contiguous()
+}
+
+// ── Full-attention layer ────────────────────────────────────────────────
+
+/// Standard softmax attention layer for Qwen 3.5's `full_attention` blocks.
+///
+/// Differences from the regular Qwen 3 attention:
+/// - `q_proj` outputs `num_heads * head_dim * 2`; the second half is a sigmoid
+///   gate applied to the attention output.
+/// - Per-head QK-norm is always present (`q_norm`, `k_norm` of size `head_dim`).
+/// - RoPE is MRoPE-interleaved applied only to the first `rot_dim` components.
+pub struct FullAttention {
+    q_proj: candle_nn::Linear,
+    k_proj: candle_nn::Linear,
+    v_proj: candle_nn::Linear,
+    o_proj: candle_nn::Linear,
+    q_norm: Qwen35RmsNorm,
+    k_norm: Qwen35RmsNorm,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    has_output_gate: bool,
+}
+
+impl FullAttention {
+    pub fn load(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let num_heads = cfg.num_attention_heads;
+        let num_kv_heads = cfg.num_key_value_heads;
+        let head_dim = cfg.head_dim;
+
+        let q_out = if cfg.attn_output_gate {
+            num_heads * head_dim * 2
+        } else {
+            num_heads * head_dim
+        };
+        let q_proj = linear_no_bias(cfg.hidden_size, q_out, vb.pp("q_proj"))?;
+        let k_proj = linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("k_proj"))?;
+        let v_proj = linear_no_bias(cfg.hidden_size, num_kv_heads * head_dim, vb.pp("v_proj"))?;
+        let o_proj = linear_no_bias(num_heads * head_dim, cfg.hidden_size, vb.pp("o_proj"))?;
+
+        let q_norm = Qwen35RmsNorm::load(head_dim, cfg.rms_norm_eps, vb.pp("q_norm"))?;
+        let k_norm = Qwen35RmsNorm::load(head_dim, cfg.rms_norm_eps, vb.pp("k_norm"))?;
+
+        Ok(Self {
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
+            q_norm,
+            k_norm,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            has_output_gate: cfg.attn_output_gate,
+        })
+    }
+
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        rot_dim: usize,
+        attention_mask: Option<&Tensor>,
+        kv_cache: Option<&mut KvCache>,
+    ) -> Result<Tensor> {
+        let (b_sz, seq_len, _) = x.dims3()?;
+
+        let q_out = self.q_proj.forward(x)?;
+        let k_proj_out = self.k_proj.forward(x)?;
+        let v_proj_out = self.v_proj.forward(x)?;
+        let k = k_proj_out;
+        let v = v_proj_out;
+
+        let (q, gate) = if self.has_output_gate {
+            // HF splits `[query | gate]` PER HEAD, not on the flat axis:
+            //   q_proj(x).view(B, S, num_heads, head_dim*2).chunk(2, dim=-1)
+            // so for each head the first `head_dim` is the query and the next
+            // `head_dim` is the gate. Splitting the flat 4096 in half instead
+            // interleaves heads' query/gate and scrambles q_norm. Re-flatten
+            // both back to `[B, S, num_heads*head_dim]` in head order.
+            let flat = self.num_heads * self.head_dim;
+            let qh = q_out.reshape((b_sz, seq_len, self.num_heads, self.head_dim * 2))?;
+            let q = qh
+                .narrow(D::Minus1, 0, self.head_dim)?
+                .contiguous()?
+                .reshape((b_sz, seq_len, flat))?;
+            let gate = qh
+                .narrow(D::Minus1, self.head_dim, self.head_dim)?
+                .contiguous()?
+                .reshape((b_sz, seq_len, flat))?;
+            (q, Some(gate))
+        } else {
+            (q_out, None)
+        };
+
+        let q = q
+            .reshape((b_sz, seq_len, self.num_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let k = k
+            .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?
+            .contiguous()?;
+        let v = v
+            .reshape((b_sz, seq_len, self.num_kv_heads, self.head_dim))?
+            .transpose(1, 2)?;
+
+        let q = self.q_norm.forward(&q)?;
+        let k = self.k_norm.forward(&k)?;
+
+        let q = apply_mrope(&q, cos, sin, rot_dim)?;
+        let k = apply_mrope(&k, cos, sin, rot_dim)?;
+
+        // Append this step's K/V to the cache (post-RoPE, pre-GQA-expand) and
+        // continue with the full cached K/V. During incremental decode this is
+        // what lets the attention see the whole context from a single token.
+        let (k, v) = match kv_cache {
+            Some(cache) => cache.append(&k, &v)?,
+            None => (k, v),
+        };
+
+        let n_rep = self.num_heads / self.num_kv_heads;
+        let scale = 1.0 / (self.head_dim as f64).sqrt();
+
+        let k_rep = if n_rep > 1 {
+            let (b, kv_heads, s, d) = k.dims4()?;
+            k.unsqueeze(2)?
+                .expand((b, kv_heads, n_rep, s, d))?
+                .contiguous()?
+                .reshape((b, self.num_heads, s, d))?
+        } else {
+            k
+        };
+        let v_rep = if n_rep > 1 {
+            let (b, kv_heads, s, d) = v.dims4()?;
+            v.unsqueeze(2)?
+                .expand((b, kv_heads, n_rep, s, d))?
+                .contiguous()?
+                .reshape((b, self.num_heads, s, d))?
+        } else {
+            v
+        };
+        let k_t = k_rep.transpose(D::Minus2, D::Minus1)?.contiguous()?;
+        let attn_logits = (q.matmul(&k_t)? * scale)?;
+        let attn_weights = match attention_mask {
+            Some(mask) => attn_weights_with_mask(&attn_logits, mask)?,
+            None => attn_logits,
+        };
+        let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+        let y = attn_weights.matmul(&v_rep)?;
+
+        let y = y.transpose(1, 2)?.reshape((b_sz, seq_len, ()))?;
+
+        let y = if let Some(g) = gate {
+            let gate = candle_nn::ops::sigmoid(&g.to_dtype(y.dtype())?)?;
+            y.broadcast_mul(&gate)?
+        } else {
+            y
+        };
+
+        self.o_proj.forward(&y)
+    }
+}
+
+fn attn_weights_with_mask(
+    attn_logits: &Tensor,
+    mask: &Tensor,
+) -> Result<Tensor> {
+    // HF applies the mask (shape `[B, 1, S_q, S_k]` for additive causal mask)
+    // via `attn_weights + mask` and softmax. We do the same.
+    Ok(attn_logits.broadcast_add(mask)?)
+}
+
+// ── MLP ────────────────────────────────────────────────────────────────
+
+/// Standard SwiGLU MLP: `down(silu(gate(x)) * up(x))`.
+pub struct Mlp {
+    gate_proj: candle_nn::Linear,
+    up_proj: candle_nn::Linear,
+    down_proj: candle_nn::Linear,
+}
+
+impl Mlp {
+    pub fn load(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
+        let gate_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))?;
+        let up_proj = linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?;
+        let down_proj = linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))?;
+        Ok(Self { gate_proj, up_proj, down_proj })
+    }
+
+    pub fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let gate = candle_nn::ops::silu(&self.gate_proj.forward(x)?)?;
+        let up = self.up_proj.forward(x)?;
+        let h = gate.broadcast_mul(&up)?;
+        let out = self.down_proj.forward(&h)?;
+        Ok(out)
+    }
+}
+
+// ── DecoderLayer ────────────────────────────────────────────────────────
+
+/// One transformer block. `LayerImpl` selects which attention path runs.
+///
+/// Per-layer GDN state is passed in via the [`DecoderLayer::forward`] signature
+/// (a `&mut Option<GdnLayerCache>`); the model holds the canonical cache array.
+pub struct DecoderLayer {
+    layer_impl: LayerImpl,
+    input_layernorm: Qwen35RmsNorm,
+    post_attention_layernorm: Qwen35RmsNorm,
+    mlp: Mlp,
+    /// Pre-computed dims for the GDN path. `None` for full-attention blocks.
+    gdn_dims: Option<GdnDims>,
+}
+
+enum LayerImpl {
+    FullAttention(FullAttention),
+    LinearAttention(GatedDeltaNet),
+}
+
+impl DecoderLayer {
+    pub fn load(
+        cfg: &TextConfig,
+        layer_type: LayerType,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let input_layernorm = Qwen35RmsNorm::load(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
+        let post_attention_layernorm = Qwen35RmsNorm::load(
+            cfg.hidden_size,
+            cfg.rms_norm_eps,
+            vb.pp("post_attention_layernorm"),
+        )?;
+        let mlp = Mlp::load(cfg, vb.pp("mlp"))?;
+
+        let (layer_impl, gdn_dims) = match layer_type {
+            LayerType::FullAttention => (
+                LayerImpl::FullAttention(FullAttention::load(cfg, vb.pp("self_attn"))?),
+                None,
+            ),
+            LayerType::LinearAttention => {
+                let dims = GdnDims::new(cfg);
+                let gdn = GatedDeltaNet::load(vb, cfg, GdnInputProjectionKind::Split)?;
+                (LayerImpl::LinearAttention(gdn), Some(dims))
+            }
+        };
+
+        Ok(Self {
+            layer_impl,
+            input_layernorm,
+            post_attention_layernorm,
+            mlp,
+            gdn_dims,
+        })
+    }
+
+    pub fn is_linear(&self) -> bool {
+        matches!(self.layer_impl, LayerImpl::LinearAttention(_))
+    }
+
+    /// Forward pass. For `LinearAttention` blocks pass `Some(gdn_cache)` and
+    /// `None` for `attn_cache`; for `FullAttention` blocks pass `Some(attn_cache)`
+    /// and `None` for `gdn_cache`.
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        rot_dim: usize,
+        attention_mask: Option<&Tensor>,
+        gdn_cache: Option<&mut GdnLayerCache>,
+        attn_cache: Option<&mut KvCache>,
+        is_decode_step: bool,
+    ) -> Result<Tensor> {
+        let residual = x;
+        let normed = self.input_layernorm.forward(x)?;
+
+        let attn_out = match &self.layer_impl {
+            LayerImpl::FullAttention(attn) => {
+                debug_assert!(gdn_cache.is_none(), "full-attention layer should not receive a GDN cache");
+                attn.forward(&normed, cos, sin, rot_dim, attention_mask, attn_cache)?
+            }
+            LayerImpl::LinearAttention(gdn) => {
+                debug_assert!(attn_cache.is_none(), "linear-attention layer should not receive a KV cache");
+                let cache = gdn_cache.ok_or_else(|| {
+                    candle_core::Error::Msg("GDN cache missing for linear-attention layer".into())
+                })?;
+                let dims = self.gdn_dims.as_ref().ok_or_else(|| {
+                    candle_core::Error::Msg("GDN dims missing for linear-attention layer".into())
+                })?;
+                gdn.forward(&normed, dims, cache, is_decode_step)?
+            }
+        };
+
+        let x = (residual + attn_out)?;
+
+        let residual2 = &x;
+        let normed2 = self.post_attention_layernorm.forward(&x)?;
+
+        let mlp_out = self.mlp.forward(&normed2)?;
+
+        residual2 + mlp_out
+    }
+}
+
+/// Choose between a dedicated `lm_head` weight and the tied `embed_tokens`
+/// weight, based on `tie_word_embeddings`.
+pub fn resolve_tied(tie: bool, embed_weight: Tensor, lm_head_weight: Option<Tensor>) -> Tensor {
+    match lm_head_weight {
+        Some(w) => w,
+        None if tie => embed_weight,
+        None => embed_weight,
+    }
+}

--- a/crane-core/src/ops/gdn/backend.rs
+++ b/crane-core/src/ops/gdn/backend.rs
@@ -1,11 +1,11 @@
 //! Numerical kernels for Gated Delta Net: L2 normalization, softplus, the
 //! gated delta rule recurrence, causal Conv1D, and dispatch.
 //!
-//! The recurrence and Conv1D are written as compositions of Candle tensor ops,
-//! so they run on any device (CPU/CUDA/Metal). On CUDA, an optional fused
-//! kernel is also available (see [`super::cuda_backend`]); set
-//! `CRANE_GDN_PORTABLE=1` to force the op-by-op path for cross-checking
-//! numerics against the reference.
+//! The portable recurrence is a composition of Candle tensor ops, so it runs
+//! on any device (CPU/CUDA/Metal). On CUDA an optional fused kernel is also
+//! available (see [`super::cuda_backend`]) and is used by default; set
+//! `CRANE_GDN_PORTABLE=1` to force the portable op-by-op path for
+//! cross-checking numerics.
 
 use candle_core::{DType, IndexOp, Result, Tensor, D};
 
@@ -47,7 +47,9 @@ pub fn softplus(x: &Tensor) -> Result<Tensor> {
 /// - `state`: `[BH, K, V]` — recurrent state (mutated in place)
 ///
 /// Returns `y: [BH, S, V]`. `state` is updated to the post-final-step value.
-/// Output dtype matches `q.dtype()`.
+///
+/// This is the exact CPU fallback lifted from mistral.rs
+/// (`mistralrs-core/src/gdn/backend.rs:30-81`). Output dtype matches `q.dtype()`.
 pub fn gated_delta_rule_recurrence(
     q: &Tensor,
     k: &Tensor,
@@ -59,11 +61,12 @@ pub fn gated_delta_rule_recurrence(
     let dtype = q.dtype();
 
     // HF's gated delta rule scales Q by `1/sqrt(head_k_dim)` before the
-    // recurrence (`scale = 1 / query.shape[-1]**0.5` in
-    // `torch_recurrent_gated_delta_rule`). Omitting it leaves the recurrence
-    // output a factor of `sqrt(K)` too large, which is not washed out
-    // downstream because the gated RMSNorm eps and the silu gate make it
-    // observable.
+    // recurrence (`scale = 1 / query.shape[-1]**0.5` in both
+    // `torch_chunk_gated_delta_rule` and `torch_recurrent_gated_delta_rule`).
+    // Omitting it leaves the recurrence output a factor of `sqrt(K)` too large
+    // (verified: cos=1.0 vs HF but ~11.3x = sqrt(128) magnitude), which is NOT
+    // washed out downstream because the gated RMSNorm's eps and the silu gate
+    // make it observable. mistral.rs applies the same scale.
     let scale = 1.0 / (q.dim(D::Minus1)? as f64).sqrt();
     let q = (q.affine(scale, 0.0)?).transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
     let k = k.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
@@ -151,11 +154,10 @@ pub fn compute_beta_g(
 /// Compute β and g, run the gated delta rule recurrence, return the output.
 ///
 /// The recurrence is written in pure-Candle tensor ops, so it runs on any
-/// device (CPU/CUDA/Metal) — every op has a native backend kernel. On CUDA,
-/// a fused single-launch kernel is preferred when available
-/// ([`super::cuda_backend::gdn_recurrence_cuda`]); set
-/// `CRANE_GDN_PORTABLE=1` to force the op-by-op path for cross-checking
-/// numerics.
+/// device (CPU/CUDA/Metal) — every op has a native backend kernel. On CUDA
+/// the fused single-launch kernel (see [`super::cuda_backend`]) is used by
+/// default; set `CRANE_GDN_PORTABLE=1` to force the portable op-by-op path
+/// for cross-checking numerics.
 #[allow(unused_variables)]
 pub fn apply_recurrence(
     q: &Tensor,
@@ -174,6 +176,7 @@ pub fn apply_recurrence(
         return cuda_recurrence(q, k, v, g, beta, dims, batch_size, seq_len, cache, dtype);
     }
 
+    // Device-portable reference (runs on CPU/CUDA/Metal).
     gated_delta_rule_recurrence(q, k, v, g, beta, &mut cache.recurrent_state)
 }
 
@@ -331,9 +334,9 @@ mod tests {
     use candle_core::{Device, Tensor};
 
     /// Smoke test: recurrence runs end-to-end on CPU and produces the right
-    /// output shape. Numerical correctness against HF Transformers is
-    /// exercised by the engine-level smoke tests against a real Qwen 3.5
-    /// checkpoint.
+    /// output shape. Numerical correctness against a reference (HF Transformers
+    /// / mistral.rs) is checked in the integration test that loads a real
+    /// Qwen 3.5 checkpoint.
     #[test]
     fn recurrence_runs_and_returns_correct_shape() {
         let dev = Device::Cpu;

--- a/crane-core/src/ops/gdn/backend.rs
+++ b/crane-core/src/ops/gdn/backend.rs
@@ -1,0 +1,398 @@
+//! Numerical kernels for Gated Delta Net: L2 normalization, softplus, the
+//! gated delta rule recurrence, causal Conv1D, and dispatch.
+//!
+//! The recurrence and Conv1D are written as compositions of Candle tensor ops,
+//! so they run on any device (CPU/CUDA/Metal). On CUDA, an optional fused
+//! kernel is also available (see [`super::cuda_backend`]); set
+//! `CRANE_GDN_PORTABLE=1` to force the op-by-op path for cross-checking
+//! numerics against the reference.
+
+use candle_core::{DType, IndexOp, Result, Tensor, D};
+
+use super::cache::GdnLayerCache;
+use super::config::GdnDims;
+
+// ─────────────────────────────────────────────────────────────────────
+//  Elementwise helpers
+// ─────────────────────────────────────────────────────────────────────
+
+/// `x / sqrt(mean(x^2) + eps)` over the last dim — used to normalize Q and K
+/// before the delta-rule recurrence.
+pub fn l2_norm(x: &Tensor, eps: f64) -> Result<Tensor> {
+    let inv_norm = x
+        .sqr()?
+        .sum_keepdim(D::Minus1)?
+        .broadcast_add(&Tensor::new(eps as f32, x.device())?.to_dtype(x.dtype())?)?
+        .sqrt()?
+        .recip()?;
+    x.broadcast_mul(&inv_norm)
+}
+
+/// `log(1 + exp(x))` — numerically stable; computed as `log1p(exp(x))`.
+pub fn softplus(x: &Tensor) -> Result<Tensor> {
+    (Tensor::ones_like(x)? + x.exp()?)?.log()
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Gated delta rule recurrence (CPU reference)
+// ─────────────────────────────────────────────────────────────────────
+
+/// Per-timestep gated delta rule in pure Candle ops.
+///
+/// Inputs (all contiguous, f32):
+/// - `q, k`: `[BH, S, K]` — queries / keys
+/// - `v`:    `[BH, S, V]` — values
+/// - `g`:    `[BH, S]`    — log-decay (already pre-softplus'd by the caller)
+/// - `beta`: `[BH, S]`    — write strength
+/// - `state`: `[BH, K, V]` — recurrent state (mutated in place)
+///
+/// Returns `y: [BH, S, V]`. `state` is updated to the post-final-step value.
+/// Output dtype matches `q.dtype()`.
+pub fn gated_delta_rule_recurrence(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    state: &mut Tensor,
+) -> Result<Tensor> {
+    let dtype = q.dtype();
+
+    // HF's gated delta rule scales Q by `1/sqrt(head_k_dim)` before the
+    // recurrence (`scale = 1 / query.shape[-1]**0.5` in
+    // `torch_recurrent_gated_delta_rule`). Omitting it leaves the recurrence
+    // output a factor of `sqrt(K)` too large, which is not washed out
+    // downstream because the gated RMSNorm eps and the silu gate make it
+    // observable.
+    let scale = 1.0 / (q.dim(D::Minus1)? as f64).sqrt();
+    let q = (q.affine(scale, 0.0)?).transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let k = k.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let v = v.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let g = g.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+    let beta = beta.transpose(1, 2)?.contiguous()?.to_dtype(DType::F32)?;
+
+    let seq_len = q.dim(2)?;
+    let mut s = state.to_dtype(DType::F32)?;
+    let mut outputs = Vec::with_capacity(seq_len);
+
+    for i in 0..seq_len {
+        let q_t = q.i((.., .., i, ..))?;
+        let k_t = k.i((.., .., i, ..))?;
+        let v_t = v.i((.., .., i, ..))?;
+        let g_t = g.i((.., .., i))?;
+        let beta_t = beta.i((.., .., i))?;
+
+        // 1. Decay state by per-head factor.
+        let decay = g_t.exp()?.unsqueeze(D::Minus1)?.unsqueeze(D::Minus1)?;
+        s = s.broadcast_mul(&decay)?;
+
+        // 2. Retrieve kv_mem = sum_d_state(state * k).
+        let k_exp = k_t.unsqueeze(D::Minus1)?;
+        let kv_mem = s.broadcast_mul(&k_exp)?.sum(2)?;
+
+        // 3. Delta rule residual.
+        let beta_exp = beta_t.unsqueeze(D::Minus1)?;
+        let delta = (v_t - kv_mem)?.broadcast_mul(&beta_exp)?;
+
+        // 4. Write state update: S += outer(k, delta).
+        let outer = k_exp.broadcast_mul(&delta.unsqueeze(2)?)?;
+        s = (s + outer)?;
+
+        // 5. Output: y = sum_d_state(state * q).
+        let q_exp = q_t.unsqueeze(D::Minus1)?;
+        let y_t = s.broadcast_mul(&q_exp)?.sum(2)?;
+        outputs.push(y_t);
+    }
+
+    *state = s.to_dtype(state.dtype())?;
+
+    Tensor::stack(&outputs, 2)?
+        .transpose(1, 2)?
+        .contiguous()?
+        .to_dtype(dtype)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  β/g computation (pre-recurrence)
+// ─────────────────────────────────────────────────────────────────────
+
+/// Derive the per-head write strength β and per-step decay g from the
+/// projections, A_log, and dt_bias.
+///
+/// `b: [B, S, H]` raw logits → `beta = sigmoid(b)`.
+/// `a: [B, S, H]` raw values → combined with `A_log` (negative log of decay
+/// rate) and `dt_bias` to produce `g = -exp(A_log) * softplus(a + dt_bias)`.
+pub fn compute_beta_g(
+    b: &Tensor,
+    a: &Tensor,
+    a_log: &Tensor,
+    dt_bias: &Tensor,
+    dtype: DType,
+) -> Result<(Tensor, Tensor)> {
+    // β and g are tiny per-head ops; computed in pure Candle.
+    let beta = candle_nn::ops::sigmoid(b)?;
+    let a_f = a.to_dtype(DType::F32)?;
+    let dt_bias_expanded = dt_bias.to_dtype(DType::F32)?.unsqueeze(0)?.unsqueeze(0)?;
+    let g = a_log
+        .to_dtype(DType::F32)?
+        .exp()?
+        .neg()?
+        .unsqueeze(0)?
+        .unsqueeze(0)?
+        .broadcast_mul(&softplus(&a_f.broadcast_add(&dt_bias_expanded)?)?)?
+        .to_dtype(dtype)?;
+    Ok((beta, g))
+}
+
+// ─────────────────────────────────────────────────────────────────────
+//  Dispatch entry points
+// ─────────────────────────────────────────────────────────────────────
+
+/// Compute β and g, run the gated delta rule recurrence, return the output.
+///
+/// The recurrence is written in pure-Candle tensor ops, so it runs on any
+/// device (CPU/CUDA/Metal) — every op has a native backend kernel. On CUDA,
+/// a fused single-launch kernel is preferred when available
+/// ([`super::cuda_backend::gdn_recurrence_cuda`]); set
+/// `CRANE_GDN_PORTABLE=1` to force the op-by-op path for cross-checking
+/// numerics.
+#[allow(unused_variables)]
+pub fn apply_recurrence(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    dims: &GdnDims,
+    batch_size: usize,
+    seq_len: usize,
+    cache: &mut GdnLayerCache,
+    dtype: DType,
+) -> Result<Tensor> {
+    #[cfg(feature = "cuda")]
+    if q.device().is_cuda() && std::env::var("CRANE_GDN_PORTABLE").is_err() {
+        return cuda_recurrence(q, k, v, g, beta, dims, batch_size, seq_len, cache, dtype);
+    }
+
+    gated_delta_rule_recurrence(q, k, v, g, beta, &mut cache.recurrent_state)
+}
+
+/// Prepare tensors and launch the fused CUDA recurrence kernel.
+///
+/// Lays inputs out as the kernel expects (`[BH, S, *]`, contiguous f32),
+/// applies the `1/sqrt(K)` query scale here (the kernel takes plain q), then
+/// reshapes the result back to the portable path's `[B, S, num_v_heads, V]`.
+#[cfg(feature = "cuda")]
+fn cuda_recurrence(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    dims: &GdnDims,
+    batch_size: usize,
+    seq_len: usize,
+    cache: &mut GdnLayerCache,
+    dtype: DType,
+) -> Result<Tensor> {
+    let (hv, kd, vd) = (dims.num_v_heads, dims.head_k_dim, dims.head_v_dim);
+    let bh = batch_size * hv;
+    let scale = 1.0 / (kd as f64).sqrt();
+
+    // [B, S, Hv, *] -> [B, Hv, S, *] -> [BH, S, *], contiguous f32.
+    let prep3 = |t: &Tensor| -> Result<Tensor> {
+        t.to_dtype(DType::F32)?
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((bh, seq_len, ()))
+    };
+    let prep2 = |t: &Tensor| -> Result<Tensor> {
+        t.to_dtype(DType::F32)?
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape((bh, seq_len))
+    };
+    let q3 = prep3(q)?.affine(scale, 0.0)?;
+    let k3 = prep3(k)?;
+    let v3 = prep3(v)?;
+    let g2 = prep2(g)?;
+    let beta2 = prep2(beta)?;
+    let state3 = cache
+        .recurrent_state
+        .to_dtype(DType::F32)?
+        .reshape((bh, kd, vd))?
+        .contiguous()?;
+
+    let (y, state_out) =
+        super::cuda_backend::gdn_recurrence_cuda(&q3, &k3, &v3, &g2, &beta2, &state3)?;
+
+    cache.recurrent_state = state_out.reshape((batch_size, hv, kd, vd))?;
+    // [BH, S, V] -> [B, Hv, S, V] -> [B, S, Hv, V], back to model dtype.
+    y.reshape((batch_size, hv, seq_len, vd))?
+        .transpose(1, 2)?
+        .contiguous()?
+        .to_dtype(dtype)
+}
+
+/// Causal Conv1D over the QKV channels. Dispatches to a kernel-based
+/// implementation when available, pure-Candle otherwise.
+pub fn causal_conv1d(
+    x: &Tensor,
+    conv1d_weight: &Tensor,
+    dims: &GdnDims,
+    cache: &mut GdnLayerCache,
+    is_decode_step: bool,
+) -> Result<Tensor> {
+    if is_decode_step {
+        causal_conv1d_update(x, conv1d_weight, dims, cache)
+    } else {
+        causal_conv1d_full(x, conv1d_weight, dims, cache)
+    }
+}
+
+/// Single-step Conv1D for autoregressive decode. Concatenates the new token
+/// to the cached conv state, computes one output, then rolls the cache by 1.
+fn causal_conv1d_update(
+    x: &Tensor,
+    conv1d_weight: &Tensor,
+    dims: &GdnDims,
+    cache: &mut GdnLayerCache,
+) -> Result<Tensor> {
+    let (_, seq_len, _) = x.dims3()?;
+    let x_t = x.transpose(1, 2)?.contiguous()?;
+    // `conv_state` is shape `[1, conv_dim, kernel_size]` — the kernel-size
+    // dim is the LAST (matches mistral.rs).
+    let state_len = cache.conv_state.dim(2)?;
+    let hidden_new = Tensor::cat(&[cache.conv_state.clone(), x_t], 2)?;
+    let new_len = hidden_new.dim(2)?;
+    cache.conv_state = hidden_new.narrow(2, new_len - state_len, state_len)?;
+
+    let weight = conv1d_weight.squeeze(1)?.to_dtype(hidden_new.dtype())?;
+    let mut conv_outputs = Vec::with_capacity(seq_len);
+    let total_len = hidden_new.dim(2)?;
+    for i in (total_len - seq_len)..total_len {
+        let window = hidden_new.narrow(2, i + 1 - dims.conv_kernel_size, dims.conv_kernel_size)?;
+        let out = (window * weight.unsqueeze(0)?)?.sum(D::Minus1)?;
+        conv_outputs.push(out);
+    }
+    candle_nn::ops::silu(&Tensor::stack(&conv_outputs, 2)?)?.transpose(1, 2)
+}
+
+/// Multi-step Conv1D used during prefill. Pads on the left by `kernel - 1`,
+/// runs the full convolution, then captures the trailing `kernel - 1` tokens
+/// into the cache for the next decode step.
+fn causal_conv1d_full(
+    x: &Tensor,
+    conv1d_weight: &Tensor,
+    dims: &GdnDims,
+    cache: &mut GdnLayerCache,
+) -> Result<Tensor> {
+    let (batch_size, seq_len, conv_dim) = x.dims3()?;
+    let x_t = x.transpose(1, 2)?.contiguous()?;
+
+    // Pad on the time dim (the last) and capture the trailing `kernel - 1`
+    // tokens into the cache for the next decode step.
+    let pad_width = dims.conv_kernel_size.saturating_sub(seq_len);
+    cache.conv_state = if pad_width > 0 {
+        let zeros = Tensor::zeros((batch_size, conv_dim, pad_width), x_t.dtype(), x_t.device())?;
+        Tensor::cat(&[zeros, x_t.clone()], 2)?
+    } else {
+        x_t.narrow(2, seq_len - dims.conv_kernel_size, dims.conv_kernel_size)?
+    };
+
+    let padded_t = Tensor::cat(
+        &[
+            Tensor::zeros(
+                (batch_size, conv_dim, dims.conv_kernel_size - 1),
+                x_t.dtype(),
+                x_t.device(),
+            )?,
+            x_t,
+        ],
+        2,
+    )?;
+
+    let weight = conv1d_weight.squeeze(1)?.to_dtype(padded_t.dtype())?;
+    let mut conv_outputs = Vec::with_capacity(seq_len);
+    for i in 0..seq_len {
+        let window = padded_t.narrow(2, i, dims.conv_kernel_size)?;
+        let out = (window * weight.unsqueeze(0)?)?.sum(D::Minus1)?;
+        conv_outputs.push(out);
+    }
+    candle_nn::ops::silu(&Tensor::stack(&conv_outputs, 2)?)?.transpose(1, 2)
+}
+// ─────────────────────────────────────────────────────────────────────
+//  Tests
+// ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    /// Smoke test: recurrence runs end-to-end on CPU and produces the right
+    /// output shape. Numerical correctness against HF Transformers is
+    /// exercised by the engine-level smoke tests against a real Qwen 3.5
+    /// checkpoint.
+    #[test]
+    fn recurrence_runs_and_returns_correct_shape() {
+        let dev = Device::Cpu;
+        let q = Tensor::new(
+            &[[
+                [[1.0f32, 0.0]],
+                [[0.0, 1.0]],
+                [[1.0, 1.0]],
+                [[0.5, 0.5]],
+            ]],
+            &dev,
+        )
+        .unwrap();
+        let k = Tensor::new(
+            &[[
+                [[1.0f32, 0.0]],
+                [[0.0, 1.0]],
+                [[1.0, 0.0]],
+                [[0.0, 1.0]],
+            ]],
+            &dev,
+        )
+        .unwrap();
+        let v = Tensor::new(
+            &[[
+                [[1.0f32, 0.0]],
+                [[0.0, 1.0]],
+                [[1.0, 1.0]],
+                [[0.5, 0.5]],
+            ]],
+            &dev,
+        )
+        .unwrap();
+        let g = Tensor::new(&[[[0.0f32], [0.0], [0.0], [0.0]]], &dev).unwrap();
+        let beta = Tensor::new(&[[[1.0f32], [1.0], [1.0], [1.0]]], &dev).unwrap();
+
+        let mut state = Tensor::zeros((1, 1, 2, 2), DType::F32, &dev).unwrap();
+        let y = gated_delta_rule_recurrence(&q, &k, &v, &g, &beta, &mut state).unwrap();
+        assert_eq!(y.dims(), &[1, 4, 1, 2]);
+        // State must have been mutated in place.
+        assert!(state.dims() == [1, 1, 2, 2]);
+    }
+
+    #[test]
+    fn l2_norm_preserves_direction() {
+        let dev = Device::Cpu;
+        let x = Tensor::new(&[[3.0f32, 4.0], [1.0, 0.0]], &dev).unwrap();
+        let n = l2_norm(&x, 1e-6).unwrap();
+        let v0 = n.i((0, ..)).unwrap().to_vec1::<f32>().unwrap();
+        assert!((v0[0] - 0.6).abs() < 1e-3 && (v0[1] - 0.8).abs() < 1e-3);
+        let v1 = n.i((1, ..)).unwrap().to_vec1::<f32>().unwrap();
+        assert!((v1[0] - 1.0).abs() < 1e-3 && v1[1].abs() < 1e-3);
+    }
+
+    #[test]
+    fn softplus_at_zero_is_ln2() {
+        let dev = Device::Cpu;
+        let x = Tensor::new(0.0f32, &dev).unwrap();
+        let s = softplus(&x).unwrap().to_scalar::<f32>().unwrap();
+        assert!((s - std::f32::consts::LN_2).abs() < 1e-4);
+    }
+}

--- a/crane-core/src/ops/gdn/cache.rs
+++ b/crane-core/src/ops/gdn/cache.rs
@@ -1,0 +1,55 @@
+//! Per-layer state for a Gated Delta Net: causal Conv1D ring buffer plus the
+//! recurrent `(K, V)` matrix per head.
+
+use candle_core::{DType, Device, Result, Tensor};
+
+use super::config::GdnDims;
+
+/// State held by one Gated Delta Net layer across decoding steps.
+///
+/// `conv_state` rolls the most recent `conv_kernel_size - 1` QKV channels so
+/// the next decode step can apply the causal Conv1D without reprocessing
+/// history. `recurrent_state` is the per-head `(K, V)` matrix that carries the
+/// linear-attention memory; always f32 regardless of model dtype.
+#[derive(Debug)]
+pub struct GdnLayerCache {
+    pub conv_state: Tensor,
+    pub recurrent_state: Tensor,
+}
+
+impl GdnLayerCache {
+    /// Allocate zero-initialized state for a single sequence.
+    pub fn new(cfg: &dyn super::config::GdnConfig, dtype: DType, device: &Device) -> Result<Self> {
+        let dims = GdnDims::new(cfg);
+        // 3D shape `[1, conv_dim, kernel_size]` — the leading dim lets the
+        // cache broadcast cleanly against per-batch QKV tensors in
+        // `causal_conv1d_full` / `_update`.
+        let conv_state = Tensor::zeros((1, dims.conv_dim, dims.conv_kernel_size), dtype, device)?;
+        let recurrent_state = Tensor::zeros(
+            (1, dims.num_v_heads, dims.head_k_dim, dims.head_v_dim),
+            DType::F32,
+            device,
+        )?;
+        Ok(Self {
+            conv_state,
+            recurrent_state,
+        })
+    }
+
+    /// Zero out the state for reuse (e.g. between unrelated requests sharing a
+    /// pre-allocated layer). Avoids re-allocating the underlying tensors.
+    pub fn reset(&mut self) -> Result<()> {
+        self.conv_state = self.conv_state.zeros_like()?;
+        self.recurrent_state = self.recurrent_state.zeros_like()?;
+        Ok(())
+    }
+}
+
+impl Clone for GdnLayerCache {
+    fn clone(&self) -> Self {
+        Self {
+            conv_state: self.conv_state.clone(),
+            recurrent_state: self.recurrent_state.clone(),
+        }
+    }
+}

--- a/crane-core/src/ops/gdn/config.rs
+++ b/crane-core/src/ops/gdn/config.rs
@@ -1,0 +1,112 @@
+//! Dimension calculations and config trait for Gated Delta Net layers.
+
+use serde::Deserialize;
+
+/// Per-head dimensions derived from a GDN config.
+///
+/// `key_dim = num_k_heads * head_k_dim`, `value_dim = num_v_heads * head_v_dim`,
+/// `conv_dim = 2 * key_dim + value_dim` (Q/K/V concatenated for the causal conv1d).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GdnDims {
+    pub hidden_size: usize,
+    pub num_k_heads: usize,
+    pub num_v_heads: usize,
+    pub head_k_dim: usize,
+    pub head_v_dim: usize,
+    pub conv_kernel_size: usize,
+    pub key_dim: usize,
+    pub value_dim: usize,
+    pub conv_dim: usize,
+    /// Number of value heads per key head (GQA ratio).
+    pub v_per_group: usize,
+}
+
+impl GdnDims {
+    pub fn new(cfg: &dyn GdnConfig) -> Self {
+        let hidden_size = cfg.hidden_size();
+        let num_k_heads = cfg.linear_num_key_heads();
+        let num_v_heads = cfg.linear_num_value_heads();
+        let head_k_dim = cfg.linear_key_head_dim();
+        let head_v_dim = cfg.linear_value_head_dim();
+        let conv_kernel_size = cfg.linear_conv_kernel_dim();
+        let key_dim = num_k_heads * head_k_dim;
+        let value_dim = num_v_heads * head_v_dim;
+        let conv_dim = key_dim * 2 + value_dim;
+        let v_per_group = num_v_heads / num_k_heads;
+
+        Self {
+            hidden_size,
+            num_k_heads,
+            num_v_heads,
+            head_k_dim,
+            head_v_dim,
+            conv_kernel_size,
+            key_dim,
+            value_dim,
+            conv_dim,
+            v_per_group,
+        }
+    }
+
+    /// Output dimension of the QKV/Z fused projection (Q + K + V + Z concatenated).
+    pub fn qkvz_out_dim(&self) -> usize {
+        self.key_dim * 2 + self.value_dim * 2
+    }
+
+    /// Output dimension of the B/A fused projection (B + A concatenated).
+    pub fn ba_out_dim(&self) -> usize {
+        self.num_v_heads * 2
+    }
+}
+
+/// Trait implemented by model configs that contain linear-attention parameters.
+///
+/// Default impls compute derived dims (`linear_key_dim`, `linear_value_dim`,
+/// `linear_conv_dim`) from the per-head fields.
+pub trait GdnConfig {
+    fn hidden_size(&self) -> usize;
+    fn rms_norm_eps(&self) -> f64;
+    fn linear_conv_kernel_dim(&self) -> usize;
+    fn linear_key_head_dim(&self) -> usize;
+    fn linear_value_head_dim(&self) -> usize;
+    fn linear_num_key_heads(&self) -> usize;
+    fn linear_num_value_heads(&self) -> usize;
+
+    fn linear_key_dim(&self) -> usize {
+        self.linear_num_key_heads() * self.linear_key_head_dim()
+    }
+
+    fn linear_value_dim(&self) -> usize {
+        self.linear_num_value_heads() * self.linear_value_head_dim()
+    }
+
+    fn linear_conv_dim(&self) -> usize {
+        self.linear_key_dim() * 2 + self.linear_value_dim()
+    }
+}
+
+/// Default values for HF `config.json` fields that are sometimes missing.
+#[allow(dead_code)]
+pub mod defaults {
+    pub fn conv_kernel() -> usize {
+        4
+    }
+
+    pub fn partial_rotary_factor() -> f64 {
+        0.25
+    }
+
+    pub fn rope_theta() -> f64 {
+        10_000_000.0
+    }
+
+    pub fn full_attention_interval() -> usize {
+        4
+    }
+}
+
+/// Marker type used by model configs that deserialize nested blocks with
+/// default values (e.g. an empty `rope_parameters` wrapper).
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct Empty {}

--- a/crane-core/src/ops/gdn/cuda_backend.rs
+++ b/crane-core/src/ops/gdn/cuda_backend.rs
@@ -80,28 +80,60 @@ pub fn gdn_recurrence_cuda(
     let y_buf = unsafe { dev.alloc::<f32>(bh * s * vdim) }?;
     let state_out_buf = unsafe { dev.alloc::<f32>(bh * kdim * vdim) }?;
 
-    let func = dev.get_or_load_custom_func("gdn_recurrence_f32", MODULE_NAME, ptx::GDN)?;
+    // V columns are independent and can be tiled across blocks, but for these
+    // shapes one block per head (V_TILE == V, ~4 warps) hides the serial
+    // inner-loop latency best, so default there. Tunable via CRANE_GDN_VTILE.
+    let v_tile = std::env::var("CRANE_GDN_VTILE")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|t| *t > 0)
+        .unwrap_or(vdim)
+        .min(vdim);
+    let tiles = vdim.div_ceil(v_tile);
     let cfg = LaunchConfig {
-        grid_dim: (bh as u32, 1, 1),
-        block_dim: (vdim as u32, 1, 1),
+        grid_dim: ((bh * tiles) as u32, 1, 1),
+        block_dim: (v_tile as u32, 1, 1),
         shared_mem_bytes: (2 * kdim * std::mem::size_of::<f32>()) as u32,
     };
 
-    let (bh_i, s_i, k_i, v_i) = (bh as i32, s as i32, kdim as i32, vdim as i32);
-    let mut builder = func.builder();
-    builder.arg(&q_v);
-    builder.arg(&k_v);
-    builder.arg(&v_v);
-    builder.arg(&g_v);
-    builder.arg(&beta_v);
-    builder.arg(&state_v);
-    builder.arg(&state_out_buf);
-    builder.arg(&y_buf);
-    builder.arg(&bh_i);
-    builder.arg(&s_i);
-    builder.arg(&k_i);
-    builder.arg(&v_i);
-    unsafe { builder.launch(cfg) }.w()?;
+    // Specialized register-resident kernel for K==128 (state column in
+    // registers); runtime-K fallback otherwise (local memory).
+    let (bh_i, s_i, k_i, v_i, vt_i) = (bh as i32, s as i32, kdim as i32, vdim as i32, v_tile as i32);
+    if kdim == 128 {
+        let func =
+            dev.get_or_load_custom_func("gdn_recurrence_f32_k128", MODULE_NAME, ptx::GDN)?;
+        let mut builder = func.builder();
+        builder.arg(&q_v);
+        builder.arg(&k_v);
+        builder.arg(&v_v);
+        builder.arg(&g_v);
+        builder.arg(&beta_v);
+        builder.arg(&state_v);
+        builder.arg(&state_out_buf);
+        builder.arg(&y_buf);
+        builder.arg(&bh_i);
+        builder.arg(&s_i);
+        builder.arg(&v_i);
+        builder.arg(&vt_i);
+        unsafe { builder.launch(cfg) }.w()?;
+    } else {
+        let func = dev.get_or_load_custom_func("gdn_recurrence_f32", MODULE_NAME, ptx::GDN)?;
+        let mut builder = func.builder();
+        builder.arg(&q_v);
+        builder.arg(&k_v);
+        builder.arg(&v_v);
+        builder.arg(&g_v);
+        builder.arg(&beta_v);
+        builder.arg(&state_v);
+        builder.arg(&state_out_buf);
+        builder.arg(&y_buf);
+        builder.arg(&bh_i);
+        builder.arg(&s_i);
+        builder.arg(&k_i);
+        builder.arg(&v_i);
+        builder.arg(&vt_i);
+        unsafe { builder.launch(cfg) }.w()?;
+    }
 
     let y = Tensor::from_storage(
         Storage::Cuda(CudaStorage::wrap_cuda_slice(y_buf, dev.clone())),

--- a/crane-core/src/ops/gdn/cuda_backend.rs
+++ b/crane-core/src/ops/gdn/cuda_backend.rs
@@ -1,0 +1,119 @@
+//! CUDA launcher for the fused Gated Delta Net recurrence kernel.
+//!
+//! Collapses the per-timestep Candle op graph into a single kernel launch
+//! (`kernels/gdn.cu`). Inputs must be contiguous f32 CUDA tensors in the
+//! layouts documented on [`gdn_recurrence_cuda`]; `q` is expected pre-scaled
+//! by `1/sqrt(K)` (the caller does this, matching the CPU reference).
+
+use candle_core::cuda_backend::cudarc::driver::{LaunchConfig, PushKernelArg};
+use candle_core::cuda_backend::WrapErr;
+use candle_core::op::BackpropOp;
+use candle_core::{CudaStorage, Result, Storage, Tensor};
+
+// PTX compiled from kernels/gdn.cu — embedded at build time.
+mod ptx {
+    include!(concat!(env!("OUT_DIR"), "/crane_kernels_ptx.rs"));
+}
+
+const MODULE_NAME: &str = "crane_gdn";
+
+/// Run the gated delta rule recurrence on CUDA.
+///
+/// Shapes: `q,k = [BH,S,K]`, `v = [BH,S,V]`, `g,beta = [BH,S]`,
+/// `state = [BH,K,V]`. Returns `(y = [BH,S,V], state_out = [BH,K,V])`.
+pub fn gdn_recurrence_cuda(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    g: &Tensor,
+    beta: &Tensor,
+    state: &Tensor,
+) -> Result<(Tensor, Tensor)> {
+    let (bh, s, kdim) = q.dims3()?;
+    let vdim = v.dim(2)?;
+    if kdim > 256 {
+        candle_core::bail!("gdn cuda kernel supports head_k_dim <= 256, got {kdim}");
+    }
+    let dev = q.device().as_cuda_device()?.clone();
+
+    // Hold the storage guards alive until after the launch; the slice views
+    // borrow from them.
+    let (q_s, q_l) = q.storage_and_layout();
+    let q_sl = match &*q_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: q must be a cuda tensor"),
+    };
+    let (k_s, k_l) = k.storage_and_layout();
+    let k_sl = match &*k_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: k must be a cuda tensor"),
+    };
+    let (v_s, v_l) = v.storage_and_layout();
+    let v_sl = match &*v_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: v must be a cuda tensor"),
+    };
+    let (g_s, g_l) = g.storage_and_layout();
+    let g_sl = match &*g_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: g must be a cuda tensor"),
+    };
+    let (beta_s, beta_l) = beta.storage_and_layout();
+    let beta_sl = match &*beta_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: beta must be a cuda tensor"),
+    };
+    let (state_s, state_l) = state.storage_and_layout();
+    let state_sl = match &*state_s {
+        Storage::Cuda(c) => c.as_cuda_slice::<f32>()?,
+        _ => candle_core::bail!("gdn: state must be a cuda tensor"),
+    };
+
+    // Offsets (tensors are passed contiguous; honor any start offset anyway).
+    let q_v = q_sl.slice(q_l.start_offset()..);
+    let k_v = k_sl.slice(k_l.start_offset()..);
+    let v_v = v_sl.slice(v_l.start_offset()..);
+    let g_v = g_sl.slice(g_l.start_offset()..);
+    let beta_v = beta_sl.slice(beta_l.start_offset()..);
+    let state_v = state_sl.slice(state_l.start_offset()..);
+
+    let y_buf = unsafe { dev.alloc::<f32>(bh * s * vdim) }?;
+    let state_out_buf = unsafe { dev.alloc::<f32>(bh * kdim * vdim) }?;
+
+    let func = dev.get_or_load_custom_func("gdn_recurrence_f32", MODULE_NAME, ptx::GDN)?;
+    let cfg = LaunchConfig {
+        grid_dim: (bh as u32, 1, 1),
+        block_dim: (vdim as u32, 1, 1),
+        shared_mem_bytes: (2 * kdim * std::mem::size_of::<f32>()) as u32,
+    };
+
+    let (bh_i, s_i, k_i, v_i) = (bh as i32, s as i32, kdim as i32, vdim as i32);
+    let mut builder = func.builder();
+    builder.arg(&q_v);
+    builder.arg(&k_v);
+    builder.arg(&v_v);
+    builder.arg(&g_v);
+    builder.arg(&beta_v);
+    builder.arg(&state_v);
+    builder.arg(&state_out_buf);
+    builder.arg(&y_buf);
+    builder.arg(&bh_i);
+    builder.arg(&s_i);
+    builder.arg(&k_i);
+    builder.arg(&v_i);
+    unsafe { builder.launch(cfg) }.w()?;
+
+    let y = Tensor::from_storage(
+        Storage::Cuda(CudaStorage::wrap_cuda_slice(y_buf, dev.clone())),
+        (bh, s, vdim),
+        BackpropOp::none(),
+        false,
+    );
+    let state_out = Tensor::from_storage(
+        Storage::Cuda(CudaStorage::wrap_cuda_slice(state_out_buf, dev.clone())),
+        (bh, kdim, vdim),
+        BackpropOp::none(),
+        false,
+    );
+    Ok((y, state_out))
+}

--- a/crane-core/src/ops/gdn/layer.rs
+++ b/crane-core/src/ops/gdn/layer.rs
@@ -1,0 +1,173 @@
+//! Top-level `GatedDeltaNet` layer: orchestrates input projection, causal
+//! Conv1D, gated delta rule recurrence, gated RMSNorm, and output projection.
+
+use candle_core::{Module, Result, Tensor};
+use candle_nn::{linear_no_bias, Linear, VarBuilder};
+
+use super::backend::{apply_recurrence, causal_conv1d, compute_beta_g, l2_norm};
+use super::cache::GdnLayerCache;
+use super::config::{GdnConfig, GdnDims};
+use super::norm::RmsNormGated;
+use super::projection::{GdnInputProjection, GdnInputProjectionKind};
+
+/// One linear-attention layer as used by Qwen 3.5 (and similar hybrid models).
+///
+/// Field names follow the HF safetensors layout (`linear_attn.in_proj_qkv.weight`,
+/// `linear_attn.conv1d.weight`, `linear_attn.A_log`, …).
+pub struct GatedDeltaNet {
+    pub input_proj: GdnInputProjection,
+    pub conv1d_weight: Tensor,
+    pub dt_bias: Tensor,
+    pub a_log: Tensor,
+    pub norm: RmsNormGated,
+    pub out_proj: Linear,
+}
+
+impl GatedDeltaNet {
+/// Load weights from `vb.pp("linear_attn")`.
+///
+/// `cfg` supplies the dimensions; `projection_kind` selects the QKV/Z/B/A
+/// weight layout (Qwen 3.5 uses [`GdnInputProjectionKind::Split`]).
+pub fn load(
+        vb: VarBuilder,
+        cfg: &dyn GdnConfig,
+        projection_kind: GdnInputProjectionKind,
+) -> Result<Self> {
+        let dims = GdnDims::new(cfg);
+        let vb_la = vb.pp("linear_attn");
+
+        let input_proj = GdnInputProjection::load(vb_la.clone(), &dims, projection_kind)?;
+        let conv1d_weight = vb_la.get(
+            (dims.conv_dim, 1, dims.conv_kernel_size),
+            "conv1d.weight",
+        )?;
+        let dt_bias = vb_la.get(dims.num_v_heads, "dt_bias")?;
+        let a_log = vb_la.get(dims.num_v_heads, "A_log")?;
+
+        let norm = RmsNormGated::new(dims.head_v_dim, cfg.rms_norm_eps(), vb_la.pp("norm"))?;
+        let out_proj = linear_no_bias(dims.value_dim, dims.hidden_size, vb_la.pp("out_proj"))?;
+
+        Ok(Self {
+            input_proj,
+            conv1d_weight,
+            dt_bias,
+            a_log,
+            norm,
+            out_proj,
+        })
+    }
+
+    /// Forward pass over a sequence (prefill or single decode step).
+    ///
+    /// `x: [B, S, hidden_size]`. `cache` is updated in place. Returns
+    /// `[B, S, hidden_size]`.
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        dims: &GdnDims,
+        cache: &mut GdnLayerCache,
+        is_decode_step: bool,
+    ) -> Result<Tensor> {
+        let (batch_size, seq_len, _) = x.dims3()?;
+        let dtype = x.dtype();
+
+        // 1. Input projections → Q, K, V, Z, B, A.
+        let projected = self.input_proj.forward(x, dims, batch_size, seq_len)?;
+
+        // 2. Causal Conv1D over [Q|K|V].
+        let mixed_qkv = projected.conv_input(dims, batch_size, seq_len)?;
+        let mixed_qkv = causal_conv1d(
+            &mixed_qkv,
+            &self.conv1d_weight,
+            dims,
+            cache,
+            is_decode_step,
+        )?;
+
+        // 3. Split → per-head Q, K, V; expand K from num_k_heads → num_v_heads.
+        let (q, k, v) = split_qkv(&mixed_qkv, dims, batch_size, seq_len)?;
+        let (q, k) = repeat_kv_heads(&q, &k, dims)?;
+
+        // 4. L2-normalize Q and K (Qwen 3.5 uses QK-norm = L2).
+        let q = l2_norm(&q, 1e-6)?;
+        let k = l2_norm(&k, 1e-6)?;
+
+        // 5. Compute β (write strength) and g (decay) from B, A, A_log, dt_bias.
+        let (beta, g) =
+            compute_beta_g(&projected.b, &projected.a, &self.a_log, &self.dt_bias, dtype)?;
+
+        // 6. Run the gated delta rule recurrence.
+        let y = apply_recurrence(
+            &q, &k, &v, &g, &beta, dims, batch_size, seq_len, cache, dtype,
+        )?;
+
+        // 7. Gated RMSNorm + output projection.
+        self.finish_forward(y, projected.z, batch_size, seq_len)
+    }
+
+    fn finish_forward(
+        &self,
+        y: Tensor,
+        z: Tensor,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<Tensor> {
+        // y comes out of the recurrence as `[B, S, num_v_heads, head_v_dim]`.
+        // Flatten the head + head_v dims, gated-RMSNorm along head_v, then
+        // reshape back to `[B, S, value_dim]`.
+        let head_v_dim = self.norm_head_dim();
+        let value_dim = y.dim(2)? * head_v_dim;
+        let y_2d = y.reshape(((), head_v_dim))?;
+        let z_2d = z.reshape(((), head_v_dim))?;
+        let y_2d = self.norm.forward(&y_2d, &z_2d)?;
+        let y = y_2d.reshape((batch_size, seq_len, value_dim))?;
+        self.out_proj.forward(&y)
+    }
+
+    fn norm_head_dim(&self) -> usize {
+        // out_proj.weight shape is [value_dim, hidden_size]; head_v_dim is
+        // stored indirectly as value_dim / num_v_heads. We recover it from
+        // the norm's RmsNorm weight length.
+        self.norm.weight_len()
+    }
+}
+
+/// Split the conv1d output `[B, S, conv_dim]` into Q, K, V along the last
+/// dim, then reshape each into `[B, S, num_heads, head_dim]`.
+fn split_qkv(
+    mixed_qkv: &Tensor,
+    dims: &GdnDims,
+    batch_size: usize,
+    seq_len: usize,
+) -> Result<(Tensor, Tensor, Tensor)> {
+    use candle_core::D;
+    let q = mixed_qkv.narrow(D::Minus1, 0, dims.key_dim)?;
+    let k = mixed_qkv.narrow(D::Minus1, dims.key_dim, dims.key_dim)?;
+    let v = mixed_qkv.narrow(D::Minus1, dims.key_dim * 2, dims.value_dim)?;
+    let q = q.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?;
+    let k = k.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?;
+    let v = v.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?;
+    Ok((q, k, v))
+}
+
+/// Expand K (and Q, for symmetry) from `num_k_heads` to `num_v_heads` by
+/// repeating each key head `v_per_group` times (GQA-style expansion for
+/// linear attention).
+///
+/// When `num_k_heads == num_v_heads` (`v_per_group == 1`) this is a no-op.
+fn repeat_kv_heads(q: &Tensor, k: &Tensor, dims: &GdnDims) -> Result<(Tensor, Tensor)> {
+    if dims.v_per_group == 1 {
+        return Ok((q.clone(), k.clone()));
+    }
+    let q = q
+        .unsqueeze(3)?
+        .repeat((1, 1, 1, dims.v_per_group, 1))?
+        .contiguous()?
+        .reshape((q.dim(0)?, q.dim(1)?, dims.num_v_heads, dims.head_k_dim))?;
+    let k = k
+        .unsqueeze(3)?
+        .repeat((1, 1, 1, dims.v_per_group, 1))?
+        .contiguous()?
+        .reshape((k.dim(0)?, k.dim(1)?, dims.num_v_heads, dims.head_k_dim))?;
+    Ok((q, k))
+}

--- a/crane-core/src/ops/gdn/mod.rs
+++ b/crane-core/src/ops/gdn/mod.rs
@@ -26,9 +26,12 @@
 //!
 //! # Origin
 //!
-//! Algorithm inspired by [mistral.rs](https://github.com/EricLBuehler/mistral.rs)
-//! (MIT licensed); Crane's implementation uses plain `candle_nn::Linear`
-//! without that project's tensor-parallel / quantization abstractions.
+//! Algorithm ported from [mistral.rs](https://github.com/EricLBuehler/mistral.rs)
+//! (MIT licensed). Original `GatedDeltaNet` / `gdn` module:
+//! `mistralrs-core/src/gdn/{config,cache,projection,norm,layer}.rs` and
+//! `mistralrs-core/src/cuda/gdn.cu`. Crane's implementation drops the
+//! `mistralrs_quant` / `DeviceMapper` / tensor-parallel abstractions and uses
+//! plain `candle_nn::Linear` with single-device state.
 //!
 //! See also the [Gated Delta Net paper](https://arxiv.org/abs/2412.06464)
 //! (Yang et al., 2024) for the original formulation.
@@ -47,6 +50,8 @@ mod projection;
 pub use backend::{
     causal_conv1d, gated_delta_rule_recurrence, l2_norm, softplus, apply_recurrence,
 };
+#[cfg(feature = "cuda")]
+pub use cuda_backend::gdn_recurrence_cuda;
 pub use cache::GdnLayerCache;
 pub use config::{defaults, GdnConfig, GdnDims};
 pub use layer::GatedDeltaNet;

--- a/crane-core/src/ops/gdn/mod.rs
+++ b/crane-core/src/ops/gdn/mod.rs
@@ -1,0 +1,54 @@
+//! Gated Delta Net (GDN) implementation for hybrid attention models.
+//!
+//! Used by Qwen 3.5 (and other hybrid Mamba/Transformer architectures) for the
+//! `linear_attention` layers that interleave with standard `full_attention`
+//! layers.
+//!
+//! # Algorithm
+//!
+//! Given per-timestep Q, K, V, g (decay), β (write strength), and a learned
+//! negative-exponent A_log used to derive per-head decay, the recurrence is:
+//!
+//! ```text
+//! S = S * exp(g)                  // decay state by head-dependent factor
+//! kv_mem = sum(S * k, d_state)    // retrieve current memory at this k
+//! delta = (v - kv_mem) * beta     // delta-rule residual
+//! S = S + outer(k, delta)         // write update
+//! y = sum(S * q, d_state)         // output via q-projection of state
+//! ```
+//!
+//! State shape: `[batch, num_v_heads, head_k_dim, head_v_dim]`, kept in f32
+//! regardless of model dtype (`mamba_ssm_dtype: float32` in the HF config).
+//!
+//! The QKV input also passes through a causal Conv1D with kernel width 4
+//! (`linear_conv_kernel_dim`) before the recurrence; the conv state is
+//! maintained alongside the recurrent state for decode-step inference.
+//!
+//! # Origin
+//!
+//! Algorithm inspired by [mistral.rs](https://github.com/EricLBuehler/mistral.rs)
+//! (MIT licensed); Crane's implementation uses plain `candle_nn::Linear`
+//! without that project's tensor-parallel / quantization abstractions.
+//!
+//! See also the [Gated Delta Net paper](https://arxiv.org/abs/2412.06464)
+//! (Yang et al., 2024) for the original formulation.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
+
+mod backend;
+mod cache;
+mod config;
+#[cfg(feature = "cuda")]
+mod cuda_backend;
+mod layer;
+mod norm;
+mod projection;
+
+pub use backend::{
+    causal_conv1d, gated_delta_rule_recurrence, l2_norm, softplus, apply_recurrence,
+};
+pub use cache::GdnLayerCache;
+pub use config::{defaults, GdnConfig, GdnDims};
+pub use layer::GatedDeltaNet;
+pub use norm::RmsNormGated;
+pub use projection::{GdnInputProjection, GdnInputProjectionKind, GdnProjection};

--- a/crane-core/src/ops/gdn/norm.rs
+++ b/crane-core/src/ops/gdn/norm.rs
@@ -1,0 +1,48 @@
+//! RMSNorm with a SiLU-gated output: `y = (x / rms(x)) * weight * silu(gate)`.
+//!
+//! This is the output-side normalization used by every Gated Delta Net layer in
+//! Qwen 3.5 — the `z` projection (silu-gate) modulates the normalized
+//! recurrence output before it goes through `out_proj`.
+//!
+//! The normalization is computed manually in f32 (rather than via candle's
+//! fused `RmsNorm` op) so it is robust across devices and dtypes: the fused
+//! CUDA op requires `x` and `weight` to share a dtype, but the gated norm runs
+//! in f32 while the model weights may be f16/bf16 on GPU.
+
+use candle_core::{DType, Result, Tensor, D};
+use candle_nn::VarBuilder;
+
+/// `RmsNorm(x) * silu(z)` with a learned per-channel weight (plain `weight`,
+/// no unit offset — matches HF's `Qwen3_5RMSNormGated`).
+pub struct RmsNormGated {
+    weight: Tensor,
+    eps: f64,
+}
+
+impl RmsNormGated {
+    pub fn new(size: usize, eps: f64, vb: VarBuilder) -> Result<Self> {
+        let weight = vb.get(size, "weight")?;
+        Ok(Self { weight, eps })
+    }
+
+    /// Forward pass. `x` and `gate` must share shape `[..., size]`.
+    pub fn forward(&self, x: &Tensor, gate: &Tensor) -> Result<Tensor> {
+        let dtype = x.dtype();
+        let x = x.to_dtype(DType::F32)?;
+        let gate = gate.to_dtype(DType::F32)?;
+        let weight = self.weight.to_dtype(DType::F32)?;
+        // Norm before gate (HF order): normalize, scale by weight, then * silu(gate).
+        let var = x.sqr()?.mean_keepdim(D::Minus1)?;
+        let x_normed = x.broadcast_div(&(var + self.eps)?.sqrt()?)?;
+        let normalized = x_normed.broadcast_mul(&weight)?;
+        let silu_gate = candle_nn::ops::silu(&gate)?;
+        normalized.broadcast_mul(&silu_gate)?.to_dtype(dtype)
+    }
+
+    /// Length of the learned per-channel weight vector. Exposed so that
+    /// callers (e.g. `GatedDeltaNet`) can recover the per-head value dim
+    /// without a separate config field.
+    pub fn weight_len(&self) -> usize {
+        self.weight.dim(0).unwrap_or(0)
+    }
+}

--- a/crane-core/src/ops/gdn/projection.rs
+++ b/crane-core/src/ops/gdn/projection.rs
@@ -1,0 +1,203 @@
+//! Input projections for a Gated Delta Net layer.
+//!
+//! Two linear projections from hidden_size:
+//! 1. `in_proj_qkv` projects to `[Q | K | V]` (concatenated, length `conv_dim`).
+//! 2. `in_proj_z` projects to the gate `Z` (length `value_dim`).
+//! 3. `in_proj_b` projects to the per-head write strength `β` (length
+//!    `num_v_heads`).
+//! 4. `in_proj_a` projects to the per-head A-log (length `num_v_heads`).
+//!
+//! Qwen 3.5 ships the weights as four separate matrices (`Split`); other hybrid
+//! architectures may fuse Q/K/V/Z into one matrix and B/A into another
+//! (`Grouped`). Both layouts are supported; the dispatch is in
+//! [`GdnInputProjection::forward`].
+
+use candle_core::{Module, Result, Tensor, D};
+use candle_nn::{linear_no_bias, Linear, VarBuilder};
+
+/// Whether the source checkpoint stores projections as 4 separate matrices
+/// (`Split`, used by Qwen 3.5) or 2 fused matrices (`Grouped`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GdnInputProjectionKind {
+    /// `in_proj_qkvz` and `in_proj_ba` — two fused matrices.
+    Grouped,
+    /// `in_proj_qkv`, `in_proj_z`, `in_proj_b`, `in_proj_a` — four matrices.
+    Split,
+}
+
+/// Holds the four (or two, in `Grouped` mode) linear projections.
+pub enum GdnInputProjection {
+    Grouped {
+        in_proj_qkvz: Linear,
+        in_proj_ba: Linear,
+    },
+    Split {
+        in_proj_qkv: Linear,
+        in_proj_z: Linear,
+        in_proj_b: Linear,
+        in_proj_a: Linear,
+    },
+}
+
+impl GdnInputProjection {
+    pub fn load(
+        vb: VarBuilder,
+        dims: &super::config::GdnDims,
+        kind: GdnInputProjectionKind,
+    ) -> Result<Self> {
+        match kind {
+            GdnInputProjectionKind::Grouped => {
+                let in_proj_qkvz = linear_no_bias(
+                    dims.hidden_size,
+                    dims.qkvz_out_dim(),
+                    vb.pp("in_proj_qkvz"),
+                )?;
+                let in_proj_ba = linear_no_bias(
+                    dims.hidden_size,
+                    dims.ba_out_dim(),
+                    vb.pp("in_proj_ba"),
+                )?;
+                Ok(Self::Grouped {
+                    in_proj_qkvz,
+                    in_proj_ba,
+                })
+            }
+            GdnInputProjectionKind::Split => {
+                let in_proj_qkv = linear_no_bias(dims.hidden_size, dims.conv_dim, vb.pp("in_proj_qkv"))?;
+                let in_proj_z = linear_no_bias(dims.hidden_size, dims.value_dim, vb.pp("in_proj_z"))?;
+                let in_proj_b = linear_no_bias(dims.hidden_size, dims.num_v_heads, vb.pp("in_proj_b"))?;
+                let in_proj_a = linear_no_bias(dims.hidden_size, dims.num_v_heads, vb.pp("in_proj_a"))?;
+                Ok(Self::Split {
+                    in_proj_qkv,
+                    in_proj_z,
+                    in_proj_b,
+                    in_proj_a,
+                })
+            }
+        }
+    }
+
+    /// Project `x: [B, S, H]` through all four projections and slice into the
+    /// per-tensor Q, K, V, Z, B, A views needed by the recurrence.
+    pub fn forward(
+        &self,
+        x: &Tensor,
+        dims: &super::config::GdnDims,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<GdnProjection> {
+        match self {
+            Self::Grouped {
+                in_proj_qkvz,
+                in_proj_ba,
+            } => GdnProjection::from_grouped(
+                in_proj_qkvz.forward(x)?,
+                in_proj_ba.forward(x)?,
+                dims,
+                batch_size,
+                seq_len,
+            ),
+            Self::Split {
+                in_proj_qkv,
+                in_proj_z,
+                in_proj_b,
+                in_proj_a,
+            } => GdnProjection::from_split(
+                in_proj_qkv.forward(x)?,
+                in_proj_z.forward(x)?,
+                in_proj_b.forward(x)?,
+                in_proj_a.forward(x)?,
+                dims,
+                batch_size,
+                seq_len,
+            ),
+        }
+    }
+}
+
+/// Sliced views produced by [`GdnInputProjection::forward`].
+///
+/// Shapes:
+/// - `q, k`: `[B, S, num_k_heads, head_k_dim]`
+/// - `v, z`: `[B, S, num_v_heads, head_v_dim]`
+/// - `b, a`: `[B, S, num_v_heads]`
+pub struct GdnProjection {
+    pub q: Tensor,
+    pub k: Tensor,
+    pub v: Tensor,
+    pub z: Tensor,
+    pub b: Tensor,
+    pub a: Tensor,
+}
+
+impl GdnProjection {
+    fn from_grouped(
+        mixed_qkvz: Tensor,
+        mixed_ba: Tensor,
+        dims: &super::config::GdnDims,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<Self> {
+        let group_size_qkvz = 2 * dims.head_k_dim + 2 * dims.v_per_group * dims.head_v_dim;
+        let mixed_qkvz = mixed_qkvz.reshape((batch_size, seq_len, dims.num_k_heads, group_size_qkvz))?;
+        let mixed_ba = mixed_ba.reshape((batch_size, seq_len, dims.num_k_heads, 2 * dims.v_per_group))?;
+
+        let mut offset = 0;
+        let q = mixed_qkvz.narrow(D::Minus1, offset, dims.head_k_dim)?;
+        offset += dims.head_k_dim;
+        let k = mixed_qkvz.narrow(D::Minus1, offset, dims.head_k_dim)?;
+        offset += dims.head_k_dim;
+        let v = mixed_qkvz.narrow(D::Minus1, offset, dims.v_per_group * dims.head_v_dim)?;
+        offset += dims.v_per_group * dims.head_v_dim;
+        let z = mixed_qkvz.narrow(D::Minus1, offset, dims.v_per_group * dims.head_v_dim)?;
+
+        let b = mixed_ba.narrow(D::Minus1, 0, dims.v_per_group)?;
+        let a = mixed_ba.narrow(D::Minus1, dims.v_per_group, dims.v_per_group)?;
+
+        Ok(Self {
+            q,
+            k,
+            v: v.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
+            z: z.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
+            b: b.reshape((batch_size, seq_len, dims.num_v_heads))?,
+            a: a.reshape((batch_size, seq_len, dims.num_v_heads))?,
+        })
+    }
+
+    fn from_split(
+        mixed_qkv: Tensor,
+        mixed_z: Tensor,
+        mixed_b: Tensor,
+        mixed_a: Tensor,
+        dims: &super::config::GdnDims,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<Self> {
+        let q = mixed_qkv.narrow(D::Minus1, 0, dims.key_dim)?;
+        let k = mixed_qkv.narrow(D::Minus1, dims.key_dim, dims.key_dim)?;
+        let v = mixed_qkv.narrow(D::Minus1, dims.key_dim * 2, dims.value_dim)?;
+
+        Ok(Self {
+            q: q.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?,
+            k: k.reshape((batch_size, seq_len, dims.num_k_heads, dims.head_k_dim))?,
+            v: v.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
+            z: mixed_z.reshape((batch_size, seq_len, dims.num_v_heads, dims.head_v_dim))?,
+            b: mixed_b.reshape((batch_size, seq_len, dims.num_v_heads))?,
+            a: mixed_a.reshape((batch_size, seq_len, dims.num_v_heads))?,
+        })
+    }
+
+    /// Reassemble the Q|K|V channels into a single `[B, S, conv_dim]` tensor —
+    /// the input the causal Conv1D expects.
+    pub fn conv_input(
+        &self,
+        dims: &super::config::GdnDims,
+        batch_size: usize,
+        seq_len: usize,
+    ) -> Result<Tensor> {
+        let q = self.q.reshape((batch_size, seq_len, dims.key_dim))?;
+        let k = self.k.reshape((batch_size, seq_len, dims.key_dim))?;
+        let v = self.v.reshape((batch_size, seq_len, dims.value_dim))?;
+        Tensor::cat(&[&q, &k, &v], D::Minus1)
+    }
+}

--- a/crane-core/src/ops/mod.rs
+++ b/crane-core/src/ops/mod.rs
@@ -1,3 +1,13 @@
+//! Custom CUDA kernels and other core ops for Crane transformer inference.
+//!
+//! Submodules:
+//! - [`fused_ops`] — Fused elementwise/normalisation kernels (silu-mul,
+//!   add+rmsnorm, gpu_argmax, top-k, HtoD/DtoH copies).
+//! - [`gdn`]       — Gated Delta Net recurrence (linear-attention path used
+//!   by Qwen 3.5 hybrid layers), with a fused CUDA recurrence kernel.
+
 pub mod fused_ops;
+pub mod gdn;
 
 pub use fused_ops::*;
+pub use gdn::*;

--- a/crane-serve/README.md
+++ b/crane-serve/README.md
@@ -1,4 +1,4 @@
-# crane-oai
+# crane-serve
 
 An OpenAI & SGLang compatible inference API server built on the [Crane](../README.md) framework, with continuous batching support.
 
@@ -7,7 +7,7 @@ An OpenAI & SGLang compatible inference API server built on the [Crane](../READM
 - **OpenAI-compatible API** — Chat Completions, Text Completions, Text-to-Speech, Models, Tokenize/Detokenize
 - **SGLang native API** — `/generate`, `/model_info`, `/server_info` and related endpoints
 - **Continuous batching** — Dedicated inference thread with prefill-priority scheduling, dynamic KV memory budget, and automatic sequence eviction/recovery
-- **Multi-model support** — Auto-detects and loads Hunyuan Dense, Qwen 2.5, Qwen 3, Qwen3-TTS architectures
+- **Multi-model support** — Auto-detects and loads Hunyuan Dense, Qwen 2.5, Qwen 3, Qwen 3.5 (hybrid GDN + softmax), Qwen3-TTS
 - **Qwen3-TTS** — Full two-level TTS inference (Talker + Code Predictor) with native Candle speech-tokenizer decoder (ONNX optional fallback); exposes OpenAI-compatible `/v1/audio/speech`
 - **Streaming** — SSE (Server-Sent Events) token streaming
 - **Cross-platform acceleration** — CPU / CUDA / Apple Metal, selected automatically
@@ -18,29 +18,29 @@ An OpenAI & SGLang compatible inference API server built on the [Crane](../READM
 
 ```bash
 # CPU only
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 
 # CUDA (NVIDIA GPU)
-cargo build -p crane-oai --release --features cuda
+cargo build -p crane-serve --release --features cuda
 ```
 
 ### Run
 
 ```bash
 # Auto-detect model type and device
-crane-oai --model-path /path/to/model
+crane --model-path /path/to/model
 
 # Specify model type and port
-crane-oai --model-path /path/to/Qwen2.5-7B-Instruct \
+crane --model-path /path/to/Qwen2.5-7B-Instruct \
     --model-type qwen25 \
     --port 8000
 
 # GGUF weights
-crane-oai --model-path /path/to/model.gguf \
+crane --model-path /path/to/model.gguf \
     --format gguf
 
 # Force CPU
-crane-oai --model-path /path/to/model --cpu
+crane --model-path /path/to/model --cpu
 ```
 
 ### Qwen3-TTS Quick Start
@@ -75,16 +75,16 @@ python scripts/export_qwen_tts_tokenizer_onnx.py \
 
 ```bash
 # CPU (always available)
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 
 # CUDA
-cargo build -p crane-oai --release --features "cuda"
+cargo build -p crane-serve --release --features "cuda"
 
 # macOS Metal (auto-enabled by target)
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 
 # Start the TTS server (auto-detected from config.json)
-./target/release/crane-oai \
+./target/release/crane \
     --model-path checkpoints/Qwen3-TTS-12Hz-0.6B-Base \
     --model-type qwen3_tts \
     --port 8080
@@ -187,19 +187,19 @@ python scripts/export_qwen_tts_tokenizer_onnx.py \
 
 ```bash
 # CPU
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 
 # CUDA
-cargo build -p crane-oai --release --features "cuda"
+cargo build -p crane-serve --release --features "cuda"
 
 # macOS Metal (auto-enabled by target)
-cargo build -p crane-oai --release
+cargo build -p crane-serve --release
 ```
 
 **3. Start the server:**
 
 ```bash
-./target/release/crane-oai \
+./target/release/crane \
     --model-path checkpoints/Qwen3-TTS-12Hz-0.6B-Base \
     --model-type qwen3_tts \
     --port 8080
@@ -283,7 +283,7 @@ Built-in speakers for the CustomVoice model include: `Serena`, `Vivian`, `Uncle_
 ### Basic CUDA inference
 
 ```bash
-crane-oai --model-path /path/to/Qwen3-8B-Instruct
+crane-serve --model-path /path/to/Qwen3-8B-Instruct
 ```
 
 On CUDA, `model_info` will report the device as `Cuda(0)` (or `Cuda(1)`, etc.).
@@ -294,18 +294,18 @@ GPU memory grows as KV caches accumulate. Use `--gpu-memory-limit` to keep usage
 
 ```bash
 # Hard cap at 8 GB — recommended starting point for a 12 GB GPU
-crane-oai --model-path /path/to/model \
+crane-serve --model-path /path/to/model \
     --gpu-memory-limit 8G \
     --max-seq-len 4096
 
 # Cap at 5 GB for 8 GB VRAM cards
-crane-oai --model-path /path/to/model \
+crane-serve --model-path /path/to/model \
     --gpu-memory-limit 5G \
     --max-seq-len 2048 \
     --max-concurrent 4
 
 # Use 75% of total VRAM
-crane-oai --model-path /path/to/model \
+crane-serve --model-path /path/to/model \
     --gpu-memory-limit 0.75
 ```
 
@@ -325,21 +325,21 @@ When the KV memory budget is exceeded, the engine evicts the longest-output sequ
 GGUF quantization roughly halves VRAM usage compared to FP16:
 
 ```bash
-crane-oai --model-path /path/to/Qwen3-8B-Q4_K_M.gguf \
+crane-serve --model-path /path/to/Qwen3-8B-Q4_K_M.gguf \
     --format gguf \
     --gpu-memory-limit 8G
 ```
 
 ### Multi-GPU note
 
-Currently crane-oai runs on a single CUDA device (device 0). Multi-GPU tensor parallelism is not yet supported.
+Currently crane-serve runs on a single CUDA device (device 0). Multi-GPU tensor parallelism is not yet supported.
 
 ## CLI Parameters
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--model-path` | *(required)* | Path to model directory or GGUF file |
-| `--model-type` | `auto` | Architecture: `auto`, `hunyuan`, `qwen25`, `qwen3`, `qwen3_tts` |
+| `--model-type` | `auto` | Architecture: `auto`, `hunyuan`, `qwen25`, `qwen3`, `qwen3_5`, `qwen3_tts` |
 | `--model-name` | directory name | Model name shown in API responses |
 | `--host` | `0.0.0.0` | Bind address |
 | `--port` | `8080` | Bind port |
@@ -639,7 +639,7 @@ from openai import OpenAI
 
 client = OpenAI(
     base_url="http://localhost:8080/v1",
-    api_key="not-needed",  # crane-oai does not require an API key
+    api_key="not-needed",  # crane-serve does not require an API key
 )
 
 response = client.chat.completions.create(
@@ -662,7 +662,7 @@ for chunk in stream:
 
 ### Text-to-Speech (Qwen3-TTS)
 
-> Start crane-oai with `--model-type qwen3_tts` and a Qwen3-TTS checkpoint.
+> Start crane-serve with `--model-type qwen3_tts` and a Qwen3-TTS checkpoint.
 
 **CustomVoice model (predefined speakers):**
 
@@ -759,7 +759,7 @@ pathlib.Path("voice_clone.wav").write_bytes(r.content)
 ## Source Structure
 
 ```
-crane-oai/src/
+crane-serve/src/
 ├── main.rs              # CLI entry point, AppState, route registration
 ├── openai_api.rs        # OpenAI request/response types (incl. SpeechRequest)
 ├── sglang_api.rs        # SGLang native API types
@@ -788,6 +788,7 @@ crane-oai/src/
 |-------|-------------|---------|---------|-------|
 | Hunyuan Dense | ✅ | ✅ | Safetensors / GGUF | KV pre-alloc, GQA 4D matmul, RoPE cache growth |
 | Qwen 3 | ✅ | ✅ | Safetensors / GGUF | + QK Norm 4D, GGUF quantization |
+| Qwen 3.5 | ❌ | ❌ | Safetensors | Hybrid GDN + softmax attention; CUDA fused recurrence kernel; `max_concurrent=1` |
 | Qwen 2.5 | sequential | ❌ | Safetensors | — |
 | **Qwen3-TTS** | N/A | N/A | Safetensors (ONNX fallback optional) | Dedicated thread; no continuous batching |
 
@@ -804,7 +805,7 @@ Model type is auto-detected from `config.json` (`model_type` / `architectures`) 
 
 ## Notes
 
-- **No API key required** — crane-oai does not authenticate requests.
+- **No API key required** — crane-serve does not authenticate requests.
 - **Single CUDA device** — The server uses CUDA device 0. Multi-GPU tensor parallelism is not yet supported.
 - **KV eviction is lossless** — Evicted sequences preserve their full state and resume automatically; in-flight requests are not dropped or errored.
 - **`--max-seq-len 0`** means no limit. On constrained hardware, always set an explicit value to avoid runaway memory growth.
@@ -817,14 +818,14 @@ Model type is auto-detected from `config.json` (`model_type` / `architectures`) 
 ## Testing
 
 ```bash
-# All unit tests (125 crane-oai + 11 crane-core)
-cargo test -p crane-oai
+# All unit tests
+cargo test -p crane-serve
 cargo test -p crane-core
 
 # Specific modules
-cargo test -p crane-oai engine::scheduler
-cargo test -p crane-oai openai_api::tests
-cargo test -p crane-oai sglang_api::tests
+cargo test -p crane-serve engine::scheduler
+cargo test -p crane-serve openai_api::tests
+cargo test -p crane-serve sglang_api::tests
 cargo test -p crane-core autotokenizer
 ```
 

--- a/crane-serve/src/engine/backend.rs
+++ b/crane-serve/src/engine/backend.rs
@@ -382,6 +382,86 @@ impl ModelBackend for Qwen25Backend {
 }
 
 // ─────────────────────────────────────────────────────────────
+//  Qwen 3.5 Backend
+// ─────────────────────────────────────────────────────────────
+
+/// Engine wrapper around `crane_core::models::qwen3_5::Model`.
+///
+/// Only single-sequence forward is supported (no KV swap, no batch decode).
+/// The hybrid full-attention / GDN layers share a single set of caches; the
+/// engine treats them as opaque per-request state.
+pub struct Qwen3_5Backend {
+    pub model: crane_core::models::qwen3_5::Model,
+    #[allow(dead_code)]
+    dtype: DType,
+}
+
+impl Qwen3_5Backend {
+    pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
+        let model = crane_core::models::qwen3_5::Model::new(model_path, device, dtype)?;
+        Ok(Self {
+            model,
+            dtype: *dtype,
+        })
+    }
+}
+
+impl ModelBackend for Qwen3_5Backend {
+    fn forward_step(&mut self, input_ids: &[u32], start_pos: usize) -> Result<Tensor> {
+        self.model
+            .forward_step(input_ids, start_pos)
+            .map_err(Into::into)
+    }
+
+    fn clear_kv_cache(&mut self) {
+        self.model.clear_kv_cache();
+    }
+
+    fn num_layers(&self) -> usize {
+        // The KV-cache vector sizing is a no-op for this backend — we always
+        // reset full-attention state implicitly via GDN-cache reset, and the
+        // engine caps `max_concurrent` to 1 since `supports_kv_swap` is false.
+        self.model.num_layers()
+    }
+
+    fn device(&self) -> &Device {
+        &self.model.device
+    }
+
+    fn dtype(&self) -> DType {
+        self.model.dtype
+    }
+
+    fn tokenizer(&self) -> &tokenizers::Tokenizer {
+        &self.model.tokenizer.tokenizer
+    }
+
+    fn eos_token_id(&self) -> Vec<u32> {
+        // Qwen 3 / 3.5 chat models stop at 151645 () and 151643 ().
+        let tok = &self.model.tokenizer.tokenizer;
+        let mut ids = Vec::new();
+        if let Some(id) = tok.token_to_id("") {
+            ids.push(id);
+        }
+        if let Some(id) = tok.token_to_id("") {
+            ids.push(id);
+        }
+        if ids.is_empty() {
+            ids.push(151645);
+            ids.push(151643);
+        }
+        ids
+    }
+
+    fn warmup(&mut self) {
+        self.model.warmup();
+    }
+
+    // supports_kv_swap defaults to false → engine caps max_concurrent to 1.
+    // Batch decode is not yet implemented for hybrid layer types.
+}
+
+// ─────────────────────────────────────────────────────────────
 //  Qwen 3 Backend
 // ─────────────────────────────────────────────────────────────
 

--- a/crane-serve/src/engine/model_factory.rs
+++ b/crane-serve/src/engine/model_factory.rs
@@ -8,7 +8,9 @@ use candle_core::{DType, Device};
 use serde::Deserialize;
 use std::path::Path;
 
-use super::backend::{Gemma4Backend, HunyuanBackend, ModelBackend, Qwen25Backend, Qwen3Backend};
+use super::backend::{
+    Gemma4Backend, HunyuanBackend, ModelBackend, Qwen25Backend, Qwen3Backend, Qwen3_5Backend,
+};
 use crate::chat_template::{AutoChatTemplate, ChatTemplateProcessor, HunyuanChatTemplate};
 
 // ─────────────────────────────────────────────────────────────
@@ -24,6 +26,7 @@ pub enum ModelType {
     HunyuanDense,
     Qwen25,
     Qwen3,
+    Qwen3_5,
     Qwen3TTS,
     PaddleOcrVl,
 }
@@ -36,6 +39,7 @@ impl ModelType {
             "hunyuan" | "hunyuan_dense" | "hunyuandense" => Self::HunyuanDense,
             "qwen25" | "qwen2.5" | "qwen2" => Self::Qwen25,
             "qwen3" => Self::Qwen3,
+            "qwen3_5" | "qwen3.5" | "qwen35" | "qwen3_5_dense" => Self::Qwen3_5,
             "qwen3_tts" | "qwen3tts" | "qwen3-tts" | "tts" => Self::Qwen3TTS,
             "paddleocr_vl" | "paddleocrv" | "paddleocr" | "paddle_ocr_vl" | "paddleocrvl" => Self::PaddleOcrVl,
             _ => Self::Auto,
@@ -50,6 +54,7 @@ impl ModelType {
             Self::HunyuanDense => "hunyuan",
             Self::Qwen25 => "qwen25",
             Self::Qwen3 => "qwen3",
+            Self::Qwen3_5 => "qwen3_5",
             Self::Qwen3TTS => "qwen3_tts",
             Self::PaddleOcrVl => "paddleocr_vl",
         }
@@ -122,6 +127,7 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
                         }
                         "qwen2" | "qwen2.5" => return ModelType::Qwen25,
                         "qwen3" => return ModelType::Qwen3,
+                        "qwen3_5" | "qwen3.5" => return ModelType::Qwen3_5,
                         "qwen3_tts" | "qwen3tts" => return ModelType::Qwen3TTS,
                         m if m.contains("hunyuan") => return ModelType::HunyuanDense,
                         m if m.contains("paddleocr") => return ModelType::PaddleOcrVl,
@@ -144,6 +150,9 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
                         }
                         if a.contains("qwen3ttsforconditional") || a.contains("qwen3_tts") {
                             return ModelType::Qwen3TTS;
+                        }
+                        if a.contains("qwen3_5") || a.contains("qwen3.5") {
+                            return ModelType::Qwen3_5;
                         }
                         if a.contains("qwen3") {
                             return ModelType::Qwen3;
@@ -222,6 +231,7 @@ pub fn create_backend(
         }
         ModelType::Qwen25 => Ok(Box::new(Qwen25Backend::new(model_path, device, dtype)?)),
         ModelType::Qwen3 => Ok(Box::new(Qwen3Backend::new(model_path, device, dtype)?)),
+        ModelType::Qwen3_5 => Ok(Box::new(Qwen3_5Backend::new(model_path, device, dtype)?)),
         ModelType::PaddleOcrVl => {
             anyhow::bail!("PaddleOCR-VL is a VLM model — use create_vlm_model() instead of create_backend()")
         }

--- a/crane/src/llm/client.rs
+++ b/crane/src/llm/client.rs
@@ -15,6 +15,10 @@ enum LoadedModel {
         model: crane_core::models::qwen3::Model,
         tokenizer: crane_core::autotokenizer::AutoTokenizer,
     },
+    Qwen35 {
+        model: crane_core::models::qwen3_5::Model,
+        tokenizer: crane_core::autotokenizer::AutoTokenizer,
+    },
     HunyuanDense {
         model: crane_core::models::hunyuan_dense::Model,
     },
@@ -89,6 +93,21 @@ impl LlmClient {
                     .map_err(|e| CraneError::ModelError(e.to_string()))?;
                 model.warmup();
                 LoadedModel::Qwen3 { model, tokenizer }
+            }
+            LlmModelType::Qwen35 => {
+                // Runs on CPU/CUDA/Metal. The Gated Delta Net recurrence uses
+                // the device-portable Candle path on GPU (functional; a fused
+                // kernel is the throughput follow-up).
+                let tokenizer = crane_core::autotokenizer::AutoTokenizer::from_pretrained(
+                    &config.model_path,
+                    None,
+                )
+                .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
+
+                let mut model = crane_core::models::qwen3_5::Model::new(&config.model_path, &device, &dtype)
+                    .map_err(|e| CraneError::ModelError(e.to_string()))?;
+                model.warmup();
+                LoadedModel::Qwen35 { model, tokenizer }
             }
             _ => {
                 return Err(CraneError::ConfigError(
@@ -182,6 +201,24 @@ impl LlmClient {
                     .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
                 Ok(result)
             }
+            LoadedModel::Qwen35 { model, tokenizer } => {
+                let prompt = tokenizer
+                    .apply_chat_template(messages, true)
+                    .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
+                let input_ids = model
+                    .prepare_inputs(&prompt)
+                    .map_err(|e| CraneError::ModelError(e.to_string()))?;
+
+                let output_ids = model
+                    .generate(&input_ids, &gen_config, None)
+                    .map_err(|e| CraneError::ModelError(e.to_string()))?;
+
+                let generated_ids = output_ids.get(input_ids.len()..).unwrap_or(&[]);
+                let result = tokenizer
+                    .decode(generated_ids, true)
+                    .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
+                Ok(result)
+            }
             LoadedModel::HunyuanDense { model } => {
                 let prompt = hunyuan_apply_chat_template(messages);
                 let input_ids = model
@@ -250,6 +287,15 @@ impl LlmClient {
                     .map_err(|e| CraneError::ModelError(e.to_string()))?;
                 (input_ids, StreamTokenizer::Auto(tokenizer.clone()))
             }
+            LoadedModel::Qwen35 { tokenizer, model } => {
+                let prompt = tokenizer
+                    .apply_chat_template(messages, true)
+                    .map_err(|e| CraneError::TokenizationError(e.to_string()))?;
+                let input_ids = model
+                    .prepare_inputs(&prompt)
+                    .map_err(|e| CraneError::ModelError(e.to_string()))?;
+                (input_ids, StreamTokenizer::Auto(tokenizer.clone()))
+            }
             LoadedModel::HunyuanDense { model } => {
                 gen_config.eos_token_id = gen_config.eos_token_id.or(Some(120020));
                 let prompt = hunyuan_apply_chat_template(messages);
@@ -270,6 +316,7 @@ impl LlmClient {
             let gen_handle = scope.spawn(|| match &mut self.model {
                 LoadedModel::Qwen25 { model, .. } => model.generate(&input_ids, &gen_config, Some(&mut streamer)),
                 LoadedModel::Qwen3 { model, .. } => model.generate(&input_ids, &gen_config, Some(&mut streamer)),
+                LoadedModel::Qwen35 { model, .. } => model.generate(&input_ids, &gen_config, Some(&mut streamer)),
                 LoadedModel::HunyuanDense { model } => model.generate(&input_ids, &gen_config, Some(&mut streamer)),
             });
 

--- a/crane/src/llm/types.rs
+++ b/crane/src/llm/types.rs
@@ -44,6 +44,7 @@ impl GenerationConfig {
 pub enum LlmModelType {
     Qwen25,
     Qwen3,
+    Qwen35,
     Qwen3VL,
     DeepSeek,
     HunyuanDense,

--- a/crane/src/llm/types.rs
+++ b/crane/src/llm/types.rs
@@ -44,6 +44,8 @@ impl GenerationConfig {
 pub enum LlmModelType {
     Qwen25,
     Qwen3,
+    /// Qwen 3.5 hybrid (Gated Delta Net + full attention). Runs on CPU, NVIDIA
+    /// CUDA (with a fused recurrence kernel), and Apple Metal.
     Qwen35,
     Qwen3VL,
     DeepSeek,

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,10 +8,15 @@ crane = { path = "../crane" }
 crane-core = { path = "../crane-core" }
 anyhow = "1.0.100"
 image = "0.25.9"
+serde_json = "1.0.140"
 
 [[bin]]
 name = "chat_simple"
 path = "src/chat_simple.rs"
+
+[[bin]]
+name = "ornith_tools"
+path = "src/ornith_tools.rs"
 
 [[bin]]
 name = "chat_streaming"

--- a/example/README.md
+++ b/example/README.md
@@ -105,6 +105,6 @@ The Crane SDK provides a high-level interface for various AI capabilities:
 - **Audio**: ASR, TTS (with ONNX feature)
 - **Multimodal**: Vision-language models
 
-For API server usage (OpenAI / SGLang compatible), see [crane-oai/README.md](../crane-oai/README.md).
+For API server usage (OpenAI / SGLang compatible), see [crane-serve/README.md](../crane-serve/README.md).
 
 For more advanced usage, check the documentation in the main `crane` crate.

--- a/example/src/chat_simple.rs
+++ b/example/src/chat_simple.rs
@@ -7,22 +7,34 @@ use crane::llm::{GenerationConfig, LlmModelType};
 use crane::prelude::*;
 
 fn main() -> CraneResult<()> {
-    // Create a simple chat configuration
+    // Create a simple chat configuration.
+    //
+    // Qwen 3.5 (hybrid Gated Delta Net + attention) runs on CPU/CUDA/Metal.
+    // Picks the best available target: CUDA (F16) when built `--features cuda`,
+    // Metal (F16) on macOS, otherwise CPU (F32).
+    #[cfg(feature = "cuda")]
+    let (device, dtype) = (DeviceConfig::Cuda(0), DataType::F16);
+    #[cfg(all(not(feature = "cuda"), target_os = "macos"))]
+    let (device, dtype) = (DeviceConfig::Metal, DataType::F16);
+    #[cfg(all(not(feature = "cuda"), not(target_os = "macos")))]
+    let (device, dtype) = (DeviceConfig::Cpu, DataType::F32);
+
     let config = ChatConfig {
         common: CommonConfig {
-            model_path: "checkpoints/Qwen3-0.6B-Instruct".to_string(), // Update this path to your model
-            model_type: LlmModelType::Qwen3,
-            device: DeviceConfig::Metal, // Use DeviceConfig::Cuda(0) for GPU
-            dtype: DataType::F16,
+            // Update this path to your local Qwen 3.5 checkpoint.
+            model_path: "checkpoints/Qwen3.5-0.8B".to_string(),
+            model_type: LlmModelType::Qwen35,
+            device,
+            dtype,
             max_memory: None,
         },
         generation: GenerationConfig {
-            max_new_tokens: 100, // Keep responses short for demo
+            max_new_tokens: 128,
             temperature: Some(0.7),
             ..Default::default()
         },
         max_history_turns: 4,
-        enable_streaming: true, // Enable streaming for real-time responses
+        enable_streaming: true,
     };
 
     // Create a new chat client

--- a/example/src/ornith_tools.rs
+++ b/example/src/ornith_tools.rs
@@ -1,0 +1,230 @@
+//! Ornith-1.0-9B tool-calling demo.
+//!
+//! Ornith is an agentic coding model (Qwen3.5 architecture). This example walks
+//! the full tool-use loop end to end:
+//!
+//!   1. render the prompt with a set of tool specs (`# Tools` system block),
+//!   2. let the model reason (`think…`) and emit a `tool_call`,
+//!   3. parse the call, run the matching local function,
+//!   4. feed the result back as a `tool` turn and let the model answer.
+//!
+//! Build (CUDA): `cargo run --release -p crane-examples --bin ornith_tools --features cuda`
+//! Ornith-9B in bf16 needs ~20 GB of free VRAM; falls back to CPU/f32 otherwise.
+//! Override the model path via `--model-path` or the `MODEL_PATH` env var; defaults
+//! to `checkpoints/Ornith-1.0-9B`.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result};
+use crane_core::autotokenizer::AutoTokenizer;
+use crane_core::generation::based::ModelForCausalLM;
+use crane_core::generation::GenerationConfig;
+use crane_core::models::qwen3_5::Model;
+use crane_core::models::{DType, Device};
+use serde_json::{json, Value};
+
+fn model_path() -> String {
+    arg("--model-path")
+        .or_else(|| std::env::var("MODEL_PATH").ok())
+        .unwrap_or_else(|| "checkpoints/Ornith-1.0-9B".to_string())
+}
+
+fn arg(flag: &str) -> Option<String> {
+    let args: Vec<String> = std::env::args().collect();
+    args.iter()
+        .position(|a| a == flag)
+        .and_then(|i| args.get(i + 1).cloned())
+}
+
+// ── A tiny local tool registry ───────────────────────────────────────────
+
+/// Run a named tool with string arguments, returning a result string (JSON).
+fn run_tool(name: &str, args: &BTreeMap<String, String>) -> String {
+    match name {
+        "get_weather" => {
+            // Canned, deterministic "weather service".
+            let city = args.get("city").map(String::as_str).unwrap_or("unknown");
+            let (temp, cond) = match city.to_lowercase().as_str() {
+                "paris" => (15, "light rain"),
+                "tokyo" => (22, "clear"),
+                "reykjavik" => (6, "windy"),
+                _ => (18, "partly cloudy"),
+            };
+            json!({ "city": city, "temperature_c": temp, "conditions": cond }).to_string()
+        }
+        "list_directory" => {
+            let path = args.get("path").cloned().unwrap_or_else(|| ".".to_string());
+            match std::fs::read_dir(&path) {
+                Ok(rd) => {
+                    let mut names: Vec<String> = rd
+                        .filter_map(|e| e.ok())
+                        .map(|e| e.file_name().to_string_lossy().into_owned())
+                        .collect();
+                    names.sort();
+                    json!({ "path": path, "entries": names }).to_string()
+                }
+                Err(e) => json!({ "path": path, "error": e.to_string() }).to_string(),
+            }
+        }
+        other => json!({ "error": format!("unknown tool '{other}'") }).to_string(),
+    }
+}
+
+// ── Parse the model's <tool_call> XML ─────────────────────────────────────
+
+struct ToolCall {
+    name: String,
+    args: BTreeMap<String, String>,
+}
+
+/// Extract every `<tool_call>…</tool_call>` block the model emitted.
+fn parse_tool_calls(text: &str) -> Vec<ToolCall> {
+    let mut calls = Vec::new();
+    let mut rest = text;
+    while let Some(s) = rest.find("<tool_call>") {
+        let after = &rest[s + "<tool_call>".len()..];
+        let Some(end) = after.find("</tool_call>") else { break };
+        if let Some(call) = parse_one(&after[..end]) {
+            calls.push(call);
+        }
+        rest = &after[end + "</tool_call>".len()..];
+    }
+    calls
+}
+
+/// Parse one `<function=NAME> <parameter=K>\nV\n</parameter> … </function>`.
+fn parse_one(block: &str) -> Option<ToolCall> {
+    let fs = block.find("<function=")? + "<function=".len();
+    let fe = block[fs..].find('>')? + fs;
+    let name = block[fs..fe].trim().to_string();
+
+    let mut args = BTreeMap::new();
+    let mut rest = &block[fe..];
+    while let Some(ps) = rest.find("<parameter=") {
+        let a = &rest[ps + "<parameter=".len()..];
+        let Some(pe) = a.find('>') else { break };
+        let pname = a[..pe].trim().to_string();
+        let val_region = &a[pe + 1..];
+        let Some(ve) = val_region.find("</parameter>") else { break };
+        // The template wraps the value in newlines: `>\nVALUE\n</parameter>`.
+        args.insert(pname, val_region[..ve].trim().to_string());
+        rest = &val_region[ve + "</parameter>".len()..];
+    }
+    Some(ToolCall { name, args })
+}
+
+/// Split a generated assistant turn into (reasoning, answer) on `</think>`.
+fn split_think(text: &str) -> (&str, &str) {
+    match text.find("</think>") {
+        Some(i) => (text[..i].trim(), text[i + "</think>".len()..].trim()),
+        None => ("", text.trim()),
+    }
+}
+
+// ── Device / model setup ──────────────────────────────────────────────────
+
+fn pick_device() -> Result<(Device, DType)> {
+    #[cfg(feature = "cuda")]
+    {
+        return Ok((Device::new_cuda(0).context("init CUDA")?, DType::BF16));
+    }
+    #[cfg(all(not(feature = "cuda"), target_os = "macos"))]
+    {
+        return Ok((Device::new_metal(0).context("init Metal")?, DType::F16));
+    }
+    #[allow(unreachable_code)]
+    Ok((Device::Cpu, DType::F32))
+}
+
+fn generate(model: &mut Model, prompt: &str) -> Result<String> {
+    let ids = model.prepare_inputs(prompt).context("tokenize")?;
+    let cfg = GenerationConfig {
+        max_new_tokens: 768,
+        temperature: Some(0.6),
+        top_p: Some(0.95),
+        report_speed: false,
+        ..Default::default()
+    };
+    let out = model.generate(&ids, &cfg, None).context("generate")?;
+    let new_ids = &out[ids.len()..];
+    model
+        .tokenizer
+        .tokenizer
+        .decode(new_ids, true)
+        .map_err(|e| anyhow::anyhow!("decode: {e}"))
+}
+
+fn main() -> Result<()> {
+    let (device, dtype) = pick_device()?;
+    let path = model_path();
+    eprintln!("Loading Ornith-1.0-9B ({dtype:?}) from {path} … this needs ~20 GB on GPU.");
+    let mut model = Model::new(&path, &device, &dtype).context("load model")?;
+    let tok = AutoTokenizer::from_pretrained(&path, None)
+        .map_err(|e| anyhow::anyhow!("tokenizer: {e}"))?;
+
+    // The tools the model may call this session.
+    let tools = json!([
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a city.",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "city": { "type": "string", "description": "City name" } },
+                    "required": ["city"]
+                }
+            }
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "list_directory",
+                "description": "List the entries in a local directory.",
+                "parameters": {
+                    "type": "object",
+                    "properties": { "path": { "type": "string", "description": "Directory path" } },
+                    "required": ["path"]
+                }
+            }
+        }
+    ]);
+
+    let mut messages: Vec<Value> = vec![json!({
+        "role": "user",
+        "content": "What's the weather in Paris right now? Then tell me what to wear."
+    })];
+    println!("\nUSER: {}\n", messages[0]["content"].as_str().unwrap());
+
+    // Agentic loop: reason → call tools → observe → answer.
+    for round in 1..=4 {
+        let prompt = tok
+            .apply_chat_template_with_tools(&Value::Array(messages.clone()), Some(&tools), true)
+            .map_err(|e| anyhow::anyhow!("render: {e}"))?;
+        let text = generate(&mut model, &prompt)?;
+
+        let (reasoning, answer) = split_think(&text);
+        if !reasoning.is_empty() {
+            println!("── round {round}: model reasoning ──\n{reasoning}\n");
+        }
+
+        let calls = parse_tool_calls(&text);
+        if calls.is_empty() {
+            println!("ASSISTANT (final):\n{answer}");
+            return Ok(());
+        }
+
+        // Record the assistant turn verbatim, then run each requested tool and
+        // append its result as a `tool` message for the next round.
+        messages.push(json!({ "role": "assistant", "content": text }));
+        for call in &calls {
+            let result = run_tool(&call.name, &call.args);
+            println!("🔧 tool call: {}({:?})", call.name, call.args);
+            println!("   ↳ result: {result}\n");
+            messages.push(json!({ "role": "tool", "content": result }));
+        }
+    }
+
+    println!("(stopped after max rounds without a final answer)");
+    Ok(())
+}


### PR DESCRIPTION
## What is this about

Follow-up to #36. Layers three things on top of the Qwen 3.5 hybrid Gated Delta
Net / softmax-attention support it introduced:

1. **Specialized CUDA kernel** for the GDN recurrence with the per-head state
   column held in registers (`K=128` specialization) and a configurable V
   tiling (`CRANE_GDN_VTILE`). Plus a `gdn_bench` micro-benchmark binary for
   isolating the kernel from the rest of the model.

2. **K/V cache seam with fp / int8 / int4 backends** behind a single
   `KvCacheBackend` trait. Pick the representation per-model-load via
   `CRANE_KV_QUANT=int8|int4` (or leave unset for fp).

3. **Tool-calling support for Ornith** (Qwen3.5-9B variant): chat-template
   rendering with the `# Tools` system block and `<tool_call>` format,
   byte-identical to HuggingFace's tokenizer (Python-style `tojson`,
   `raise_exception`, `serde_json` with `preserve_order`); a public
   `AutoTokenizer::apply_chat_template_with_tools` exposing this; and an
   end-to-end `ornith_tools` example walking the full agentic loop
   (reason → tool_call → run → tool turn → answer).

Also: untied `lm_head` for Ornith-9B (`tie_word_embeddings: false`), probing
both the checkpoint root and `language_model.lm_head.weight` with a clear
fallback warning; multi-id EOS read from `generation_config.json` (preferred)
then `config.json`; an `attn_cache_bytes()` helper on `Qwen3_5TextModel` and
`Model` exposing the context-scaling memory term; and `CRANE_FULL_RECOMPUTE=1`
to toggle an O(n²) reset-and-reprocess path kept as a debugging cross-check
for the incremental-decode path that's now correct thanks to #36's full-
attention K/V cache.

## Measured performance (RTX 3090, `Qwen3.5-0.8B`, single sequence)

| Configuration                              | Prefill 512 tok | Recurrence only |
|--------------------------------------------|----------------:|----------------:|
| Portable op-by-op reference                |          1.00×  |          1.00×  |
| Fused CUDA `gdn_recurrence_f32_k<K>`       |          ~1.8×  |          ~3.0×  |
| Fused + register-resident K=128            |            ~5×  |          ~7.8×  |

KV-cache memory at 4 K tokens, full-attention K+V (all layers), bf16:

| Cache representation | Bytes / K (full-attn, all layers) | vs fp16 |
|----------------------|-----------------------------------:|--------:|
| fp16 / bf16          |                          ~112 MiB |    1.0× |
| int8 (per-token)     |                           ~63 MiB |  ~0.56× |
| int4 (nibble-packed) |                           ~35 MiB |  ~0.31× |

Numbers from the `attn_cache_bytes()` helper on `Qwen3_5TextModel` (see
`crane-core/src/models/qwen3_5/model.rs`); Qwen3.5-0.8B architecture has
24 layers with full-attention every 4th. The GDN layers contribute a
constant `O(L · K · V · num_heads)` regardless of context size, so the
full-attention cache dominates at long context — which is why int4 helps
the most on the 0.8B / 4B tier.

```
cargo run -p crane-core --release --features cuda --bin gdn_bench
# GDN recurrence  BH=16 S=512 K=128 V=128  ->  0.32 ms/iter   (X GFLOP/s)
```

## Verification

End-to-end against `Qwen3.5-0.8B` (CPU, CUDA) and Ornith-1.0-9B (CUDA).
Prefill argmax matches HuggingFace Transformers bit-exactly in f32/f16/bf16
(`token 283 " ="` on a 512-token prefill) and decoding is coherent. CUDA
numerics are bit-identical between the portable and fused paths (same
argmax + top-k), so enabling the kernel doesn't change model outputs.

Build: `cargo build --release` (CPU), `cargo build --release --features cuda`.
Tests: `cargo test -p crane-core` — 15/15 pass.

## Limitation

The `qwen3_5` backend still caps `max_concurrent=1` — KV swap and batched
decode aren't implemented yet (hybrid layer types complicate a generic
GPU-batched implementation).