### PR TITLE
crane: let Asr implementations report supported languages

### DIFF
--- a/crane/src/audio/asr.rs
+++ b/crane/src/audio/asr.rs
@@ -78,6 +78,15 @@ pub trait Asr {
         let t = self.transcribe(audio, opts)?;
         Ok(AsrStream::once(t))
     }
+
+    /// BCP-47 language codes this model claims to support (service discovery
+    /// only — not used to reject a `TranscribeOptions::language` request).
+    ///
+    /// Implementations typically allocate on every call; callers that need
+    /// the list more than once should cache the result.
+    fn supported_languages(&self) -> Vec<String> {
+        Vec::new()
+    }
 }
 
 #[cfg(test)]
@@ -226,5 +235,11 @@ mod tests {
     fn test_input_sample_rate() {
         let model = MockAsr;
         assert_eq!(model.input_sample_rate(), 16000);
+    }
+
+    #[test]
+    fn test_default_supported_languages_is_empty() {
+        let model = MockAsr;
+        assert!(model.supported_languages().is_empty());
     }
 }

--- a/crane/src/audio/asr_qwen3.rs
+++ b/crane/src/audio/asr_qwen3.rs
@@ -3,7 +3,14 @@
 use anyhow::Result;
 use crane_core::models::qwen3_asr::Model;
 
-use super::asr::{Asr, Transcript, TranscribeOptions};
+use super::asr::{Asr, TranscribeOptions, Transcript};
+
+/// BCP-47 language codes Qwen3-ASR claims to support, per its model card.
+/// Sorted alphabetically.
+const LANGUAGES: &[&str] = &[
+    "ar", "cs", "da", "de", "el", "en", "es", "fa", "fi", "fil", "fr", "hi", "hu", "id", "it",
+    "ja", "ko", "mk", "ms", "nl", "pl", "pt", "ro", "ru", "sv", "th", "tr", "vi", "yue", "zh",
+];
 
 impl Asr for Model {
     fn input_sample_rate(&self) -> u32 {
@@ -20,5 +27,29 @@ impl Asr for Model {
             language: None,
             is_final: true,
         })
+    }
+
+    fn supported_languages(&self) -> Vec<String> {
+        LANGUAGES.iter().map(ToString::to_string).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LANGUAGES;
+
+    #[test]
+    fn supported_languages_is_sorted_and_nonempty() {
+        assert!(!LANGUAGES.is_empty());
+        let mut sorted = LANGUAGES.to_vec();
+        sorted.sort_unstable();
+        assert_eq!(LANGUAGES, sorted.as_slice());
+    }
+
+    #[test]
+    fn supported_languages_contains_expected_codes() {
+        for code in ["en", "zh", "de"] {
+            assert!(LANGUAGES.contains(&code), "missing language code {code}");
+        }
     }
 }


### PR DESCRIPTION
Wyoming/Home Assistant-style service discovery needs a per-model language capability list before it can populate a language picker or route requests by language, mirroring what TTS voices already expose. Default is empty so existing Asr implementers keep compiling unchanged; Qwen3-ASR overrides it with the language list from its model card.