### PR TITLE
crane-core: port pre-allocated KV cache to shared GqaAttention

### DIFF
--- a/crane-core/src/models/modules/attention.rs
+++ b/crane-core/src/models/modules/attention.rs
@@ -14,8 +14,11 @@
 //! These names match the safetensors checkpoint layout for Qwen3-TTS and Qwen2.5.
 
 use candle_core::{DType, Module, Result, Tensor, D};
+use candle_nn::attention::AttnMask;
 use candle_nn::VarBuilder;
 
+use super::flash_attn::dispatch_flash_attn;
+use super::kv_cache;
 use crate::models::utils::repeat_kv;
 use crate::models::with_tracing::{linear_b, Linear, RmsNorm};
 
@@ -82,6 +85,8 @@ pub struct GqaAttention {
     /// Precomputed `cfg.n_heads / cfg.n_kv_heads`.
     n_kv_groups: usize,
     kv_cache: Option<(Tensor, Tensor)>,
+    /// Number of valid (filled) positions in `kv_cache`'s pre-allocated buffer.
+    cache_seq_len: usize,
 }
 
 impl Clone for GqaAttention {
@@ -101,6 +106,7 @@ impl Clone for GqaAttention {
             cfg: self.cfg,
             n_kv_groups: self.n_kv_groups,
             kv_cache: None,
+            cache_seq_len: 0,
         }
     }
 }
@@ -169,6 +175,7 @@ impl GqaAttention {
             n_kv_groups: cfg.n_heads / cfg.n_kv_heads,
             cfg,
             kv_cache: None,
+            cache_seq_len: 0,
         })
     }
 
@@ -185,7 +192,9 @@ impl GqaAttention {
     /// * `attention_mask` — Optional additive mask broadcastable to
     ///   `[batch, n_heads, q_seq_len, kv_seq_len]`. Set blocked positions to
     ///   `f32::NEG_INFINITY` (or a sufficiently large negative value) to prevent
-    ///   attention flow.
+    ///   attention flow. During single-token decode (`q_seq_len == 1`), the
+    ///   mask's head dimension must be `1` (i.e. must not vary per head) —
+    ///   the decode fast paths broadcast one mask row across all heads.
     ///
     /// # Returns
     ///
@@ -195,7 +204,6 @@ impl GqaAttention {
     ///
     /// Returns a candle error if `cos_sin` is `None` but `rope_mode` is not
     /// `RopeMode::None`, or if any tensor operation fails.
-    #[allow(clippy::cast_precision_loss)]
     pub fn forward(
         &mut self,
         hidden_states: &Tensor,
@@ -257,21 +265,67 @@ impl GqaAttention {
             }
         };
 
-        // 5. KV cache: concat new K/V with cached K/V along the sequence dim
-        let (k, v) = match self.kv_cache.take() {
-            Some((ck, cv)) => (Tensor::cat(&[&ck, &k], 2)?, Tensor::cat(&[&cv, &v], 2)?),
-            None => (k, v),
-        };
-        self.kv_cache = Some((k.clone(), v.clone()));
+        // 5. KV cache: pre-allocated buffer with in-place `slice_set` writes
+        let (k, v) = self.update_kv_cache(&k, &v)?;
 
-        // 6. GQA: repeat KV heads to match the query head count
-        let k = repeat_kv(k, self.n_kv_groups)?.contiguous()?;
-        let v = repeat_kv(v, self.n_kv_groups)?.contiguous()?;
+        // 6. Scaled dot-product attention
+        let n_rep = self.n_kv_groups;
+        // head_dim is bounded by model config (typically 2-256), well within
+        // f64's exact integer range.
+        #[allow(clippy::cast_precision_loss)]
+        let scale = 1.0 / (self.cfg.head_dim as f64).sqrt();
+        // 1/sqrt(head_dim) is always small and positive; f64->f32 here only
+        // drops precision flash_attn's own f32 accumulator would discard anyway.
+        #[allow(clippy::cast_possible_truncation)]
+        let scale_f32 = scale as f32;
 
-        // 7. Scaled dot-product attention; softmax in F32 for numerical stability
+        if q_seq_len == 1 && b_sz == 1 && q.device().is_cpu() {
+            // ── Fused flash attention for decode (seq_len=1), CPU only ──
+            // candle's cpu_flash kernel streams K/V with online softmax
+            // (O(head_dim) working set instead of materializing an O(S)
+            // scores tensor 3 times), and handles GQA natively via integer
+            // division — no K/V repeat needed. b_sz == 1 only: candle's
+            // flash_attn hard-errors for B>1 with an explicit Mask tensor
+            // (only Causal/None are allowed).
+            return self.flash_attn_decode(&q, &k, &v, attention_mask, scale_f32, b_sz);
+        }
+
+        // No unconditional flash-attn prefill fast path here: unlike the
+        // qwen3-specific model (always a causal decoder), `GqaAttention` is
+        // documented to leave causality entirely up to the caller's
+        // `attention_mask` — `None` means full (non-causal) attention, as
+        // used by Voxtral's bidirectional `AcousticTransformer`. Guessing
+        // `AttnMask::Causal` whenever the mask is absent would silently
+        // break that contract for any single-sequence CPU caller.
+
+        if n_rep > 1 && q_seq_len == 1 {
+            // ── GQA-grouped SDPA for decode (seq_len=1), GPU fallback ──
+            // Reshape Q to group queries with their KV head instead of
+            // repeating K/V n_rep times.
+            let q_g = (q.reshape((b_sz, self.cfg.n_kv_heads, n_rep, self.cfg.head_dim))?
+                * scale)?;
+            let k_t = k.transpose(2, 3)?;
+            let attn_weights = q_g.matmul(&k_t)?;
+            let attn_weights = match attention_mask {
+                Some(mask) => attn_weights.broadcast_add(mask)?,
+                None => attn_weights,
+            };
+            let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+            let attn_output = attn_weights.matmul(&v)?;
+
+            // [B, n_kv_heads, n_rep, D] → [B, 1, H*D]; flattening (n_kv_heads,
+            // n_rep, D) matches (H, D) since H = n_kv_heads * n_rep.
+            let attn_output =
+                attn_output.reshape((b_sz, 1, self.cfg.n_heads * self.cfg.head_dim))?;
+            return self.o_proj.forward(&attn_output);
+        }
+
+        // ── Standard SDPA for prefill or when n_rep == 1 ──
+        // Softmax in F32 for numerical stability.
+        let k = repeat_kv(k, n_rep)?.contiguous()?;
+        let v = repeat_kv(v, n_rep)?.contiguous()?;
         // Q may be non-contiguous after transpose(1,2) when RoPE was not applied.
         let q = q.contiguous()?;
-        let scale = 1.0 / (self.cfg.head_dim as f64).sqrt();
         let attn_weights = (q.matmul(&k.transpose(D::Minus1, D::Minus2)?)? * scale)?;
         let attn_weights = match attention_mask {
             Some(mask) => attn_weights.broadcast_add(mask)?,
@@ -282,7 +336,7 @@ impl GqaAttention {
             .to_dtype(input_dtype)?;
         let attn_output = attn_weights.matmul(&v)?;
 
-        // 8. Reassemble heads and project back to the hidden dimension
+        // 7. Reassemble heads and project back to the hidden dimension
         let attn_output =
             attn_output
                 .transpose(1, 2)?
@@ -297,6 +351,61 @@ impl GqaAttention {
     /// contaminating the next sequence.
     pub fn clear_kv_cache(&mut self) {
         self.kv_cache = None;
+        self.cache_seq_len = 0;
+    }
+
+    /// Update the pre-allocated KV cache with new K,V tensors.
+    ///
+    /// Uses `slice_set` for O(1) in-place writes when the buffer has room.
+    /// Falls back to cat + reallocate when the buffer is full.
+    fn update_kv_cache(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        let cache = self.kv_cache.take();
+        let prev_seq_len = std::mem::replace(&mut self.cache_seq_len, 0);
+        let update = kv_cache::update_kv_cache(cache, prev_seq_len, k, v)?;
+        self.kv_cache = Some(update.buffer);
+        self.cache_seq_len = update.seq_len;
+        Ok((update.k, update.v))
+    }
+
+    /// Fused flash-attention decode path: `q_seq_len == 1`, `b_sz == 1`, CPU only.
+    ///
+    /// `q`, `k`, `v` are in `[batch, heads, seq, head_dim]` layout. See the
+    /// call site in [`Self::forward`] for why this path is gated the way it is.
+    fn flash_attn_decode(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        attention_mask: Option<&Tensor>,
+        scale_f32: f32,
+        b_sz: usize,
+    ) -> Result<Tensor> {
+        // Non-contiguous is fine — the decode kernel indexes by stride.
+        let q_bshd = q.transpose(1, 2)?;
+        let k_bshd = k.transpose(1, 2)?;
+        let v_bshd = v.transpose(1, 2)?;
+
+        let mask = match attention_mask {
+            Some(mask) => {
+                debug_assert!(
+                    mask.dim(1).is_ok_and(|d| d == 1),
+                    "CPU flash-attn decode broadcasts one mask row across all heads; \
+                     a mask with head dim != 1 would be silently misapplied"
+                );
+                // AttnMask::Mask takes ownership; Tensor is Arc-backed, so
+                // this is a refcount bump, not a data copy.
+                AttnMask::Mask(mask.clone())
+            }
+            None => AttnMask::None,
+        };
+
+        let attn_output = dispatch_flash_attn(&q_bshd, &k_bshd, &v_bshd, scale_f32, mask)?;
+
+        // flash_attn output is BHSD [B, H, 1, D] → [B, 1, H*D].
+        let attn_output = attn_output
+            .reshape((b_sz, self.cfg.n_heads, self.cfg.head_dim))?
+            .reshape((b_sz, 1, self.cfg.n_heads * self.cfg.head_dim))?;
+        self.o_proj.forward(&attn_output)
     }
 }
 
@@ -849,6 +958,70 @@ mod tests {
     }
 
     #[test]
+    fn test_kv_cache_buffer_overflow() {
+        // `update_kv_cache` pre-allocates a buffer with 256 slots of room and
+        // reallocates (cat + zeros) once that room is exhausted. Decode past
+        // that boundary and verify the output still matches a single-shot
+        // masked prefill over the same tokens — i.e. the reallocation
+        // preserves all previously cached K/V content.
+        let cfg = base_cfg();
+        let vb1 = nonzero_vb(&cfg, 0.02);
+        let vb2 = nonzero_vb(&cfg, 0.02);
+        let device = &Device::Cpu;
+
+        let mut attn_prefill = GqaAttention::new(cfg, vb1).expect("prefill attn");
+        let mut attn_incr = GqaAttention::new(cfg, vb2).expect("incremental attn");
+
+        // First prefill call allocates a buffer sized seq_len + 256; decoding
+        // 256 more one-token steps exactly exhausts that room, so the next
+        // step (the 257th) must hit the overflow/reallocation branch.
+        let prefill_len = 4usize;
+        let decode_steps = 257usize;
+        let seq_len = prefill_len + decode_steps;
+        let x = varying_input(1, seq_len, cfg.dim);
+
+        let n = seq_len;
+        let mask_data: Vec<f32> = (0..n * n)
+            .map(|i| {
+                if (i % n) > (i / n) {
+                    f32::NEG_INFINITY
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        let mask = Tensor::from_vec(mask_data, (1, 1, n, n), device).expect("causal mask");
+        let out_prefill = attn_prefill
+            .forward(&x, None, Some(&mask))
+            .expect("prefill forward");
+        let last_prefill = out_prefill.narrow(1, seq_len - 1, 1).expect("narrow prefill");
+
+        let prefill_tokens = x.narrow(1, 0, prefill_len).expect("prefill tokens");
+        let mut out_last = attn_incr
+            .forward(&prefill_tokens, None, None)
+            .expect("incremental prefill");
+        for i in 0..decode_steps {
+            let token = x.narrow(1, prefill_len + i, 1).expect("decode token");
+            out_last = attn_incr.forward(&token, None, None).expect("decode step");
+        }
+        // Unnormalized attention over 261 accumulated positions makes the
+        // output magnitude large (no LayerNorm at this layer in isolation),
+        // so compare relative rather than absolute error.
+        let mag = last_prefill
+            .abs()
+            .expect("abs")
+            .max_all()
+            .expect("max_all")
+            .to_scalar::<f32>()
+            .expect("to_scalar");
+        let rel_diff = max_abs_diff(&out_last, &last_prefill) / mag;
+        assert!(
+            rel_diff < 1e-5,
+            "decode past the KV buffer's 256-slot room must match full prefill (rel_diff={rel_diff})"
+        );
+    }
+
+    #[test]
     fn test_clear_kv_cache_resets_to_fresh_state() {
         let cfg = base_cfg();
         let vb = nonzero_vb(&cfg, 0.02);
@@ -919,6 +1092,116 @@ mod tests {
         assert!(
             max_abs_diff(&out_last, &last_prefill) < 1e-5,
             "incremental decode must match full prefill at the last token position"
+        );
+    }
+
+    #[test]
+    fn test_incremental_decode_matches_full_prefill_gqa() {
+        // Same property as `test_incremental_decode_matches_full_prefill`,
+        // but with n_kv_groups > 1 so decode steps exercise the
+        // GQA-grouped SDPA path instead of the n_rep==1 flash-attn path.
+        // b_sz=2 is required for this: the CPU flash-attn decode fast path
+        // (forward's `q_seq_len == 1 && b_sz == 1 && q.device().is_cpu()`
+        // branch) is unconditional on `n_rep`, so a b_sz=1 CPU test would
+        // take that branch instead of the GQA-grouped one being tested here.
+        let cfg = AttentionConfig {
+            dim: 16,
+            n_heads: 8,
+            n_kv_heads: 2,
+            head_dim: 2,
+            ..base_cfg()
+        };
+        let vb1 = nonzero_vb(&cfg, 0.02);
+        let vb2 = nonzero_vb(&cfg, 0.02);
+        let device = &Device::Cpu;
+
+        let mut attn_prefill = GqaAttention::new(cfg, vb1).expect("prefill attn");
+        let mut attn_incr = GqaAttention::new(cfg, vb2).expect("incremental attn");
+
+        let seq_len = 3usize;
+        let x = varying_input(2, seq_len, cfg.dim);
+
+        let n = seq_len;
+        let mask_data: Vec<f32> = (0..n * n)
+            .map(|i| {
+                if (i % n) > (i / n) {
+                    f32::NEG_INFINITY
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        let mask = Tensor::from_vec(mask_data, (1, 1, n, n), device).expect("causal mask");
+        let out_prefill = attn_prefill
+            .forward(&x, None, Some(&mask))
+            .expect("prefill forward");
+        let last_prefill = out_prefill
+            .narrow(1, seq_len - 1, 1)
+            .expect("narrow prefill");
+
+        let t0 = x.narrow(1, 0, 1).expect("t0");
+        let t1 = x.narrow(1, 1, 1).expect("t1");
+        let t2 = x.narrow(1, 2, 1).expect("t2");
+        attn_incr.forward(&t0, None, None).expect("step 0");
+        attn_incr.forward(&t1, None, None).expect("step 1");
+        let out_last = attn_incr.forward(&t2, None, None).expect("step 2");
+
+        assert!(
+            max_abs_diff(&out_last, &last_prefill) < 1e-5,
+            "GQA-grouped incremental decode must match full prefill at the last token position"
+        );
+    }
+
+    #[test]
+    fn test_flash_attn_decode_with_explicit_mask() {
+        // Verify `GqaAttention::forward`'s CPU flash-attn decode branch
+        // (`q_seq_len == 1 && b_sz == 1 && q.device().is_cpu()`) actually
+        // wires an explicit `Some(mask)` through as `AttnMask::Mask` rather
+        // than silently dropping it (e.g. by always passing `AttnMask::None`).
+        let cfg = base_cfg();
+        let vb1 = nonzero_vb(&cfg, 0.02);
+        let vb2 = nonzero_vb(&cfg, 0.02);
+        let device = &Device::Cpu;
+
+        let mut attn_no_mask = GqaAttention::new(cfg, vb1).expect("no mask attn");
+        let mut attn_masked = GqaAttention::new(cfg, vb2).expect("masked attn");
+
+        let prefill_len = 3usize;
+        let x = varying_input(1, prefill_len + 1, cfg.dim);
+        let prefill = x.narrow(1, 0, prefill_len).expect("prefill tokens");
+        let decode_tok = x.narrow(1, prefill_len, 1).expect("decode token");
+
+        attn_no_mask
+            .forward(&prefill, None, None)
+            .expect("prefill no mask");
+        attn_masked
+            .forward(&prefill, None, None)
+            .expect("prefill masked");
+
+        let y_no_mask = attn_no_mask
+            .forward(&decode_tok, None, None)
+            .expect("decode no mask");
+
+        // Non-trivial additive mask: force attention onto only the oldest
+        // KV position (mask every other position to -1e9), matching
+        // crane-serve's -1e9/0.0 padding-mask convention. `nonzero_vb`'s
+        // smoothly-increasing weights make dot products grow with position,
+        // so unmasked softmax already saturates almost entirely on the
+        // newest position — masking down to *that same* position wouldn't
+        // move the output. Forcing attention onto the oldest position
+        // instead guarantees a detectable difference.
+        let kv_len = prefill_len + 1;
+        let mut mask_data = vec![-1e9f32; kv_len];
+        mask_data[0] = 0.0;
+        let mask = Tensor::from_vec(mask_data, (1, 1, 1, kv_len), device).expect("mask");
+        let y_masked = attn_masked
+            .forward(&decode_tok, None, Some(&mask))
+            .expect("decode masked");
+
+        assert_eq!(y_no_mask.dims(), y_masked.dims());
+        assert!(
+            max_abs_diff(&y_no_mask, &y_masked) > 1e-4,
+            "explicit mask must change the CPU flash-attn decode output; diff was too small"
         );
     }
 

--- a/crane-core/src/models/modules/kv_cache.rs
+++ b/crane-core/src/models/modules/kv_cache.rs
@@ -1,0 +1,220 @@
+//! Pre-allocated KV cache buffer shared by [`super::attention::GqaAttention`]
+//! and the qwen3-specific `Attention`.
+//!
+//! Backs the cache with a buffer sized `seq_len + ROOM` positions and writes
+//! new K/V in place via `slice_set` — `O(new_seq_len)` per decode step instead
+//! of an `O(cache_len)` `Tensor::cat` on every call. Falls back to `cat` +
+//! reallocate only once the buffer's room is exhausted.
+
+use candle_core::{Result, Tensor};
+
+/// Headroom (in positions) added when (re)allocating, to amortize growth.
+const ROOM: usize = 256;
+
+/// Result of [`update_kv_cache`].
+pub(crate) struct KvCacheUpdate {
+    /// The (possibly reallocated) `(buf_k, buf_v)` buffer to store back.
+    pub buffer: (Tensor, Tensor),
+    /// Number of valid (filled) positions now in `buffer`.
+    pub seq_len: usize,
+    /// View over all cached K positions in the compute dtype.
+    pub k: Tensor,
+    /// View over all cached V positions in the compute dtype.
+    pub v: Tensor,
+}
+
+/// Append `k`/`v` to a pre-allocated KV cache buffer.
+///
+/// `kv_cache` is the caller's current `(buf_k, buf_v)` buffer (`None` on the
+/// first call) and `cache_seq_len` is the number of valid positions already
+/// written into it. Returns the (possibly reallocated) buffer to store back,
+/// the new valid length, and views over the full `k`/`v` spanning all cached
+/// positions in the compute dtype.
+///
+/// # Errors
+///
+/// Returns a candle error if any tensor operation (`contiguous`, `slice_set`,
+/// `narrow`, `cat`, `zeros`) fails.
+pub(crate) fn update_kv_cache(
+    kv_cache: Option<(Tensor, Tensor)>,
+    cache_seq_len: usize,
+    k: &Tensor,
+    v: &Tensor,
+) -> Result<KvCacheUpdate> {
+    let k = k.contiguous()?;
+    let v = v.contiguous()?;
+    let new_seq_len = k.dim(2)?;
+
+    let Some((buf_k, buf_v)) = kv_cache else {
+        // First use — allocate buffer with extra room.
+        let (batch, heads, seq, dim) = k.dims4()?;
+        let buf_k = Tensor::zeros((batch, heads, seq + ROOM, dim), k.dtype(), k.device())?;
+        let buf_v = Tensor::zeros((batch, heads, seq + ROOM, dim), v.dtype(), v.device())?;
+        buf_k.slice_set(&k, 2, 0)?;
+        buf_v.slice_set(&v, 2, 0)?;
+        return Ok(KvCacheUpdate {
+            buffer: (buf_k, buf_v),
+            seq_len: seq,
+            k,
+            v,
+        });
+    };
+
+    let buf_len = buf_k.dim(2)?;
+    let new_total = cache_seq_len + new_seq_len;
+
+    if new_total <= buf_len {
+        // In-place write — O(new_seq_len).
+        buf_k.slice_set(&k, 2, cache_seq_len)?;
+        buf_v.slice_set(&v, 2, cache_seq_len)?;
+        let k_view = buf_k.narrow(2, 0, new_total)?;
+        let v_view = buf_v.narrow(2, 0, new_total)?;
+        Ok(KvCacheUpdate {
+            buffer: (buf_k, buf_v),
+            seq_len: new_total,
+            k: k_view,
+            v: v_view,
+        })
+    } else {
+        // Buffer overflow — grow with extra room.
+        let cur_k = buf_k.narrow(2, 0, cache_seq_len)?;
+        let cur_v = buf_v.narrow(2, 0, cache_seq_len)?;
+        drop(buf_k);
+        drop(buf_v);
+        let full_k = Tensor::cat(&[&cur_k, &k], 2)?;
+        let full_v = Tensor::cat(&[&cur_v, &v], 2)?;
+        drop(cur_k);
+        drop(cur_v);
+        let total = full_k.dim(2)?;
+        let (batch, heads, _, dim) = full_k.dims4()?;
+        let new_buf_k = Tensor::zeros((batch, heads, total + ROOM, dim), k.dtype(), k.device())?;
+        let new_buf_v = Tensor::zeros((batch, heads, total + ROOM, dim), v.dtype(), v.device())?;
+        new_buf_k.slice_set(&full_k, 2, 0)?;
+        new_buf_v.slice_set(&full_v, 2, 0)?;
+        Ok(KvCacheUpdate {
+            buffer: (new_buf_k, new_buf_v),
+            seq_len: total,
+            k: full_k,
+            v: full_v,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::Device;
+
+    use super::*;
+
+    /// Builds a tensor whose values are `offset + [0, 1, 2, ...]` — pass a
+    /// distinct `offset` per call so tests can tell which call's data landed
+    /// where, instead of every same-shape call producing identical content.
+    fn bhsd(batch: usize, heads: usize, seq: usize, dim: usize, offset: f32) -> Tensor {
+        let data: Vec<f32> = (0..batch * heads * seq * dim)
+            .map(|i| i as f32 + offset)
+            .collect();
+        Tensor::from_vec(data, (batch, heads, seq, dim), &Device::Cpu).expect("bhsd tensor")
+    }
+
+    #[test]
+    fn first_call_allocates_buffer_with_room() {
+        let (batch, heads, seq, dim) = (1, 2, 3, 4);
+        let k = bhsd(batch, heads, seq, dim, 0.0);
+        let v = bhsd(batch, heads, seq, dim, 0.0);
+
+        let update = update_kv_cache(None, 0, &k, &v).expect("first call");
+
+        assert_eq!(update.seq_len, seq);
+        assert_eq!(update.buffer.0.dims(), &[batch, heads, seq + ROOM, dim]);
+        assert_eq!(update.buffer.1.dims(), &[batch, heads, seq + ROOM, dim]);
+        assert_eq!(update.k.dims(), k.dims());
+        assert_eq!(update.v.dims(), v.dims());
+    }
+
+    #[test]
+    fn in_place_write_appends_within_room() {
+        let (batch, heads, dim) = (1, 2, 4);
+        let prefill = bhsd(batch, heads, 3, dim, 0.0);
+        let prefill_update =
+            update_kv_cache(None, 0, &prefill, &prefill).expect("prefill");
+
+        let step = bhsd(batch, heads, 1, dim, 1000.0);
+        let step_update = update_kv_cache(
+            Some(prefill_update.buffer),
+            prefill_update.seq_len,
+            &step,
+            &step,
+        )
+        .expect("decode step");
+
+        assert_eq!(step_update.seq_len, prefill_update.seq_len + 1);
+        // Same buffer identity (no reallocation): dims unchanged.
+        assert_eq!(step_update.buffer.0.dims(), &[batch, heads, 3 + ROOM, dim]);
+        assert_eq!(
+            step_update.k.dims(),
+            &[batch, heads, step_update.seq_len, dim]
+        );
+        // The appended step must be readable back from the cache view.
+        let appended = step_update
+            .k
+            .narrow(2, prefill_update.seq_len, 1)
+            .expect("narrow appended");
+        let diff = (&appended - &step)
+            .expect("sub")
+            .abs()
+            .expect("abs")
+            .max_all()
+            .expect("max_all")
+            .to_scalar::<f32>()
+            .expect("scalar");
+        assert!(diff < 1e-6, "appended slot must equal the written step");
+    }
+
+    #[test]
+    fn overflow_reallocates_and_preserves_content() {
+        let (batch, heads, dim) = (1, 1, 2);
+        let prefill = bhsd(batch, heads, 1, dim, 0.0);
+        let mut update = update_kv_cache(None, 0, &prefill, &prefill).expect("prefill");
+
+        // Exhaust the buffer's room (allocated as 1 + ROOM), then push one more
+        // to force the overflow/reallocation branch. Each step gets a distinct
+        // offset so the final assertion can tell them apart.
+        for i in 0..ROOM {
+            let offset = (i as f32 + 1.0) * 1000.0;
+            let step = bhsd(batch, heads, 1, dim, offset);
+            update = update_kv_cache(Some(update.buffer), update.seq_len, &step, &step)
+                .expect("fill room");
+        }
+        assert_eq!(update.seq_len, 1 + ROOM);
+
+        let overflow_step = bhsd(batch, heads, 1, dim, (ROOM as f32 + 1.0) * 1000.0);
+        let final_update = update_kv_cache(
+            Some(update.buffer),
+            update.seq_len,
+            &overflow_step,
+            &overflow_step,
+        )
+        .expect("overflow step");
+
+        assert_eq!(final_update.seq_len, update.seq_len + 1);
+        assert_eq!(
+            final_update.buffer.0.dims(),
+            &[batch, heads, final_update.seq_len + ROOM, dim]
+        );
+        assert_eq!(
+            final_update.k.dims(),
+            &[batch, heads, final_update.seq_len, dim]
+        );
+        // The original prefill value must survive the reallocation, at position 0.
+        let first = final_update.k.narrow(2, 0, 1).expect("narrow first");
+        let diff = (&first - &prefill)
+            .expect("sub")
+            .abs()
+            .expect("abs")
+            .max_all()
+            .expect("max_all")
+            .to_scalar::<f32>()
+            .expect("scalar");
+        assert!(diff < 1e-6, "prefill content must survive reallocation");
+    }
+}

--- a/crane-core/src/models/modules/mod.rs
+++ b/crane-core/src/models/modules/mod.rs
@@ -2,6 +2,7 @@
 pub mod attention;
 pub mod ffn;
 pub mod flash_attn;
+pub(crate) mod kv_cache;
 pub mod mel;
 pub mod rotary;
 pub mod siglip2;

--- a/crane-core/src/models/qwen3/modeling.rs
+++ b/crane-core/src/models/qwen3/modeling.rs
@@ -45,6 +45,7 @@ use serde::Deserialize;
 use std::io::{Read, Seek};
 
 use crate::models::modules::flash_attn::dispatch_flash_attn;
+use crate::models::modules::kv_cache;
 use crate::models::modules::rotary::RotaryEmbedding;
 
 // Reuse the polymorphic linear layer and GGUF loader from the shared Hunyuan module.
@@ -276,63 +277,13 @@ impl Attention {
     ///
     /// Uses `slice_set` for O(1) in-place writes when the buffer has room.
     /// Falls back to cat + reallocate when the buffer is full.
-    fn update_kv_cache(&mut self, k: Tensor, v: Tensor) -> Result<(Tensor, Tensor)> {
-        let k = k.contiguous()?;
-        let v = v.contiguous()?;
-        let new_seq_len = k.dim(2)?;
-        let cache_seq_len = self.cache_seq_len;
-
-        match self.kv_cache.take() {
-            Some((buf_k, buf_v)) => {
-                let buf_len = buf_k.dim(2)?;
-                let new_total = cache_seq_len + new_seq_len;
-
-                if new_total <= buf_len {
-                    // In-place write — O(new_seq_len).
-                    buf_k.slice_set(&k, 2, cache_seq_len)?;
-                    buf_v.slice_set(&v, 2, cache_seq_len)?;
-                    let k_view = buf_k.narrow(2, 0, new_total)?;
-                    let v_view = buf_v.narrow(2, 0, new_total)?;
-                    self.kv_cache = Some((buf_k, buf_v));
-                    self.cache_seq_len = new_total;
-                    Ok((k_view, v_view))
-                } else {
-                    // Buffer overflow — grow with extra room.
-                    let cur_k = buf_k.narrow(2, 0, cache_seq_len)?;
-                    let cur_v = buf_v.narrow(2, 0, cache_seq_len)?;
-                    drop(buf_k);
-                    drop(buf_v);
-                    let full_k = Tensor::cat(&[&cur_k, &k], 2)?;
-                    let full_v = Tensor::cat(&[&cur_v, &v], 2)?;
-                    drop(cur_k);
-                    drop(cur_v);
-                    let total = full_k.dim(2)?;
-                    let room = 256; // fixed small room — avoids 2x over-allocation
-                    let (b, h, _, d) = full_k.dims4()?;
-                    let new_buf_k =
-                        Tensor::zeros((b, h, total + room, d), k.dtype(), k.device())?;
-                    let new_buf_v =
-                        Tensor::zeros((b, h, total + room, d), v.dtype(), v.device())?;
-                    new_buf_k.slice_set(&full_k, 2, 0)?;
-                    new_buf_v.slice_set(&full_v, 2, 0)?;
-                    self.kv_cache = Some((new_buf_k, new_buf_v));
-                    self.cache_seq_len = total;
-                    Ok((full_k, full_v))
-                }
-            }
-            None => {
-                // First use — allocate buffer with extra room.
-                let (b, h, s, d) = k.dims4()?;
-                let room = 256; // fixed small room — avoids 2x over-allocation
-                let buf_k = Tensor::zeros((b, h, s + room, d), k.dtype(), k.device())?;
-                let buf_v = Tensor::zeros((b, h, s + room, d), v.dtype(), v.device())?;
-                buf_k.slice_set(&k, 2, 0)?;
-                buf_v.slice_set(&v, 2, 0)?;
-                self.kv_cache = Some((buf_k, buf_v));
-                self.cache_seq_len = s;
-                Ok((k, v))
-            }
-        }
+    fn update_kv_cache(&mut self, k: &Tensor, v: &Tensor) -> Result<(Tensor, Tensor)> {
+        let cache = self.kv_cache.take();
+        let prev_seq_len = std::mem::replace(&mut self.cache_seq_len, 0);
+        let update = kv_cache::update_kv_cache(cache, prev_seq_len, k, v)?;
+        self.kv_cache = Some(update.buffer);
+        self.cache_seq_len = update.seq_len;
+        Ok((update.k, update.v))
     }
 
     fn forward(
@@ -394,7 +345,7 @@ impl Attention {
         let k = k.transpose(1, 2)?;
 
         // Update KV cache (pre-allocated with slice_set)
-        let (k, v) = self.update_kv_cache(k, v)?;
+        let (k, v) = self.update_kv_cache(&k, &v)?;
 
         // ── SDPA ──
         let n_rep = self.num_heads / self.num_kv_heads;


### PR DESCRIPTION
GqaAttention (used by Qwen2.5, Qwen3-TTS, Voxtral TTS) grew its KV cache via Tensor::cat (O(cache_len) copy per decode step) and always ran 3-pass SDPA. Port the qwen3-specific Attention's optimizations: a pre-allocated slice_set KV cache buffer, a CPU/single-sequence flash_attn decode path (dispatch_flash_attn now shared between the two modules), and a GQA-grouped SDPA decode path that reshapes Q instead of expanding K/V.