### PR TITLE
Fix clippy warnings of the crane-serve inference engine

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,9 @@
+# https://rust-lang.github.io/rustfmt/
+style_edition = "2024"
+match_block_trailing_comma = true
+single_line_let_else_max_width = 0
+
+## Currently unstable features
+# force_multiline_blocks = true
+# format_strings = true
+# imports_layout = "HorizontalVertical"

--- a/crane-serve/src/engine/backend.rs
+++ b/crane-serve/src/engine/backend.rs
@@ -14,6 +14,10 @@
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor};
 
+/// Per-layer KV cache for one sequence: `(K, V)` per layer, or `None` for
+/// layers with no cached state yet.
+pub type SequenceKvCaches = Vec<Option<(Tensor, Tensor)>>;
+
 // ─────────────────────────────────────────────────────────────
 //  Trait
 // ─────────────────────────────────────────────────────────────
@@ -30,6 +34,10 @@ pub trait ModelBackend: Send + 'static {
     /// * `start_pos` — KV cache position (0 for a fresh sequence)
     ///
     /// Returns logits tensor, typically `[1, seq_len, vocab_size]`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the forward pass fails.
     fn forward_step(&mut self, input_ids: &[u32], start_pos: usize) -> Result<Tensor>;
 
     /// Clear all KV caches.
@@ -61,12 +69,12 @@ pub trait ModelBackend: Send + 'static {
     }
 
     /// Extract per-layer KV caches from the model.
-    fn get_kv_caches(&self) -> Vec<Option<(Tensor, Tensor)>> {
+    fn get_kv_caches(&self) -> SequenceKvCaches {
         vec![]
     }
 
     /// Restore per-layer KV caches into the model.
-    fn set_kv_caches(&mut self, _caches: Vec<Option<(Tensor, Tensor)>>) {}
+    fn set_kv_caches(&mut self, _caches: SequenceKvCaches) {}
 
     /// Compute bytes held by the model's active KV caches without copying.
     /// Used for memory tracking without the overhead of `get_kv_caches()`.
@@ -83,15 +91,23 @@ pub trait ModelBackend: Send + 'static {
     }
 
     /// Pad and load per-sequence KV caches for batched decoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this backend doesn't support batch decode.
     fn setup_batch_decode(
         &mut self,
-        _seq_kv_caches: &[Vec<Option<(Tensor, Tensor)>>],
+        _seq_kv_caches: &[SequenceKvCaches],
         _extra_room: usize,
     ) -> candle_core::Result<(Vec<usize>, usize)> {
         candle_core::bail!("Batch decode not supported by this backend")
     }
 
     /// Run one batched decode step.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this backend doesn't support batch decode.
     fn step_batch_decode(
         &mut self,
         _input_ids: &Tensor,
@@ -103,16 +119,24 @@ pub trait ModelBackend: Send + 'static {
     }
 
     /// Extract per-sequence KV caches from batched state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this backend doesn't support batch decode.
     fn extract_batch_kv(
         &mut self,
         _kv_lens: &[usize],
         _original_max_kv: usize,
         _rounds_done: usize,
-    ) -> candle_core::Result<Vec<Vec<Option<(Tensor, Tensor)>>>> {
+    ) -> candle_core::Result<Vec<SequenceKvCaches>> {
         candle_core::bail!("Batch decode not supported by this backend")
     }
 
     /// Build attention mask for batched decoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if this backend doesn't support batch decode.
     fn build_batch_decode_mask(
         &self,
         _kv_lens: &[usize],
@@ -132,6 +156,9 @@ pub struct Gemma4Backend {
 }
 
 impl Gemma4Backend {
+    /// # Errors
+    ///
+    /// Returns an error if the model fails to load from `model_path`.
     pub fn new(
         model_path: &str,
         device: &Device,
@@ -204,6 +231,9 @@ pub struct HunyuanBackend {
 }
 
 impl HunyuanBackend {
+    /// # Errors
+    ///
+    /// Returns an error if the model fails to load from `model_path`.
     pub fn new(
         model_path: &str,
         device: &Device,
@@ -244,7 +274,7 @@ impl ModelBackend for HunyuanBackend {
     }
 
     fn eos_token_id(&self) -> Vec<u32> {
-        vec![120020]
+        vec![120_020]
     }
 
     fn warmup(&mut self) {
@@ -330,6 +360,9 @@ pub struct Qwen25Backend {
 }
 
 impl Qwen25Backend {
+    /// # Errors
+    ///
+    /// Returns an error if the model fails to load from `model_path`.
     pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
         let model = crane_core::models::qwen25::Model::new(model_path, device, dtype)?;
         Ok(Self {
@@ -372,8 +405,7 @@ impl ModelBackend for Qwen25Backend {
             .tokenizer
             .token_to_id("<|endoftext|>")
             .or_else(|| self.model.tokenizer.tokenizer.token_to_id("<|im_end|>"))
-            .map(|id| vec![id])
-            .unwrap_or_else(|| vec![151643])
+            .map_or_else(|| vec![151_643], |id| vec![id])
     }
 
     fn warmup(&mut self) {
@@ -397,6 +429,9 @@ pub struct Qwen3_5Backend {
 }
 
 impl Qwen3_5Backend {
+    /// # Errors
+    ///
+    /// Returns an error if the model fails to load from `model_path`.
     pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
         let model = crane_core::models::qwen3_5::Model::new(model_path, device, dtype)?;
         Ok(Self {
@@ -408,9 +443,8 @@ impl Qwen3_5Backend {
 
 impl ModelBackend for Qwen3_5Backend {
     fn forward_step(&mut self, input_ids: &[u32], start_pos: usize) -> Result<Tensor> {
-        self.model
-            .forward_step(input_ids, start_pos)
-            .map_err(Into::into)
+        // The underlying model already returns anyhow::Result — no conversion needed.
+        self.model.forward_step(input_ids, start_pos)
     }
 
     fn clear_kv_cache(&mut self) {
@@ -447,8 +481,8 @@ impl ModelBackend for Qwen3_5Backend {
             ids.push(id);
         }
         if ids.is_empty() {
-            ids.push(151645);
-            ids.push(151643);
+            ids.push(151_645);
+            ids.push(151_643);
         }
         ids
     }
@@ -472,6 +506,9 @@ pub struct Qwen3Backend {
 }
 
 impl Qwen3Backend {
+    /// # Errors
+    ///
+    /// Returns an error if the model fails to load from `model_path`.
     pub fn new(model_path: &str, device: &Device, dtype: &DType) -> Result<Self> {
         let model = crane_core::models::qwen3::Model::new(model_path, device, dtype)?;
         Ok(Self {
@@ -515,7 +552,7 @@ impl ModelBackend for Qwen3Backend {
         let mut ids = Vec::new();
         if let Some(id) = tok.token_to_id("<|im_end|>") { ids.push(id); }
         if let Some(id) = tok.token_to_id("<|endoftext|>") { ids.push(id); }
-        if ids.is_empty() { ids.push(151645); ids.push(151643); }
+        if ids.is_empty() { ids.push(151_645); ids.push(151_643); }
         ids
     }
 

--- a/crane-serve/src/engine/mod.rs
+++ b/crane-serve/src/engine/mod.rs
@@ -79,6 +79,7 @@ impl MemoryConfig {
     /// `gpu_memory_limit` accepts:
     ///   - Absolute sizes: "5G", "8G", "5120M", "5368709120" (bytes)
     ///   - Utilization fraction: "0.7" (70% of total GPU memory)
+    #[must_use]
     pub fn parse(max_seq_len: usize, gpu_memory_limit: Option<&str>, device: &Device) -> Self {
         let gpu_memory_limit_bytes = match gpu_memory_limit {
             Some(s) => Self::parse_memory_limit(s, device),
@@ -99,15 +100,25 @@ impl MemoryConfig {
 
         // Try absolute sizes: "5G", "8G", "5120M", "1024K"
         let upper = s.to_uppercase();
-        if upper.ends_with('G') {
-            if let Ok(n) = upper[..upper.len() - 1].trim().parse::<f64>() {
-                return (n * (1u64 << 30) as f64) as u64;
-            }
+        if upper.ends_with('G')
+            && let Ok(n) = upper[..upper.len() - 1].trim().parse::<f64>()
+        {
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            return (n * (1u64 << 30) as f64) as u64;
         }
-        if upper.ends_with('M') {
-            if let Ok(n) = upper[..upper.len() - 1].trim().parse::<f64>() {
-                return (n * (1u64 << 20) as f64) as u64;
-            }
+        if upper.ends_with('M')
+            && let Ok(n) = upper[..upper.len() - 1].trim().parse::<f64>()
+        {
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            return (n * (1u64 << 20) as f64) as u64;
         }
 
         // Try as a fraction (0.0 - 1.0)
@@ -115,16 +126,22 @@ impl MemoryConfig {
             if (0.0..=1.0).contains(&frac) {
                 let total = Self::query_total_gpu_memory(device);
                 if total > 0 {
+                    #[allow(
+                        clippy::cast_possible_truncation,
+                        clippy::cast_sign_loss,
+                        clippy::cast_precision_loss
+                    )]
                     return (frac * total as f64) as u64;
                 }
             }
             // If > 1.0, treat as bytes
             if frac > 1.0 {
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 return frac as u64;
             }
         }
 
-        tracing::warn!("Could not parse gpu_memory_limit '{}', ignoring", s);
+        tracing::warn!("Could not parse gpu_memory_limit '{s}', ignoring");
         0
     }
 
@@ -150,7 +167,7 @@ impl MemoryConfig {
     }
 }
 
-/// Query current GPU memory usage. Returns (used_bytes, total_bytes).
+/// Query current GPU memory usage. Returns (`used_bytes`, `total_bytes`).
 /// Returns (0, 0) if not on CUDA.
 fn query_gpu_memory_usage(_device: &Device) -> (u64, u64) {
     #[cfg(feature = "cuda")]
@@ -169,12 +186,14 @@ fn query_gpu_memory_usage(_device: &Device) -> (u64, u64) {
 /// Format a byte count as a human-readable string (used in engine log messages).
 fn format_bytes_engine(bytes: u64) -> String {
     if bytes >= 1 << 30 {
-        format!("{:.1}G", bytes as f64 / (1u64 << 30) as f64)
-    } else if bytes >= 1 << 20 {
-        format!("{:.0}M", bytes as f64 / (1u64 << 20) as f64)
-    } else {
-        format!("{}B", bytes)
+        #[allow(clippy::cast_precision_loss)]
+        return format!("{:.1}G", bytes as f64 / (1u64 << 30) as f64);
     }
+    if bytes >= 1 << 20 {
+        #[allow(clippy::cast_precision_loss)]
+        return format!("{:.0}M", bytes as f64 / (1u64 << 20) as f64);
+    }
+    format!("{bytes}B")
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -246,10 +265,7 @@ impl InferenceEngine {
             1.min(max_concurrent)
         };
         if effective_max != max_concurrent {
-            info!(
-                "Model does not support KV swap — limiting max_concurrent to {}",
-                effective_max
-            );
+            info!("Model does not support KV swap — limiting max_concurrent to {effective_max}");
         }
 
         let stats = Arc::new(EngineStats::new());
@@ -267,7 +283,9 @@ impl InferenceEngine {
             step_counter: 0,
             sampling_buffers: SamplingBuffers::new(),
             memory_config,
-            last_mem_warn: Instant::now() - std::time::Duration::from_secs(60),
+            last_mem_warn: Instant::now()
+                .checked_sub(std::time::Duration::from_mins(1))
+                .unwrap_or_else(Instant::now),
             tracked_kv_bytes: 0,
             eviction_cooldown: 0,
         };
@@ -360,18 +378,17 @@ impl InferenceEngine {
                     }
                     self.step_counter += 1;
 
-                    if self.step_counter % 50 == 0 {
+                    if self.step_counter.is_multiple_of(50) {
                         self.log_stats();
                     }
                 }
                 None => {
-                    match self.request_rx.blocking_recv() {
-                        Some(req) => self.accept_request(req),
-                        None => {
-                            info!("Engine channel closed, shutting down");
-                            self.log_stats();
-                            return;
-                        }
+                    if let Some(req) = self.request_rx.blocking_recv() {
+                        self.accept_request(req);
+                    } else {
+                        info!("Engine channel closed, shutting down");
+                        self.log_stats();
+                        return;
                     }
                 }
             }
@@ -388,6 +405,7 @@ impl InferenceEngine {
         } else {
             String::new()
         };
+        #[allow(clippy::cast_precision_loss)]
         let gpu_info = if gpu_total > 0 {
             format!(
                 " | gpu_mem: {:.1}G/{:.1}G ({:.0}%) | kv_cache: {}{}",
@@ -548,17 +566,13 @@ impl InferenceEngine {
                 .max_by_key(|(_, len)| *len)
                 .map(|(id, _)| id);
 
-            let victim_id = match victim_id {
-                Some(id) => id,
-                None => break,
-            };
+            let Some(victim_id) = victim_id else { break };
 
             // Compute bytes being freed.
             let freed = self
                 .sequences
                 .get(&victim_id)
-                .map(|seq| sequence::kv_cache_bytes(&seq.kv_caches))
-                .unwrap_or(0);
+                .map_or(0, |seq| sequence::kv_cache_bytes(&seq.kv_caches));
 
             info!(
                 id = %victim_id,
@@ -606,7 +620,7 @@ impl InferenceEngine {
         self.eviction_cooldown = 5;
     }
 
-    /// Effective max_tokens for a request, taking server-level max_seq_len into account.
+    /// Effective `max_tokens` for a request, taking server-level `max_seq_len` into account.
     fn effective_max_tokens(&self, prompt_len: usize, requested_max_tokens: usize) -> usize {
         if self.memory_config.max_seq_len == 0 {
             return requested_max_tokens;
@@ -731,7 +745,7 @@ impl InferenceEngine {
             // performs every scheduling round.
             self.step_decode_batch(output.batch);
         } else {
-            self.step_decode_sequential(output.batch);
+            self.step_decode_sequential(&output.batch);
         }
     }
 
@@ -772,11 +786,13 @@ impl InferenceEngine {
 
         self.swap_out(&seq_id);
 
+        #[allow(clippy::cast_possible_truncation)]
         let prefill_us = t0.elapsed().as_micros() as u64;
         self.stats
             .total_prefill_time_us
             .fetch_add(prefill_us, Ordering::Relaxed);
 
+        #[allow(clippy::cast_precision_loss)]
         let prefill_tok_s = if prefill_us > 0 {
             (prompt_len as f64) / (prefill_us as f64 / 1_000_000.0)
         } else {
@@ -810,21 +826,15 @@ impl InferenceEngine {
     //  Batched decode
     // ─────────────────────────────────────────────────────────
 
-    /// Decode step for all running sequences — TRUE BATCHED forward.
-    ///
-    /// Uses **lazy eviction**: when a sequence completes or is cancelled
-    /// mid-loop, it stays in the batch tensor (wasting trivial compute)
-    /// rather than triggering an expensive extract→re-setup cycle.
-    fn step_decode_batch(&mut self, batch: Vec<String>) {
-        let t0 = Instant::now();
-
-        // Filter cancelled sequences.
+    /// Remove cancelled/disconnected sequences from a decode batch, cleaning
+    /// each one up. Returns the filtered batch.
+    fn filter_cancelled_batch(&mut self, batch: Vec<String>) -> Vec<String> {
         let cancelled: Vec<String> = batch
             .iter()
             .filter(|id| {
                 self.sequences
                     .get(id.as_str())
-                    .map_or(true, |s| s.response_tx.is_closed())
+                    .is_none_or(|s| s.response_tx.is_closed())
             })
             .cloned()
             .collect();
@@ -833,17 +843,15 @@ impl InferenceEngine {
             self.stats.cancelled_requests.fetch_add(1, Ordering::Relaxed);
             self.cleanup_sequence(id);
         }
-        let batch: Vec<String> = batch
+        batch
             .into_iter()
             .filter(|id| !cancelled.contains(id))
-            .collect();
-        if batch.is_empty() {
-            return;
-        }
+            .collect()
+    }
 
-        let batch_size = batch.len();
-
-        // Flush model's internal KV cache state.
+    /// Flush the model's active single-sequence KV cache before batch decode
+    /// takes over, saving it back to the owning sequence.
+    fn flush_active_kv_for_batch(&mut self) {
         if let Some(ref prev_id) = self.active_seq_id.take() {
             if self.sequences.contains_key(prev_id) {
                 let caches = self.model.get_kv_caches();
@@ -854,6 +862,65 @@ impl InferenceEngine {
             self.model.clear_kv_cache();
         }
         self.recount_kv_bytes();
+    }
+
+    /// Extract per-sequence KV caches from the model's batched buffer back
+    /// into `self.sequences` after a batch decode step.
+    fn save_extracted_batch_kv(
+        &mut self,
+        batch: &[String],
+        alive: &[bool],
+        kv_lens: &[usize],
+        original_max_kv: usize,
+        rounds_done: usize,
+    ) {
+        if rounds_done == 0 {
+            return;
+        }
+        match self
+            .model
+            .extract_batch_kv(kv_lens, original_max_kv, rounds_done)
+        {
+            Ok(extracted) => {
+                for (i, seq_id) in batch.iter().enumerate() {
+                    if alive[i]
+                        && let Some(seq) = self.sequences.get_mut(seq_id)
+                        && i < extracted.len()
+                    {
+                        seq.kv_caches.clone_from(&extracted[i]);
+                    }
+                }
+                // KV caches changed for multiple sequences — recount.
+                self.recount_kv_bytes();
+            }
+            Err(e) => {
+                error!("Final KV extraction failed: {e}");
+                self.model.clear_kv_cache();
+                self.recount_kv_bytes();
+            }
+        }
+    }
+
+    /// Decode step for all running sequences — TRUE BATCHED forward.
+    ///
+    /// Uses **lazy eviction**: when a sequence completes or is cancelled
+    /// mid-loop, it stays in the batch tensor (wasting trivial compute)
+    /// rather than triggering an expensive extract→re-setup cycle.
+    // The setup, multi-round decode loop, and finalization below are one
+    // cohesive decode step; splitting them further would scatter shared
+    // local state (batch, kv_lens, alive, positions) across functions.
+    #[allow(clippy::too_many_lines)]
+    fn step_decode_batch(&mut self, batch: Vec<String>) {
+        let t0 = Instant::now();
+
+        let batch = self.filter_cancelled_batch(batch);
+        if batch.is_empty() {
+            return;
+        }
+
+        let batch_size = batch.len();
+
+        self.flush_active_kv_for_batch();
 
         // Collect KV caches and setup batched decode.
         let kv_caches: Vec<Vec<Option<(Tensor, Tensor)>>> = batch
@@ -1014,13 +1081,13 @@ impl InferenceEngine {
 
                 self.send_token(seq_id, next_token);
 
-                if self.sequences.get(seq_id).map_or(true, |s| s.should_stop()) {
+                if self.sequences.get(seq_id).is_none_or(Sequence::should_stop) {
                     alive[i] = false;
                     pending_finish.push(seq_id.clone());
                 } else if self
                     .sequences
                     .get(seq_id)
-                    .map_or(true, |s| s.response_tx.is_closed())
+                    .is_none_or(|s| s.response_tx.is_closed())
                 {
                     warn!(id = %seq_id, "Client disconnected mid-batch-decode");
                     alive[i] = false;
@@ -1028,37 +1095,12 @@ impl InferenceEngine {
                 }
             }
 
-            for p in positions.iter_mut() {
+            for p in &mut positions {
                 *p += 1;
             }
         }
 
-        // Extract per-sequence KV caches.
-        if rounds_done > 0 {
-            match self
-                .model
-                .extract_batch_kv(&kv_lens, original_max_kv, rounds_done)
-            {
-                Ok(extracted) => {
-                    for (i, seq_id) in batch.iter().enumerate() {
-                        if alive[i] {
-                            if let Some(seq) = self.sequences.get_mut(seq_id) {
-                                if i < extracted.len() {
-                                    seq.kv_caches = extracted[i].clone();
-                                }
-                            }
-                        }
-                    }
-                    // KV caches changed for multiple sequences — recount.
-                    self.recount_kv_bytes();
-                }
-                Err(e) => {
-                    error!("Final KV extraction failed: {e}");
-                    self.model.clear_kv_cache();
-                    self.recount_kv_bytes();
-                }
-            }
-        }
+        self.save_extracted_batch_kv(&batch, &alive, &kv_lens, original_max_kv, rounds_done);
 
         for id in &pending_finish {
             self.finish_sequence(id);
@@ -1068,23 +1110,27 @@ impl InferenceEngine {
             self.cleanup_sequence(id);
         }
 
+        #[allow(clippy::cast_possible_truncation)]
         let decode_us = t0.elapsed().as_micros() as u64;
         self.stats
             .total_decode_time_us
             .fetch_add(decode_us, Ordering::Relaxed);
 
         if total_tokens_this_step > 0 {
+            #[allow(clippy::cast_precision_loss)]
             let tok_s = if decode_us > 0 {
                 (total_tokens_this_step as f64) / (decode_us as f64 / 1_000_000.0)
             } else {
                 0.0
             };
+            #[allow(clippy::cast_possible_truncation)]
+            let setup_ms = t_setup.as_millis() as u64;
             debug!(
                 batch_size,
                 tokens = total_tokens_this_step,
                 rounds = rounds_done,
                 finished = pending_finish.len(),
-                setup_ms = t_setup.as_millis() as u64,
+                setup_ms,
                 decode_ms = decode_us / 1000,
                 tok_s = format!("{:.1}", tok_s),
                 "Batched decode step complete",
@@ -1100,15 +1146,15 @@ impl InferenceEngine {
     // ─────────────────────────────────────────────────────────
 
     /// Sequential decode for backends without batch decode support.
-    fn step_decode_sequential(&mut self, batch: Vec<String>) {
+    fn step_decode_sequential(&mut self, batch: &[String]) {
         let t0 = Instant::now();
         let mut total_tokens: u64 = 0;
 
-        for seq_id in &batch {
+        for seq_id in batch {
             if self
                 .sequences
                 .get(seq_id)
-                .map_or(true, |s| s.response_tx.is_closed())
+                .is_none_or(|s| s.response_tx.is_closed())
             {
                 self.stats
                     .cancelled_requests
@@ -1121,10 +1167,7 @@ impl InferenceEngine {
 
             for _round in 0..self.decode_tokens_per_seq {
                 let (input_ids, start_pos) = {
-                    let seq = match self.sequences.get(seq_id) {
-                        Some(s) => s,
-                        None => break,
-                    };
+                    let Some(seq) = self.sequences.get(seq_id) else { break };
                     (seq.next_input_ids().to_vec(), seq.start_pos())
                 };
 
@@ -1161,7 +1204,7 @@ impl InferenceEngine {
                 if self
                     .sequences
                     .get(seq_id)
-                    .map_or(true, |s| s.should_stop())
+                    .is_none_or(Sequence::should_stop)
                 {
                     self.finish_sequence(seq_id);
                     break;
@@ -1170,7 +1213,7 @@ impl InferenceEngine {
                 if self
                     .sequences
                     .get(seq_id)
-                    .map_or(true, |s| s.response_tx.is_closed())
+                    .is_none_or(|s| s.response_tx.is_closed())
                 {
                     warn!(id = %seq_id, "Client disconnected mid-decode");
                     self.stats
@@ -1184,12 +1227,14 @@ impl InferenceEngine {
             self.swap_out(seq_id);
         }
 
+        #[allow(clippy::cast_possible_truncation)]
         let decode_us = t0.elapsed().as_micros() as u64;
         self.stats
             .total_decode_time_us
             .fetch_add(decode_us, Ordering::Relaxed);
 
         if total_tokens > 0 {
+            #[allow(clippy::cast_precision_loss)]
             let tok_s = if decode_us > 0 {
                 (total_tokens as f64) / (decode_us as f64 / 1_000_000.0)
             } else {
@@ -1217,10 +1262,8 @@ impl InferenceEngine {
         }
 
         if !self.model.supports_kv_swap() {
-            if self.active_seq_id.as_deref() != Some(seq_id) {
-                self.model.clear_kv_cache();
-                self.active_seq_id = Some(seq_id.to_string());
-            }
+            self.model.clear_kv_cache();
+            self.active_seq_id = Some(seq_id.to_string());
             return;
         }
 
@@ -1236,8 +1279,7 @@ impl InferenceEngine {
         let caches = self
             .sequences
             .get(seq_id)
-            .map(|s| s.kv_caches.clone())
-            .unwrap_or_else(|| vec![None; self.num_layers]);
+            .map_or_else(|| vec![None; self.num_layers], |s| s.kv_caches.clone());
         self.model.set_kv_caches(caches);
         self.active_seq_id = Some(seq_id.to_string());
 
@@ -1262,10 +1304,10 @@ impl InferenceEngine {
         // Drop stale seq cache references (from the last swap_in) to free
         // GPU memory.  swap_in will extract fresh caches from the model
         // when switching to a different sequence.
-        if let Some(seq) = self.sequences.get_mut(seq_id) {
-            if seq.kv_caches.iter().any(|c| c.is_some()) {
-                seq.kv_caches = vec![None; seq.kv_caches.len()];
-            }
+        if let Some(seq) = self.sequences.get_mut(seq_id)
+            && seq.kv_caches.iter().any(Option::is_some)
+        {
+            seq.kv_caches = vec![None; seq.kv_caches.len()];
         }
         self.recount_kv_bytes();
     }
@@ -1288,14 +1330,13 @@ impl InferenceEngine {
             return;
         };
 
-        if let Some(seq) = self.sequences.get(seq_id) {
-            if seq
+        if let Some(seq) = self.sequences.get(seq_id)
+            && seq
                 .response_tx
                 .send(EngineResponse::Token { text, token_id })
                 .is_err()
-            {
-                debug!(id = %seq_id, "Response channel closed (client disconnected)");
-            }
+        {
+            debug!(id = %seq_id, "Response channel closed (client disconnected)");
         }
     }
 
@@ -1315,13 +1356,13 @@ impl InferenceEngine {
             .and_then(|s| s.decode_rest().ok().flatten())
             .unwrap_or_default();
 
-        if !remaining.is_empty() {
-            if let Some(seq) = self.sequences.get(seq_id) {
-                let _ = seq.response_tx.send(EngineResponse::Token {
-                    text: remaining,
-                    token_id: 0,
-                });
-            }
+        if !remaining.is_empty()
+            && let Some(seq) = self.sequences.get(seq_id)
+        {
+            let _ = seq.response_tx.send(EngineResponse::Token {
+                text: remaining,
+                token_id: 0,
+            });
         }
 
         if let Some(seq) = self.sequences.get(seq_id) {

--- a/crane-serve/src/engine/mod.rs
+++ b/crane-serve/src/engine/mod.rs
@@ -37,7 +37,7 @@ pub mod types;
 
 // Re-export commonly used items for convenience.
 pub use stats::{EngineStats, StatsSnapshot};
-pub use types::{EngineHandle, EngineRequest, EngineResponse};
+pub use types::{EngineHandle, EngineRequest, EngineResponse, GenerationParams};
 
 use std::collections::HashMap;
 use std::sync::atomic::Ordering;

--- a/crane-serve/src/engine/model_factory.rs
+++ b/crane-serve/src/engine/model_factory.rs
@@ -33,6 +33,10 @@ pub enum ModelType {
 }
 
 impl ModelType {
+    // Infallible convenience constructor, not the fallible std::str::FromStr
+    // trait (unknown strings fall back to `Auto` instead of erroring).
+    #[allow(clippy::should_implement_trait)]
+    #[must_use]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "gemma4" | "gemma-4" | "gemma4_e2b" => Self::Gemma4,
@@ -48,6 +52,7 @@ impl ModelType {
         }
     }
 
+    #[must_use]
     pub fn display_name(&self) -> &'static str {
         match self {
             Self::Auto => "auto",
@@ -64,11 +69,13 @@ impl ModelType {
     }
 
     /// Whether this model type is a vision-language model.
+    #[must_use]
     pub fn is_vlm(&self) -> bool {
         matches!(self, Self::PaddleOcrVl | Self::Gemma4VL)
     }
 
     /// Whether this model type is a TTS model.
+    #[must_use]
     pub fn is_tts(&self) -> bool {
         matches!(self, Self::Qwen3TTS | Self::VoxtralTTS)
     }
@@ -83,6 +90,10 @@ pub enum ModelFormat {
 }
 
 impl ModelFormat {
+    // Infallible convenience constructor, not the fallible std::str::FromStr
+    // trait (unknown strings fall back to `Auto` instead of erroring).
+    #[allow(clippy::should_implement_trait)]
+    #[must_use]
     pub fn from_str(s: &str) -> Self {
         match s.to_lowercase().as_str() {
             "safetensors" => Self::Safetensors,
@@ -96,7 +107,7 @@ impl ModelFormat {
 //  Detection
 // ─────────────────────────────────────────────────────────────
 
-/// Minimal subset of HuggingFace `config.json` for architecture detection.
+/// Minimal subset of `HuggingFace` `config.json` for architecture detection.
 #[derive(Deserialize, Default)]
 struct HfConfig {
     model_type: Option<String>,
@@ -121,55 +132,54 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
         Some(path.join("config.json"))
     };
 
-    if let Some(config_path) = config_path {
-        if let Ok(data) = std::fs::read(&config_path) {
-            if let Ok(config) = serde_json::from_slice::<HfConfig>(&data) {
-                // 1. Check `model_type` field
-                if let Some(ref mt) = config.model_type {
-                    match mt.to_lowercase().as_str() {
-                        "gemma4" => {
-                            return if config.vision_config.is_some() {
-                                ModelType::Gemma4VL
-                            } else {
-                                ModelType::Gemma4
-                            };
-                        }
-                        "qwen2" | "qwen2.5" => return ModelType::Qwen25,
-                        "qwen3" => return ModelType::Qwen3,
-                        "qwen3_5" | "qwen3.5" => return ModelType::Qwen3_5,
-                        "qwen3_tts" | "qwen3tts" => return ModelType::Qwen3TTS,
-                        m if m.contains("hunyuan") => return ModelType::HunyuanDense,
-                        m if m.contains("paddleocr") => return ModelType::PaddleOcrVl,
-                        _ => {}
-                    }
+    if let Some(config_path) = config_path
+        && let Ok(data) = std::fs::read(&config_path)
+        && let Ok(config) = serde_json::from_slice::<HfConfig>(&data)
+    {
+        // 1. Check `model_type` field
+        if let Some(ref mt) = config.model_type {
+            match mt.to_lowercase().as_str() {
+                "gemma4" => {
+                    return if config.vision_config.is_some() {
+                        ModelType::Gemma4VL
+                    } else {
+                        ModelType::Gemma4
+                    };
                 }
+                "qwen2" | "qwen2.5" => return ModelType::Qwen25,
+                "qwen3" => return ModelType::Qwen3,
+                "qwen3_5" | "qwen3.5" => return ModelType::Qwen3_5,
+                "qwen3_tts" | "qwen3tts" => return ModelType::Qwen3TTS,
+                m if m.contains("hunyuan") => return ModelType::HunyuanDense,
+                m if m.contains("paddleocr") => return ModelType::PaddleOcrVl,
+                _ => {}
+            }
+        }
 
-                // 2. Check `architectures` field
-                if let Some(ref archs) = config.architectures {
-                    for arch in archs {
-                        let a = arch.to_lowercase();
-                        if a.contains("paddleocr") {
-                            return ModelType::PaddleOcrVl;
-                        }
-                        if a.contains("hunyuan") {
-                            return ModelType::HunyuanDense;
-                        }
-                        if a.contains("gemma4") {
-                            return ModelType::Gemma4;
-                        }
-                        if a.contains("qwen3ttsforconditional") || a.contains("qwen3_tts") {
-                            return ModelType::Qwen3TTS;
-                        }
-                        if a.contains("qwen3_5") || a.contains("qwen3.5") {
-                            return ModelType::Qwen3_5;
-                        }
-                        if a.contains("qwen3") {
-                            return ModelType::Qwen3;
-                        }
-                        if a.contains("qwen2") {
-                            return ModelType::Qwen25;
-                        }
-                    }
+        // 2. Check `architectures` field
+        if let Some(ref archs) = config.architectures {
+            for arch in archs {
+                let a = arch.to_lowercase();
+                if a.contains("paddleocr") {
+                    return ModelType::PaddleOcrVl;
+                }
+                if a.contains("hunyuan") {
+                    return ModelType::HunyuanDense;
+                }
+                if a.contains("gemma4") {
+                    return ModelType::Gemma4;
+                }
+                if a.contains("qwen3ttsforconditional") || a.contains("qwen3_tts") {
+                    return ModelType::Qwen3TTS;
+                }
+                if a.contains("qwen3_5") || a.contains("qwen3.5") {
+                    return ModelType::Qwen3_5;
+                }
+                if a.contains("qwen3") {
+                    return ModelType::Qwen3;
+                }
+                if a.contains("qwen2") {
+                    return ModelType::Qwen25;
                 }
             }
         }
@@ -181,16 +191,13 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
     } else {
         Some(path.join("params.json"))
     };
-    if let Some(params_path) = params_path {
-        if let Ok(data) = std::fs::read(&params_path) {
-            if let Ok(config) = serde_json::from_slice::<MistralConfig>(&data) {
-                if let Some(ref mt) = config.model_type {
-                    if mt == "voxtral_tts" {
-                        return ModelType::VoxtralTTS;
-                    }
-                }
-            }
-        }
+    if let Some(params_path) = params_path
+        && let Ok(data) = std::fs::read(&params_path)
+        && let Ok(config) = serde_json::from_slice::<MistralConfig>(&data)
+        && let Some(ref mt) = config.model_type
+        && mt == "voxtral_tts"
+    {
+        return ModelType::VoxtralTTS;
     }
 
     // 4. Heuristic: check the model path name
@@ -231,6 +238,11 @@ fn resolve(model_type: ModelType, model_path: &str) -> ModelType {
 }
 
 /// Create a model backend.
+///
+/// # Errors
+///
+/// Returns an error if `model_type` resolves to a VLM/TTS type (use
+/// `create_vlm_model()`/`create_tts_model()` instead) or the model fails to load.
 pub fn create_backend(
     model_type: ModelType,
     model_path: &str,
@@ -303,6 +315,10 @@ pub fn create_chat_template(
 }
 
 /// Create a PaddleOCR-VL model for VLM inference.
+///
+/// # Errors
+///
+/// Returns an error if the model fails to load from `model_path`.
 pub fn create_vlm_model(
     model_path: &str,
     use_cpu: bool,
@@ -313,6 +329,10 @@ pub fn create_vlm_model(
 }
 
 /// Create a Qwen3-TTS model for TTS inference.
+///
+/// # Errors
+///
+/// Returns an error if the model fails to load from `model_path`.
 pub fn create_tts_model(
     model_path: &str,
     device: &Device,
@@ -323,6 +343,10 @@ pub fn create_tts_model(
 }
 
 /// Create a Voxtral TTS model for TTS inference.
+///
+/// # Errors
+///
+/// Returns an error if the model fails to load from `model_path`.
 pub fn create_voxtral_tts_model(
     model_path: &str,
     device: &Device,

--- a/crane-serve/src/engine/sampling.rs
+++ b/crane-serve/src/engine/sampling.rs
@@ -26,7 +26,14 @@ pub struct SamplingBuffers {
     pub topk_neg_vecs: HashMap<usize, Tensor>,
 }
 
+impl Default for SamplingBuffers {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SamplingBuffers {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             topk_cumsum_mats: HashMap::new(),
@@ -36,64 +43,78 @@ impl SamplingBuffers {
         }
     }
 
+    /// # Errors
+    ///
+    /// Returns an error if tensor allocation on `device` fails.
     pub fn get_topk_neg_vec(
         &mut self,
         k: usize,
         device: &Device,
     ) -> candle_core::Result<Tensor> {
-        if let Some(t) = self.topk_neg_vecs.get(&k) {
-            if t.device().same_device(device) {
-                return Ok(t.clone());
-            }
+        if let Some(t) = self.topk_neg_vecs.get(&k)
+            && t.device().same_device(device)
+        {
+            return Ok(t.clone());
         }
         let t = Tensor::full(-1e9f32, k, device)?;
         self.topk_neg_vecs.insert(k, t.clone());
         Ok(t)
     }
 
+    /// # Errors
+    ///
+    /// Returns an error if `k <= 1` or tensor allocation on `device` fails.
     pub fn get_topk_shift_idx(
         &mut self,
         k: usize,
         device: &Device,
     ) -> candle_core::Result<Tensor> {
-        if let Some(t) = self.topk_shift_idxs.get(&k) {
-            if t.device().same_device(device) {
-                return Ok(t.clone());
-            }
+        if let Some(t) = self.topk_shift_idxs.get(&k)
+            && t.device().same_device(device)
+        {
+            return Ok(t.clone());
         }
         if k <= 1 {
             candle_core::bail!("get_topk_shift_idx expects k > 1")
         }
+        #[allow(clippy::cast_possible_truncation)]
         let t = Tensor::arange(1u32, k as u32, device)?;
         self.topk_shift_idxs.insert(k, t.clone());
         Ok(t)
     }
 
+    /// # Errors
+    ///
+    /// Returns an error if tensor allocation on `device` fails.
     pub fn get_topk_shift_buf(
         &mut self,
         k: usize,
         device: &Device,
         dtype: DType,
     ) -> candle_core::Result<Tensor> {
-        if let Some(t) = self.topk_shift_bufs.get(&k) {
-            if t.device().same_device(device) && t.dtype() == dtype {
-                return Ok(t.clone());
-            }
+        if let Some(t) = self.topk_shift_bufs.get(&k)
+            && t.device().same_device(device)
+            && t.dtype() == dtype
+        {
+            return Ok(t.clone());
         }
         let t = Tensor::zeros(k, dtype, device)?;
         self.topk_shift_bufs.insert(k, t.clone());
         Ok(t)
     }
 
+    /// # Errors
+    ///
+    /// Returns an error if tensor allocation on `device` fails.
     pub fn get_topk_cumsum_mat(
         &mut self,
         k: usize,
         device: &Device,
     ) -> candle_core::Result<Tensor> {
-        if let Some(t) = self.topk_cumsum_mats.get(&k) {
-            if t.device().same_device(device) {
-                return Ok(t.clone());
-            }
+        if let Some(t) = self.topk_cumsum_mats.get(&k)
+            && t.device().same_device(device)
+        {
+            return Ok(t.clone());
         }
         let mut data = Vec::with_capacity(k * k);
         for row in 0..k {
@@ -114,6 +135,13 @@ impl SamplingBuffers {
 /// - Top-k filtering with GPU-native Gumbel-max sampling
 /// - Top-p (nucleus) filtering with cumulative softmax masking
 /// - CPU fallback via `LogitsProcessor` when needed
+///
+/// # Errors
+///
+/// Returns an error if a tensor operation fails.
+// The branching by device/top-k/top-p is one cohesive decode path; splitting
+// it up would scatter state across smaller functions rather than clarify it.
+#[allow(clippy::too_many_lines)]
 pub fn sample(
     seq_id: &str,
     seq: &mut Sequence,
@@ -132,14 +160,19 @@ pub fn sample(
     };
     #[cfg(feature = "cuda")]
     {
+        // `repetition_penalty` is compared against the exact "disabled" sentinel
+        // (1.0), not a computed float, so strict equality is correct.
+        #[allow(clippy::float_cmp)]
         if greedy && seq.repetition_penalty == 1.0 && logits.device().is_cuda() {
             let flat = logits.squeeze(0)?.squeeze(0)?;
             let token = crane_core::ops::gpu_argmax(&flat)?;
             if trace {
                 let t_done = Instant::now();
+                #[allow(clippy::cast_possible_truncation)]
+                let total_us = t_done.duration_since(t0).as_micros() as u64;
                 tracing::debug!(
                     id = %seq_id,
-                    total_us = t_done.duration_since(t0).as_micros() as u64,
+                    total_us,
                     "sample(gpu_argmax_fast)"
                 );
             }
@@ -148,14 +181,17 @@ pub fn sample(
     }
 
     let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
-    let t_after_prep = Instant::now();
+    let t_preprocessed = Instant::now();
 
+    // `repetition_penalty` is compared against the exact "disabled" sentinel
+    // (1.0), not a computed float, so strict equality is correct.
+    #[allow(clippy::float_cmp)]
     if seq.repetition_penalty != 1.0 {
         let start_at = seq.tokens.len().saturating_sub(seq.repeat_last_n);
         apply_repeat_penalty_inplace(&logits, seq.repetition_penalty, &seq.tokens[start_at..])
             .map_err(anyhow::Error::from)?;
     }
-    let t_after_rep = Instant::now();
+    let t_penalty_applied = Instant::now();
 
     if greedy {
         return Ok(logits.argmax(0)?.to_scalar::<u32>()?);
@@ -183,12 +219,14 @@ pub fn sample(
                 let next_token = seq.logits_processor.sample(&logits)?;
                 if trace {
                     let t_done = Instant::now();
+                    #[allow(clippy::cast_possible_truncation)]
+                    let total_us = t_done.duration_since(t0).as_micros() as u64;
                     debug!(
                         id = %seq_id,
                         vocab,
                         top_p = ?seq.top_p,
                         temp = ?seq.temperature,
-                        total_us = t_done.duration_since(t0).as_micros() as u64,
+                        total_us,
                         "sample(cpu_logits_processor)"
                     );
                 }
@@ -219,15 +257,22 @@ pub fn sample(
 
                 if trace {
                     let t_done = Instant::now();
+                    #[allow(clippy::cast_possible_truncation)]
+                    let (prep_us, rep_us, topk_us, total_us) = (
+                        t_preprocessed.duration_since(t0).as_micros() as u64,
+                        t_penalty_applied.duration_since(t_preprocessed).as_micros() as u64,
+                        t_after_topk.duration_since(t_penalty_applied).as_micros() as u64,
+                        t_done.duration_since(t0).as_micros() as u64,
+                    );
                     debug!(
                         id = %seq_id,
                         top_k,
                         top_p = ?seq.top_p,
                         temp = ?seq.temperature,
-                        prep_us = t_after_prep.duration_since(t0).as_micros() as u64,
-                        rep_us = t_after_rep.duration_since(t_after_prep).as_micros() as u64,
-                        topk_us = t_after_topk.duration_since(t_after_rep).as_micros() as u64,
-                        total_us = t_done.duration_since(t0).as_micros() as u64,
+                        prep_us,
+                        rep_us,
+                        topk_us,
+                        total_us,
                         "sample(topk->cpu)"
                     );
                 }
@@ -285,6 +330,12 @@ pub fn sample(
 }
 
 /// Gumbel-max trick for GPU-native categorical sampling.
+///
+/// # Errors
+///
+/// Returns an error if a tensor operation fails.
+// `temperature == 1.0` is the exact "no scaling" sentinel, not a computed value.
+#[allow(clippy::float_cmp)]
 pub fn sample_gumbel_max_idx(logits: &Tensor, temperature: f64) -> candle_core::Result<Tensor> {
     if temperature <= 0.0 {
         return logits.argmax(candle_core::D::Minus1);
@@ -298,6 +349,10 @@ pub fn sample_gumbel_max_idx(logits: &Tensor, temperature: f64) -> candle_core::
 }
 
 /// Apply repetition penalty in-place (GPU-friendly scatter/gather).
+///
+/// # Errors
+///
+/// Returns an error if a tensor operation fails.
 pub fn apply_repeat_penalty_inplace(
     logits: &Tensor,
     penalty: f32,
@@ -320,17 +375,21 @@ pub fn apply_repeat_penalty_inplace(
     let idx = Tensor::new(token_ids.as_slice(), logits.device())?;
     let selected = logits.gather(&idx, candle_core::D::Minus1)?;
     let mask = selected.ge(0f64)?;
-    let on_true = (&selected / penalty as f64)?;
-    let on_false = (&selected * penalty as f64)?;
+    let on_true = (&selected / f64::from(penalty))?;
+    let on_false = (&selected * f64::from(penalty))?;
     let updated = mask.where_cond(&on_true, &on_false)?;
     logits.scatter_set(&idx, &updated, candle_core::D::Minus1)
 }
 
 /// Generate a random seed from system time.
+#[must_use]
 pub fn rand_seed() -> u64 {
     use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
+    let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
-        .as_nanos() as u64
+        .as_nanos();
+    #[allow(clippy::cast_possible_truncation)]
+    let seed = nanos as u64;
+    seed
 }

--- a/crane-serve/src/engine/scheduler.rs
+++ b/crane-serve/src/engine/scheduler.rs
@@ -37,6 +37,7 @@ pub struct Scheduler {
 }
 
 impl Scheduler {
+    #[must_use]
     pub fn new(max_running: usize) -> Self {
         Self {
             waiting: VecDeque::new(),
@@ -66,8 +67,9 @@ impl Scheduler {
     pub fn schedule(&mut self) -> Option<SchedulerOutput> {
         // Priority 1: Prefill a waiting sequence if there's capacity.
         let max = self.effective_max_running.unwrap_or(self.max_running);
-        if !self.waiting.is_empty() && self.running.len() < max {
-            let seq_id = self.waiting.pop_front().unwrap();
+        if self.running.len() < max
+            && let Some(seq_id) = self.waiting.pop_front()
+        {
             return Some(SchedulerOutput {
                 batch: vec![seq_id],
                 is_prefill: true,
@@ -85,8 +87,7 @@ impl Scheduler {
 
         // Priority 3: Nothing running but waiting has items — prefill.
         // (This happens if max is 0, which shouldn't normally happen, but just in case).
-        if !self.waiting.is_empty() {
-            let seq_id = self.waiting.pop_front().unwrap();
+        if let Some(seq_id) = self.waiting.pop_front() {
             return Some(SchedulerOutput {
                 batch: vec![seq_id],
                 is_prefill: true,
@@ -103,12 +104,14 @@ impl Scheduler {
 
     /// Total active sequences (waiting + running).
     #[allow(dead_code)]
+    #[must_use]
     pub fn active_count(&self) -> usize {
         self.waiting.len() + self.running.len()
     }
 
     /// Whether there is any work pending.
     #[allow(dead_code)]
+    #[must_use]
     pub fn has_work(&self) -> bool {
         !self.waiting.is_empty() || !self.running.is_empty()
     }

--- a/crane-serve/src/engine/sequence.rs
+++ b/crane-serve/src/engine/sequence.rs
@@ -3,6 +3,7 @@ use candle_transformers::generation::LogitsProcessor;
 use tokio::sync::mpsc;
 
 /// Compute the total GPU memory (in bytes) held by a set of KV caches.
+#[must_use]
 pub fn kv_cache_bytes(caches: &[Option<(Tensor, Tensor)>]) -> u64 {
     caches
         .iter()
@@ -62,19 +63,21 @@ pub struct Sequence {
 
 impl Sequence {
     /// Number of tokens generated so far (excluding prompt).
+    #[must_use]
     pub fn num_generated(&self) -> usize {
         self.tokens.len().saturating_sub(self.prompt_len)
     }
 
     /// Whether generation should stop.
+    #[must_use]
     pub fn should_stop(&self) -> bool {
         if self.num_generated() >= self.max_tokens {
             return true;
         }
-        if let Some(&last) = self.tokens.last() {
-            if self.eos_token_id.contains(&last) {
-                return true;
-            }
+        if let Some(&last) = self.tokens.last()
+            && self.eos_token_id.contains(&last)
+        {
+            return true;
         }
         false
     }
@@ -83,6 +86,7 @@ impl Sequence {
     /// For a fresh sequence, `start_pos = 0`.
     /// After prefill of N prompt tokens, `start_pos = N`.
     /// During decode, `start_pos = tokens.len() - 1` (everything except the latest token).
+    #[must_use]
     pub fn start_pos(&self) -> usize {
         // After prefill the kv_caches cover prompt_len tokens.
         // During decode each step adds one token, so the cache covers
@@ -95,6 +99,7 @@ impl Sequence {
     }
 
     /// Tokens to feed into the next forward step.
+    #[must_use]
     pub fn next_input_ids(&self) -> &[u32] {
         if self.status == SequenceStatus::Waiting {
             // Prefill: feed all prompt tokens.
@@ -105,12 +110,13 @@ impl Sequence {
         }
     }
 
-    /// Finish reason string for the OpenAI response.
+    /// Finish reason string for the `OpenAI` response.
+    #[must_use]
     pub fn finish_reason(&self) -> &'static str {
-        if let Some(&last) = self.tokens.last() {
-            if self.eos_token_id.contains(&last) {
-                return "stop";
-            }
+        if let Some(&last) = self.tokens.last()
+            && self.eos_token_id.contains(&last)
+        {
+            return "stop";
         }
         "length"
     }

--- a/crane-serve/src/engine/stats.rs
+++ b/crane-serve/src/engine/stats.rs
@@ -18,7 +18,14 @@ pub struct EngineStats {
     pub waiting_sequences: AtomicU64,
 }
 
+impl Default for EngineStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EngineStats {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             total_requests: AtomicU64::new(0),
@@ -40,6 +47,7 @@ impl EngineStats {
     pub fn snapshot(&self) -> StatsSnapshot {
         let total_decode = self.total_decode_steps.load(Ordering::Relaxed);
         let total_decode_us = self.total_decode_time_us.load(Ordering::Relaxed);
+        #[allow(clippy::cast_precision_loss)]
         let avg_decode_tok_s = if total_decode_us > 0 {
             (total_decode as f64) / (total_decode_us as f64 / 1_000_000.0)
         } else {
@@ -47,6 +55,7 @@ impl EngineStats {
         };
         let total_prefill_us = self.total_prefill_time_us.load(Ordering::Relaxed);
         let total_prompt = self.total_prompt_tokens.load(Ordering::Relaxed);
+        #[allow(clippy::cast_precision_loss)]
         let avg_prefill_tok_s = if total_prefill_us > 0 {
             (total_prompt as f64) / (total_prefill_us as f64 / 1_000_000.0)
         } else {
@@ -158,8 +167,12 @@ mod tests {
         s.total_decode_steps.store(50, Ordering::Relaxed);
         // time stays 0
         let snap = s.snapshot();
-        assert_eq!(snap.avg_decode_tokens_per_sec, 0.0);
-        assert_eq!(snap.avg_prefill_tokens_per_sec, 0.0);
+        // The zero-time branch returns the literal 0.0, so exact comparison is correct here.
+        #[allow(clippy::float_cmp)]
+        {
+            assert_eq!(snap.avg_decode_tokens_per_sec, 0.0);
+            assert_eq!(snap.avg_prefill_tokens_per_sec, 0.0);
+        }
     }
 
     #[test]

--- a/crane-serve/src/engine/types.rs
+++ b/crane-serve/src/engine/types.rs
@@ -20,6 +20,22 @@ pub struct EngineRequest {
     pub response_tx: mpsc::UnboundedSender<EngineResponse>,
 }
 
+/// Sampling parameters for a generation request.
+pub struct GenerationParams {
+    /// Maximum number of tokens to generate.
+    pub max_tokens: usize,
+    /// Sampling temperature; `None` disables temperature scaling.
+    pub temperature: Option<f64>,
+    /// Nucleus sampling probability mass; `None` disables top-p filtering.
+    pub top_p: Option<f64>,
+    /// Number of highest-probability tokens to keep; `None` disables top-k filtering.
+    pub top_k: Option<usize>,
+    /// Penalty applied to previously generated tokens (1.0 = no penalty).
+    pub repetition_penalty: f32,
+    /// Token IDs that terminate generation when produced.
+    pub eos_token_id: Vec<u32>,
+}
+
 /// A response chunk from the engine to an API handler.
 #[derive(Debug, Clone)]
 pub enum EngineResponse {
@@ -45,28 +61,27 @@ pub struct EngineHandle {
 
 impl EngineHandle {
     /// Submit a new generation request. Returns a receiver for response chunks.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the engine thread has shut down.
     pub fn submit(
         &self,
         id: String,
         tokens: Vec<u32>,
-        max_tokens: usize,
-        temperature: Option<f64>,
-        top_p: Option<f64>,
-        top_k: Option<usize>,
-        repetition_penalty: f32,
-        eos_token_id: Vec<u32>,
+        params: GenerationParams,
     ) -> anyhow::Result<mpsc::UnboundedReceiver<EngineResponse>> {
         let (response_tx, response_rx) = mpsc::unbounded_channel();
         self.request_tx
             .send(EngineRequest {
                 id,
                 tokens,
-                max_tokens,
-                temperature,
-                top_p,
-                top_k,
-                repetition_penalty,
-                eos_token_id,
+                max_tokens: params.max_tokens,
+                temperature: params.temperature,
+                top_p: params.top_p,
+                top_k: params.top_k,
+                repetition_penalty: params.repetition_penalty,
+                eos_token_id: params.eos_token_id,
                 response_tx,
             })
             .map_err(|_| anyhow::anyhow!("Engine thread has shut down"))?;
@@ -74,6 +89,7 @@ impl EngineHandle {
     }
 
     /// Number of active sequences (waiting + running).
+    #[must_use]
     pub fn active_count(&self) -> u64 {
         self.stats.active_sequences.load(Ordering::Relaxed)
             + self.stats.waiting_sequences.load(Ordering::Relaxed)
@@ -102,12 +118,14 @@ mod tests {
         let rx = handle.submit(
             "test-1".into(),
             vec![1, 2, 3],
-            10,
-            Some(0.8),
-            Some(0.95),
-            Some(40),
-            1.0,
-            vec![0],
+            GenerationParams {
+                max_tokens: 10,
+                temperature: Some(0.8),
+                top_p: Some(0.95),
+                top_k: Some(40),
+                repetition_penalty: 1.0,
+                eos_token_id: vec![0],
+            },
         );
         assert!(rx.is_ok());
     }
@@ -123,18 +141,17 @@ mod tests {
         let result = handle.submit(
             "test-2".into(),
             vec![1],
-            10,
-            None,
-            None,
-            None,
-            1.0,
-            vec![0],
+            GenerationParams {
+                max_tokens: 10,
+                temperature: None,
+                top_p: None,
+                top_k: None,
+                repetition_penalty: 1.0,
+                eos_token_id: vec![0],
+            },
         );
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("shut down"));
+        assert!(result.unwrap_err().to_string().contains("shut down"));
     }
 
     #[test]
@@ -198,16 +215,20 @@ mod tests {
             stats: Arc::new(EngineStats::new()),
         };
 
-        let _resp_rx = handle.submit(
-            "req-42".into(),
-            vec![10, 20, 30],
-            100,
-            Some(0.7),
-            Some(0.9),
-            None,
-            1.1,
-            vec![2],
-        ).unwrap();
+        let _resp_rx = handle
+            .submit(
+                "req-42".into(),
+                vec![10, 20, 30],
+                GenerationParams {
+                    max_tokens: 100,
+                    temperature: Some(0.7),
+                    top_p: Some(0.9),
+                    top_k: None,
+                    repetition_penalty: 1.1,
+                    eos_token_id: vec![2],
+                },
+            )
+            .unwrap();
 
         let req = rx.recv().await.unwrap();
         assert_eq!(req.id, "req-42");

--- a/crane-serve/src/handlers/openai.rs
+++ b/crane-serve/src/handlers/openai.rs
@@ -19,7 +19,7 @@ use axum::{
     },
 };
 
-use crate::engine::EngineResponse;
+use crate::engine::{EngineResponse, GenerationParams};
 use crate::openai_api::*;
 use crate::{make_error, now_epoch, AppState};
 
@@ -71,12 +71,14 @@ pub async fn chat_completions(
         .submit(
             request_id.clone(),
             input_ids,
-            req.max_tokens,
-            req.temperature.or(Some(0.8)),
-            req.top_p.or(Some(0.95)),
-            req.top_k.or(Some(40)),
-            req.repetition_penalty.unwrap_or(1.05),
-            state.eos_token_id.clone(),
+            GenerationParams {
+                max_tokens: req.max_tokens,
+                temperature: req.temperature.or(Some(0.8)),
+                top_p: req.top_p.or(Some(0.95)),
+                top_k: req.top_k.or(Some(40)),
+                repetition_penalty: req.repetition_penalty.unwrap_or(1.05),
+                eos_token_id: state.eos_token_id.clone(),
+            },
         )
         .map_err(|e| make_error(StatusCode::SERVICE_UNAVAILABLE, &e.to_string()))?;
 
@@ -146,12 +148,14 @@ pub async fn completions(
         .submit(
             request_id.clone(),
             input_ids,
-            req.max_tokens,
-            req.temperature.or(Some(0.8)),
-            req.top_p.or(Some(0.95)),
-            req.top_k.or(Some(40)),
-            req.repetition_penalty.unwrap_or(1.05),
-            state.eos_token_id.clone(),
+            GenerationParams {
+                max_tokens: req.max_tokens,
+                temperature: req.temperature.or(Some(0.8)),
+                top_p: req.top_p.or(Some(0.95)),
+                top_k: req.top_k.or(Some(40)),
+                repetition_penalty: req.repetition_penalty.unwrap_or(1.05),
+                eos_token_id: state.eos_token_id.clone(),
+            },
         )
         .map_err(|e| make_error(StatusCode::SERVICE_UNAVAILABLE, &e.to_string()))?;
 

--- a/crane-serve/src/handlers/sglang.rs
+++ b/crane-serve/src/handlers/sglang.rs
@@ -20,7 +20,7 @@ use axum::{
 };
 use serde_json::json;
 
-use crate::engine::EngineResponse;
+use crate::engine::{EngineResponse, GenerationParams};
 use crate::openai_api::ErrorResponse;
 use crate::sglang_api::*;
 use crate::{make_error, AppState};
@@ -75,12 +75,14 @@ pub async fn generate(
         .submit(
             request_id.clone(),
             input_ids,
-            sp.max_new_tokens,
-            sp.temperature.or(Some(0.8)),
-            sp.top_p.or(Some(0.95)),
-            sp.top_k.or(Some(20)),
-            sp.repetition_penalty,
-            state.eos_token_id.clone(),
+            GenerationParams {
+                max_tokens: sp.max_new_tokens,
+                temperature: sp.temperature.or(Some(0.8)),
+                top_p: sp.top_p.or(Some(0.95)),
+                top_k: sp.top_k.or(Some(20)),
+                repetition_penalty: sp.repetition_penalty,
+                eos_token_id: state.eos_token_id.clone(),
+            },
         )
         .map_err(|e| make_error(StatusCode::SERVICE_UNAVAILABLE, &e.to_string()))?;
 
@@ -191,12 +193,14 @@ pub async fn health_generate(
         .submit(
             request_id,
             probe_tokens,
-            1, // generate just 1 token
-            Some(0.0), // greedy
-            None,
-            None,
-            1.0,
-            state.eos_token_id.clone(),
+            GenerationParams {
+                max_tokens: 1, // generate just 1 token
+                temperature: Some(0.0), // greedy
+                top_p: None,
+                top_k: None,
+                repetition_penalty: 1.0,
+                eos_token_id: state.eos_token_id.clone(),
+            },
         )
         .map_err(|e| {
             make_error(


### PR DESCRIPTION
This fixes pedantic clippy warnings of the inference engine. We should actually fix all of them as they enforce modern rust and make it easier to move from one Rust Edition to the next. The CI pipeline runs clippy but allows it to fail.