### PR TITLE
Extract shared SwiGluFfn building block

### DIFF
--- a/crane-core/src/models/gemma4/modeling.rs
+++ b/crane-core/src/models/gemma4/modeling.rs
@@ -22,12 +22,13 @@
 use candle_core::quantized::gguf_file;
 use candle_core::{DType, Device, Module, Result, Tensor, D};
 use candle_nn::rotary_emb::rope;
-use candle_nn::{linear_no_bias, Embedding, Linear, RmsNorm, VarBuilder};
+use candle_nn::{linear_no_bias, Activation, Embedding, Linear, RmsNorm, VarBuilder};
 use serde::Deserialize;
 use std::io::{Read, Seek};
 
 // Reuse the polymorphic linear layer and GGUF loader from the shared Hunyuan module.
 pub use crate::models::hunyuan_dense::modeling::{Gguf, LinearLayer};
+use crate::models::modules::ffn::SwiGluFfn;
 
 // Note: Gemma 4 norms use standard `x * weight` (no `+1` shift unlike Gemma 3).
 // Weights are stored in final form. Use candle_nn::rms_norm / gg.rms_norm directly.
@@ -555,35 +556,23 @@ impl Attention {
 
 // ── MLP ─────────────────────────────────────────────────────────────────
 
-struct Mlp {
-    gate_proj: LinearLayer,
-    up_proj: LinearLayer,
-    down_proj: LinearLayer,
+enum Mlp {
+    Standard(SwiGluFfn),
+    Gguf {
+        gate_proj: LinearLayer,
+        up_proj: LinearLayer,
+        down_proj: LinearLayer,
+    },
 }
 
 impl Mlp {
     fn new(config: &Gemma4TextConfig, intermediate_size: usize, vb: VarBuilder) -> Result<Self> {
-        let gate_proj = LinearLayer::Standard(linear_no_bias(
+        Ok(Self::Standard(SwiGluFfn::new(
             config.hidden_size,
             intermediate_size,
-            vb.pp("gate_proj"),
-        )?);
-        let up_proj = LinearLayer::Standard(linear_no_bias(
-            config.hidden_size,
-            intermediate_size,
-            vb.pp("up_proj"),
-        )?);
-        let down_proj = LinearLayer::Standard(linear_no_bias(
-            intermediate_size,
-            config.hidden_size,
-            vb.pp("down_proj"),
-        )?);
-
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-        })
+            Activation::GeluPytorchTanh,
+            vb,
+        )?))
     }
 
     fn new_from_gguf<R: Read + Seek>(gg: &mut Gguf<R>, layer_idx: usize) -> Result<Self> {
@@ -591,7 +580,7 @@ impl Mlp {
         let gate_proj = gg.linear(&format!("{prefix}.ffn_gate.weight"))?;
         let up_proj = gg.linear(&format!("{prefix}.ffn_up.weight"))?;
         let down_proj = gg.linear(&format!("{prefix}.ffn_down.weight"))?;
-        Ok(Self {
+        Ok(Self::Gguf {
             gate_proj,
             up_proj,
             down_proj,
@@ -599,10 +588,19 @@ impl Mlp {
     }
 
     fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        let gate = self.gate_proj.forward(x)?;
-        let gate = candle_nn::Activation::GeluPytorchTanh.forward(&gate)?;
-        let up = self.up_proj.forward(x)?;
-        self.down_proj.forward(&(gate * up)?)
+        match self {
+            Self::Standard(ffn) => ffn.forward(x),
+            Self::Gguf {
+                gate_proj,
+                up_proj,
+                down_proj,
+            } => {
+                let gate = gate_proj.forward(x)?;
+                let gate = Activation::GeluPytorchTanh.forward(&gate)?;
+                let up = up_proj.forward(x)?;
+                down_proj.forward(&(gate * up)?)
+            }
+        }
     }
 }
 

--- a/crane-core/src/models/modules/ffn.rs
+++ b/crane-core/src/models/modules/ffn.rs
@@ -1,0 +1,299 @@
+use candle_core::{Result, Tensor, D};
+use candle_nn::{Activation, Module, VarBuilder};
+
+use crate::models::with_tracing::{linear_no_bias, Linear};
+
+/// `SwiGLU` feed-forward network with merged gate/up projection.
+///
+/// Computes `activation(x @ gate) * (x @ up) @ down` with a single fused
+/// matmul for the gate+up path. Uses `fused_silu_mul` on CUDA when the
+/// activation is `Silu`.
+#[derive(Debug)]
+pub struct SwiGluFfn {
+    gate_up_proj: Linear,
+    down_proj: Linear,
+    intermediate_size: usize,
+    activation: Activation,
+}
+
+impl SwiGluFfn {
+    /// Create a `SwiGLU` FFN: `activation(x @ gate_proj) * (x @ up_proj) @ down_proj`.
+    ///
+    /// Gate and up weights are merged into a single `[2*intermediate_size, hidden_size]`
+    /// matrix at construction time, enabling a single matmul per forward pass and the
+    /// `fused_silu_mul` CUDA kernel when the activation is `Silu`.
+    ///
+    /// # Arguments
+    /// * `hidden_size` - Input and output dimension
+    /// * `intermediate_size` - Intermediate (gate/up output) dimension
+    /// * `activation` - Activation applied to the gate branch (e.g. `Activation::Silu`)
+    /// * `vb` - `VarBuilder` scoped to this layer; loads weights at `gate_proj`, `up_proj`, `down_proj`
+    ///
+    /// # Errors
+    ///
+    /// Returns a candle error if weight loading fails.
+    // VarBuilder::pp() consumes self, so it must be taken by value.
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new(
+        hidden_size: usize,
+        intermediate_size: usize,
+        activation: Activation,
+        vb: VarBuilder,
+    ) -> Result<Self> {
+        let gate_proj = linear_no_bias(hidden_size, intermediate_size, vb.pp("gate_proj"))?;
+        let up_proj = linear_no_bias(hidden_size, intermediate_size, vb.pp("up_proj"))?;
+        let gate_up_w = Tensor::cat(&[gate_proj.weight(), up_proj.weight()], 0)?;
+        // gate_proj and up_proj are dropped here — their memory is freed.
+        let gate_up_proj = Linear::from_weights(gate_up_w, None);
+        let down_proj = linear_no_bias(intermediate_size, hidden_size, vb.pp("down_proj"))?;
+        Ok(Self {
+            gate_up_proj,
+            down_proj,
+            intermediate_size,
+            activation,
+        })
+    }
+}
+
+impl Module for SwiGluFfn {
+    /// Compute `activation(x @ gate) * (x @ up) @ down`.
+    ///
+    /// On CUDA with `Silu` activation, uses `fused_silu_mul` for a single kernel launch.
+    fn forward(&self, x: &Tensor) -> Result<Tensor> {
+        let gu = x.apply(&self.gate_up_proj)?;
+
+        #[cfg(feature = "cuda")]
+        if matches!(self.activation, Activation::Silu) && gu.device().is_cuda() {
+            let activated =
+                crate::ops::fused_silu_mul(&gu.contiguous()?, self.intermediate_size)?;
+            return self.down_proj.forward(&activated);
+        }
+
+        let gate = gu.narrow(D::Minus1, 0, self.intermediate_size)?;
+        let up = gu.narrow(D::Minus1, self.intermediate_size, self.intermediate_size)?;
+        let gate = gate.apply(&self.activation)?;
+        (gate * up)?.apply(&self.down_proj)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use candle_core::{DType, Device, Tensor};
+
+    // Keys use dot-separated format ("gate_proj.weight") to match VarBuilder::pp("gate_proj").
+    fn make_vb(
+        hidden: usize,
+        intermediate: usize,
+        gate_data: Vec<f32>,
+        up_data: Vec<f32>,
+        down_data: Vec<f32>,
+    ) -> candle_nn::VarBuilder<'static> {
+        let device = &Device::Cpu;
+        let mut tensors: HashMap<String, Tensor> = HashMap::new();
+        tensors.insert(
+            "gate_proj.weight".to_string(),
+            Tensor::from_vec(gate_data, (intermediate, hidden), device).expect("gate weight"),
+        );
+        tensors.insert(
+            "up_proj.weight".to_string(),
+            Tensor::from_vec(up_data, (intermediate, hidden), device).expect("up weight"),
+        );
+        tensors.insert(
+            "down_proj.weight".to_string(),
+            Tensor::from_vec(down_data, (hidden, intermediate), device).expect("down weight"),
+        );
+        candle_nn::VarBuilder::from_tensors(tensors, DType::F32, device)
+    }
+
+    fn zeros_ffn(hidden: usize, intermediate: usize, act: Activation) -> SwiGluFfn {
+        let gate = vec![0.0f32; hidden * intermediate];
+        let up = vec![0.0f32; hidden * intermediate];
+        let down = vec![0.0f32; intermediate * hidden];
+        let vb = make_vb(hidden, intermediate, gate, up, down);
+        SwiGluFfn::new(hidden, intermediate, act, vb).expect("SwiGluFfn::new")
+    }
+
+    fn identity_vb(hidden: usize) -> candle_nn::VarBuilder<'static> {
+        let eye: Vec<f32> = (0..hidden * hidden)
+            .map(|idx| if idx / hidden == idx % hidden { 1.0_f32 } else { 0.0 })
+            .collect();
+        make_vb(hidden, hidden, eye.clone(), eye.clone(), eye)
+    }
+
+    #[test]
+    fn test_output_shape_2d() {
+        let ffn = zeros_ffn(8, 16, Activation::Silu);
+        let x = Tensor::zeros((4, 8), DType::F32, &Device::Cpu).expect("zeros");
+        let y = ffn.forward(&x).expect("forward");
+        assert_eq!(y.dims(), &[4, 8]);
+    }
+
+    #[test]
+    fn test_output_shape_3d() {
+        let ffn = zeros_ffn(16, 32, Activation::Silu);
+        let x = Tensor::zeros((2, 5, 16), DType::F32, &Device::Cpu).expect("zeros");
+        let y = ffn.forward(&x).expect("forward");
+        assert_eq!(y.dims(), &[2, 5, 16]);
+    }
+
+    #[test]
+    fn test_zero_weights_give_zero_output() {
+        let ffn = zeros_ffn(8, 16, Activation::Silu);
+        let x = Tensor::ones((3, 8), DType::F32, &Device::Cpu).expect("ones");
+        let y = ffn.forward(&x).expect("forward");
+        let max_val: f32 = y
+            .abs()
+            .expect("abs")
+            .max_all()
+            .expect("max_all")
+            .to_scalar()
+            .expect("scalar");
+        assert!(
+            max_val < 1e-8,
+            "expected zero output for zero weights, got max={max_val}"
+        );
+    }
+
+    #[test]
+    fn test_zero_input_gives_zero_output() {
+        let ffn = identity_vb(8);
+        let ffn = SwiGluFfn::new(8, 8, Activation::Silu, ffn).expect("new");
+        let x = Tensor::zeros((2, 8), DType::F32, &Device::Cpu).expect("zeros");
+        let y = ffn.forward(&x).expect("forward");
+        let max_val: f32 = y
+            .abs()
+            .expect("abs")
+            .max_all()
+            .expect("max_all")
+            .to_scalar()
+            .expect("scalar");
+        assert!(
+            max_val < 1e-8,
+            "expected zero output for zero input, got max={max_val}"
+        );
+    }
+
+    #[test]
+    fn test_intermediate_size_larger_than_hidden() {
+        let ffn = zeros_ffn(32, 128, Activation::Silu);
+        let x = Tensor::zeros((1, 32), DType::F32, &Device::Cpu).expect("zeros");
+        let y = ffn.forward(&x).expect("forward");
+        assert_eq!(y.dims(), &[1, 32]);
+    }
+
+    #[test]
+    fn test_activation_changes_output() {
+        // Same weights and input; SiLU and GELU must produce different values on non-trivial input.
+        let device = &Device::Cpu;
+        let hidden = 4usize;
+        let intermediate = 8usize;
+        let gate: Vec<f32> = (0..hidden * intermediate)
+            .map(|i| (i as f32 + 1.0) * 0.1)
+            .collect();
+        let up: Vec<f32> = gate.iter().map(|v| v * 0.5).collect();
+        let down: Vec<f32> = (0..intermediate * hidden)
+            .map(|i| (i as f32 + 1.0) * 0.1)
+            .collect();
+
+        let vb_silu = make_vb(hidden, intermediate, gate.clone(), up.clone(), down.clone());
+        let vb_gelu = make_vb(hidden, intermediate, gate, up, down);
+        let ffn_silu = SwiGluFfn::new(hidden, intermediate, Activation::Silu, vb_silu).expect("silu");
+        let ffn_gelu =
+            SwiGluFfn::new(hidden, intermediate, Activation::GeluPytorchTanh, vb_gelu).expect("gelu");
+
+        let x = Tensor::ones((1, hidden), DType::F32, device).expect("ones");
+        let out_silu = ffn_silu.forward(&x).expect("silu forward");
+        let out_gelu = ffn_gelu.forward(&x).expect("gelu forward");
+
+        let diff: f32 = (&out_silu - &out_gelu)
+            .expect("sub")
+            .abs()
+            .expect("abs")
+            .max_all()
+            .expect("max_all")
+            .to_scalar()
+            .expect("scalar");
+        assert!(
+            diff > 1e-4,
+            "SiLU and GeluPytorchTanh should produce different outputs; got max_diff={diff}"
+        );
+    }
+
+    #[test]
+    fn test_formula_manual_verification() {
+        // hidden=2, intermediate=2
+        // gate_proj.weight = [[1, 0], [0, 1]]  (I, row-major so output[i] = x[i])
+        // up_proj.weight   = [[2, 0], [0, 2]]  (2*I)
+        // down_proj.weight = [[1, 0], [0, 1]]  (I)
+        // x = [1.0, 0.5]
+        //
+        // Linear stores weight as [out, in] and computes x @ weight.T:
+        //   gate = x @ I.T = [1.0, 0.5]
+        //   gate_activated = silu([1.0, 0.5])
+        //   up = x @ (2*I).T = [2.0, 1.0]
+        //   product = gate_activated * up
+        //   output = product @ I.T = product
+        let device = &Device::Cpu;
+        let identity = vec![1.0f32, 0.0, 0.0, 1.0];
+        let doubled = vec![2.0f32, 0.0, 0.0, 2.0];
+        let vb = make_vb(2, 2, identity.clone(), doubled, identity);
+        let ffn = SwiGluFfn::new(2, 2, Activation::Silu, vb).expect("new");
+
+        let x = Tensor::new(&[1.0f32, 0.5], device)
+            .expect("tensor")
+            .reshape((1, 2))
+            .expect("reshape");
+        let y = ffn.forward(&x).expect("forward");
+        let got = y.squeeze(0).expect("squeeze").to_vec1::<f32>().expect("to_vec1");
+
+        let silu = |v: f32| v / (1.0 + (-v).exp());
+        let expected = [silu(1.0_f32) * 2.0, silu(0.5_f32) * 1.0];
+
+        for (i, (&g, &e)) in got.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (g - e).abs() < 1e-5,
+                "output[{i}]: got {g}, expected {e}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_batch_consistency() {
+        // Identical rows in a batch should produce identical output rows.
+        let device = &Device::Cpu;
+        let hidden = 8usize;
+        let intermediate = 16usize;
+        let gate: Vec<f32> = (0..hidden * intermediate)
+            .map(|i| (i as f32 + 1.0) * 0.01)
+            .collect();
+        let up: Vec<f32> = gate.iter().map(|v| v * 0.5).collect();
+        let down: Vec<f32> = (0..intermediate * hidden)
+            .map(|i| (i as f32 + 1.0) * 0.01)
+            .collect();
+        let vb = make_vb(hidden, intermediate, gate, up, down);
+        let ffn = SwiGluFfn::new(hidden, intermediate, Activation::Silu, vb).expect("new");
+
+        let row: Vec<f32> = (0..hidden).map(|i| (i as f32 + 1.0) * 0.1).collect();
+        let single = Tensor::from_vec(row, (1, hidden), device).expect("single row");
+        let batch = Tensor::cat(&[&single, &single, &single], 0).expect("cat");
+
+        let out_batch = ffn.forward(&batch).expect("batch forward");
+        let out_single = ffn.forward(&single).expect("single forward");
+
+        for b in 0..3 {
+            let row_b = out_batch.narrow(0, b, 1).expect("narrow");
+            let diff: f32 = (&row_b - &out_single)
+                .expect("sub")
+                .abs()
+                .expect("abs")
+                .max_all()
+                .expect("max_all")
+                .to_scalar()
+                .expect("scalar");
+            assert!(diff < 1e-6, "batch row {b} differs from single: max_diff={diff}");
+        }
+    }
+}

--- a/crane-core/src/models/modules/ffn.rs
+++ b/crane-core/src/models/modules/ffn.rs
@@ -8,7 +8,7 @@ use crate::models::with_tracing::{linear_no_bias, Linear};
 /// Computes `activation(x @ gate) * (x @ up) @ down` with a single fused
 /// matmul for the gate+up path. Uses `fused_silu_mul` on CUDA when the
 /// activation is `Silu`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SwiGluFfn {
     gate_up_proj: Linear,
     down_proj: Linear,

--- a/crane-core/src/models/modules/mod.rs
+++ b/crane-core/src/models/modules/mod.rs
@@ -1,3 +1,4 @@
 // pub mod conn_ve_llm;
+pub mod ffn;
 pub mod rotary;
 pub mod siglip2;

--- a/crane-core/src/models/qwen25/qwen2.rs
+++ b/crane-core/src/models/qwen25/qwen2.rs
@@ -15,6 +15,7 @@
 //! - 🤗 [Qwen2 Model](https://huggingface.co/Qwen/Qwen2-7B)
 //!
 
+use crate::models::modules::ffn::SwiGluFfn;
 use crate::models::modules::rotary::RotaryEmbedding;
 use crate::models::with_tracing::{linear, linear_no_bias, Linear, RmsNorm};
 use candle_core::{DType, Device, IndexOp, Module, Result, Tensor, D};
@@ -38,39 +39,6 @@ pub struct Config {
     pub hidden_act: Activation,
 }
 
-
-#[derive(Debug, Clone)]
-#[allow(clippy::upper_case_acronyms)]
-struct MLP {
-    gate_proj: Linear,
-    up_proj: Linear,
-    down_proj: Linear,
-    act_fn: Activation,
-}
-
-impl MLP {
-    fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let intermediate_sz = cfg.intermediate_size;
-        let gate_proj = linear_no_bias(hidden_sz, intermediate_sz, vb.pp("gate_proj"))?;
-        let up_proj = linear_no_bias(hidden_sz, intermediate_sz, vb.pp("up_proj"))?;
-        let down_proj = linear_no_bias(intermediate_sz, hidden_sz, vb.pp("down_proj"))?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act,
-        })
-    }
-}
-
-impl Module for MLP {
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = xs.apply(&self.gate_proj)?.apply(&self.act_fn)?;
-        let rhs = xs.apply(&self.up_proj)?;
-        (lhs * rhs)?.apply(&self.down_proj)
-    }
-}
 
 #[derive(Debug, Clone)]
 struct Attention {
@@ -177,7 +145,7 @@ impl Attention {
 #[derive(Debug, Clone)]
 struct DecoderLayer {
     self_attn: Attention,
-    mlp: MLP,
+    mlp: SwiGluFfn,
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
 }
@@ -185,7 +153,7 @@ struct DecoderLayer {
 impl DecoderLayer {
     fn new(cfg: &Config, vb: VarBuilder) -> Result<Self> {
         let self_attn = Attention::new(cfg, vb.pp("self_attn"))?;
-        let mlp = MLP::new(cfg, vb.pp("mlp"))?;
+        let mlp = SwiGluFfn::new(cfg.hidden_size, cfg.intermediate_size, cfg.hidden_act, vb.pp("mlp"))?;
         let input_layernorm =
             RmsNorm::new(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let post_attention_layernorm = RmsNorm::new(

--- a/crane-core/src/models/qwen3_tts/modeling.rs
+++ b/crane-core/src/models/qwen3_tts/modeling.rs
@@ -16,6 +16,7 @@
 
 use candle_core::{DType, Device, Module, Result, Tensor, D};
 use candle_nn::{linear, linear_no_bias, Embedding, Linear, RmsNorm, VarBuilder};
+use super::super::modules::ffn::SwiGluFfn;
 use super::super::modules::rotary::RotaryEmbedding;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -430,30 +431,6 @@ impl Attention {
     }
 }
 
-// ── MLP ─────────────────────────────────────────────────────────────────
-
-struct Mlp {
-    gate_proj: Linear,
-    up_proj: Linear,
-    down_proj: Linear,
-}
-
-impl Mlp {
-    fn new(hidden_size: usize, intermediate_size: usize, vb: VarBuilder) -> Result<Self> {
-        Ok(Self {
-            gate_proj: linear_no_bias(hidden_size, intermediate_size, vb.pp("gate_proj"))?,
-            up_proj: linear_no_bias(hidden_size, intermediate_size, vb.pp("up_proj"))?,
-            down_proj: linear_no_bias(intermediate_size, hidden_size, vb.pp("down_proj"))?,
-        })
-    }
-
-    fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        let gate = candle_nn::Activation::Silu.forward(&self.gate_proj.forward(x)?)?;
-        let up = self.up_proj.forward(x)?;
-        self.down_proj.forward(&(gate * up)?)
-    }
-}
-
 // ── Resize MLP (text_projection) ────────────────────────────────────────
 
 struct ResizeMlp {
@@ -484,7 +461,7 @@ impl ResizeMlp {
 
 struct DecoderLayer {
     self_attn: Attention,
-    mlp: Mlp,
+    mlp: SwiGluFfn,
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
 }
@@ -510,7 +487,7 @@ impl DecoderLayer {
                 bias,
                 vb.pp("self_attn"),
             )?,
-            mlp: Mlp::new(hidden_size, intermediate_size, vb.pp("mlp"))?,
+            mlp: SwiGluFfn::new(hidden_size, intermediate_size, candle_nn::Activation::Silu, vb.pp("mlp"))?,
             input_layernorm: candle_nn::rms_norm(hidden_size, rms_norm_eps, vb.pp("input_layernorm"))?,
             post_attention_layernorm: candle_nn::rms_norm(
                 hidden_size,

--- a/crane-core/src/models/qwen3_tts/speech_tokenizer_v2.rs
+++ b/crane-core/src/models/qwen3_tts/speech_tokenizer_v2.rs
@@ -3,9 +3,11 @@ use candle_core::{DType, Device, IndexOp, Tensor, D};
 use super::super::modules::rotary::RotaryEmbedding;
 use candle_core::{Module, StreamingModule};
 use candle_nn::{
-    conv1d, conv1d_no_bias, conv_transpose1d, layer_norm, linear, linear_no_bias, Conv1d,
-    Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, LayerNorm, Linear, RmsNorm, VarBuilder,
+    conv1d, conv1d_no_bias, conv_transpose1d, layer_norm, linear, linear_no_bias, Activation,
+    Conv1d, Conv1dConfig, ConvTranspose1d, ConvTranspose1dConfig, LayerNorm, Linear, RmsNorm,
+    VarBuilder,
 };
+use super::super::modules::ffn::SwiGluFfn;
 use candle_transformers::models::mimi;
 use serde::Deserialize;
 use std::cell::RefCell;
@@ -399,32 +401,9 @@ impl LayerScale {
 }
 
 #[derive(Debug, Clone)]
-struct TokenizerMlp {
-    gate_proj: Linear,
-    up_proj: Linear,
-    down_proj: Linear,
-}
-
-impl TokenizerMlp {
-    fn new(cfg: &DecoderConfig, vb: VarBuilder) -> Result<Self> {
-        Ok(Self {
-            gate_proj: linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("gate_proj"))?,
-            up_proj: linear_no_bias(cfg.hidden_size, cfg.intermediate_size, vb.pp("up_proj"))?,
-            down_proj: linear_no_bias(cfg.intermediate_size, cfg.hidden_size, vb.pp("down_proj"))?,
-        })
-    }
-
-    fn forward(&self, x: &Tensor) -> Result<Tensor> {
-        let g = x.apply(&self.gate_proj)?.silu()?;
-        let u = x.apply(&self.up_proj)?;
-        Ok(g.broadcast_mul(&u)?.apply(&self.down_proj)?)
-    }
-}
-
-#[derive(Debug, Clone)]
 struct TokenizerTransformerLayer {
     self_attn: TokenizerAttention,
-    mlp: TokenizerMlp,
+    mlp: SwiGluFfn,
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
     self_attn_layer_scale: LayerScale,
@@ -435,7 +414,7 @@ impl TokenizerTransformerLayer {
     fn new(cfg: &DecoderConfig, vb: VarBuilder) -> Result<Self> {
         Ok(Self {
             self_attn: TokenizerAttention::new(cfg, vb.pp("self_attn"))?,
-            mlp: TokenizerMlp::new(cfg, vb.pp("mlp"))?,
+            mlp: SwiGluFfn::new(cfg.hidden_size, cfg.intermediate_size, Activation::Silu, vb.pp("mlp"))?,
             input_layernorm: candle_nn::rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?,
             post_attention_layernorm: candle_nn::rms_norm(
                 cfg.hidden_size,
@@ -463,7 +442,7 @@ impl TokenizerTransformerLayer {
 
         let residual = hidden.clone();
         let hidden = hidden.apply(&self.post_attention_layernorm)?;
-        let hidden = self.mlp.forward(&hidden)?;
+        let hidden = hidden.apply(&self.mlp)?;
         Ok((residual + self.mlp_layer_scale.forward(&hidden)?)?)
     }
 }

--- a/crane-core/src/models/qwen3_vl/text.rs
+++ b/crane-core/src/models/qwen3_vl/text.rs
@@ -2,12 +2,12 @@ use std::sync::{Arc, Mutex};
 
 use candle::{DType, Device, IndexOp, Result, Tensor};
 use candle_nn::{
-    embedding, kv_cache::KvCache, linear, linear_b, rms_norm, rotary_emb::rope, Activation,
-    Embedding, Linear, Module, RmsNorm, VarBuilder,
+    embedding, kv_cache::KvCache, linear, linear_b, rms_norm, rotary_emb::rope, Embedding,
+    Linear, Module, RmsNorm, VarBuilder,
 };
 
 use super::config::TextConfig;
-use crate::models::modules::rotary::RotaryEmbedding;
+use crate::models::modules::{ffn::SwiGluFfn, rotary::RotaryEmbedding};
 
 fn apply_rotary_emb_batched(
     rotary_emb: &RotaryEmbedding,
@@ -30,34 +30,6 @@ fn apply_rotary_emb_batched(
     Ok((Tensor::cat(&q_embeds, 0)?, Tensor::cat(&k_embeds, 0)?))
 }
 
-struct Mlp {
-    gate_proj: Linear,
-    up_proj: Linear,
-    down_proj: Linear,
-    act_fn: Activation,
-}
-
-impl Mlp {
-    fn new(cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
-        let hidden_sz = cfg.hidden_size;
-        let intermediate_sz = cfg.intermediate_size;
-        let gate_proj = linear_b(hidden_sz, intermediate_sz, false, vb.pp("gate_proj"))?;
-        let up_proj = linear_b(hidden_sz, intermediate_sz, false, vb.pp("up_proj"))?;
-        let down_proj = linear_b(intermediate_sz, hidden_sz, false, vb.pp("down_proj"))?;
-        Ok(Self {
-            gate_proj,
-            up_proj,
-            down_proj,
-            act_fn: cfg.hidden_act,
-        })
-    }
-
-    fn forward(&self, xs: &Tensor) -> Result<Tensor> {
-        let lhs = self.gate_proj.forward(xs)?.apply(&self.act_fn)?;
-        let rhs = self.up_proj.forward(xs)?;
-        self.down_proj.forward(&(lhs * rhs)?)
-    }
-}
 
 struct Attention {
     q_proj: Linear,
@@ -172,7 +144,7 @@ impl Attention {
 
 pub struct DecoderLayer {
     self_attn: Attention,
-    mlp: Mlp,
+    mlp: SwiGluFfn,
     input_layernorm: RmsNorm,
     post_attention_layernorm: RmsNorm,
 }
@@ -180,7 +152,7 @@ pub struct DecoderLayer {
 impl DecoderLayer {
     fn new(rotary_emb: Arc<RotaryEmbedding>, cfg: &TextConfig, vb: VarBuilder) -> Result<Self> {
         let self_attn = Attention::new(rotary_emb, cfg, vb.pp("self_attn"))?;
-        let mlp = Mlp::new(cfg, vb.pp("mlp"))?;
+        let mlp = SwiGluFfn::new(cfg.hidden_size, cfg.intermediate_size, cfg.hidden_act, vb.pp("mlp"))?;
         let input_layernorm =
             rms_norm(cfg.hidden_size, cfg.rms_norm_eps, vb.pp("input_layernorm"))?;
         let post_attention_layernorm = rms_norm(

--- a/crane-core/src/models/with_tracing.rs
+++ b/crane-core/src/models/with_tracing.rs
@@ -46,6 +46,10 @@ impl Linear {
         let span = tracing::span!(tracing::Level::TRACE, "linear");
         Self { inner, span }
     }
+
+    pub fn weight(&self) -> &Tensor {
+        self.inner.weight()
+    }
 }
 
 pub fn linear_b(d1: usize, d2: usize, b: bool, vb: VarBuilder) -> Result<Linear> {


### PR DESCRIPTION
This creates a shared SwiGluFfn implementation. The forward() function has a CUDA fast path, so all models using that have that path now.

However I'm unable to test CUDA. I have an AMD graphics card and haven't got [ZLUDA](https://github.com/vosen/ZLUDA) compiled yet. I just tested Qwen-TTS CPU path and it worked fine.