### PR TITLE
crane-core: fix flaky qwen3_asr generation_loop_runs test

### DIFF
--- a/crane-core/src/models/qwen3_asr/model.rs
+++ b/crane-core/src/models/qwen3_asr/model.rs
@@ -286,7 +286,12 @@ mod tests {
             audio_token_id: TEST_AUDIO_TOKEN_ID,
             timestamp_token_id: 21,
             pad_token_id: 0,
-            eos_token_id: vec![1, 2],
+            // Left unreachable: `generation_loop_runs` samples from randomly
+            // initialized weights (unseeded on the CPU backend), so a
+            // reachable id here would make the loop's early-exit
+            // non-deterministic and occasionally sample it on the very
+            // first token, leaving `generated` empty.
+            eos_token_id: vec![],
             tie_word_embeddings: true,
         }
     }


### PR DESCRIPTION
The test's tiny_asr_config used eos_token_id: vec![1, 2] with a 32-token vocab and randomly initialized, unseeded weights. If the very first sampled token during the decode loop happened to be 1 or 2, the loop broke before pushing anything to generated, failing 'assertion failed: !generated.is_empty()'.

Set eos_token_id to an empty vec so the EOS check can never trigger.