### PR TITLE
crane: standardize TTS language on ISO 639-1 at the Tts trait boundary

### DIFF
--- a/crane-serve/src/openai_api.rs
+++ b/crane-serve/src/openai_api.rs
@@ -332,7 +332,7 @@ pub struct SpeechRequest {
     /// Voice name (speaker ID or preset for CustomVoice models).
     #[serde(default)]
     pub voice: Option<String>,
-    /// Language hint (e.g. "chinese", "english", "japanese", "auto").
+    /// Language hint as an ISO 639-1 code (e.g. "zh", "en", "ja") or "auto".
     #[serde(default)]
     pub language: Option<String>,
     /// Optional system-level instructions.

--- a/crane/src/audio/tts.rs
+++ b/crane/src/audio/tts.rs
@@ -20,8 +20,8 @@ pub struct VoiceInfo {
     pub name: String,
     /// Language identifiers this voice supports (e.g. `["en", "zh"]`).
     ///
-    /// Values are typically BCP-47 codes for Wyoming service discovery but
-    /// may be any string the model recognizes. Empty means the voice works
+    /// Values are ISO 639-1 codes, matching the `language` parameter
+    /// accepted by [`Tts::generate_speech`]. Empty means the voice works
     /// with any language the model supports.
     pub languages: Vec<String>,
 }
@@ -101,7 +101,7 @@ pub trait Tts {
     /// # Parameters
     ///
     /// * `text` — The text to synthesize.
-    /// * `language` — Target language (e.g. "english", "auto").
+    /// * `language` — Target language as an ISO 639-1 code (e.g. "en", "de") or "auto".
     /// * `voice` — Voice name from [`voices`](Tts::voices), or `None` for the model default.
     /// * `opts` — Generation parameters (temperature, max tokens, etc.).
     ///
@@ -121,7 +121,7 @@ pub trait Tts {
     /// # Parameters
     ///
     /// * `text` — The text to synthesize.
-    /// * `language` — Target language.
+    /// * `language` — Target language as an ISO 639-1 code (e.g. "en", "de") or "auto".
     /// * `ref_audio` — Path to a reference WAV file of the target speaker.
     /// * `ref_text` — Transcript of the reference audio (required by some models).
     /// * `opts` — Generation parameters.

--- a/crane/src/audio/tts_qwen3.rs
+++ b/crane/src/audio/tts_qwen3.rs
@@ -29,6 +29,28 @@ fn language_name_to_code(name: &str) -> &str {
     }
 }
 
+/// Maps an ISO 639-1 language code to the full English name that
+/// `codec_language_id` uses as its key.
+///
+/// Codes not in the mapping — including "auto" and already-full names such
+/// as "english" — pass through unchanged, so both formats work.
+fn language_code_to_name(code: &str) -> String {
+    match code {
+        "zh" => "chinese",
+        "en" => "english",
+        "de" => "german",
+        "it" => "italian",
+        "pt" => "portuguese",
+        "es" => "spanish",
+        "ja" => "japanese",
+        "ko" => "korean",
+        "fr" => "french",
+        "ru" => "russian",
+        other => other,
+    }
+    .to_string()
+}
+
 /// Derives the sorted list of ISO 639-1 language codes a custom-voice talker
 /// supports.
 ///
@@ -86,7 +108,8 @@ impl Tts for Model {
         voice: Option<&str>,
         opts: &SpeechOptions,
     ) -> Result<Tensor> {
-        let (tensor, _sample_rate) = Model::generate_speech(self, text, language, voice, opts)?;
+        let lang = language_code_to_name(language);
+        let (tensor, _sample_rate) = Model::generate_speech(self, text, &lang, voice, opts)?;
         Ok(tensor)
     }
 
@@ -102,8 +125,9 @@ impl Tts for Model {
     ) -> Result<Tensor> {
         let spk_sr = self.speaker_encoder_sample_rate();
         let ref_samples = load_wav_f32(ref_audio, spk_sr)?;
+        let lang = language_code_to_name(language);
         let (tensor, _sample_rate) =
-            Model::generate_voice_clone(self, text, language, &ref_samples, ref_text, opts)?;
+            Model::generate_voice_clone(self, text, &lang, &ref_samples, ref_text, opts)?;
         Ok(tensor)
     }
 
@@ -115,15 +139,42 @@ impl Tts for Model {
         opts: &SpeechOptions,
     ) -> Result<TtsStream<'_>> {
         let audio_info = self.audio_info();
-        let stream = self.generate_speech_streaming(text, language, voice, opts)?;
+        let lang = language_code_to_name(language);
+        let stream = self.generate_speech_streaming(text, &lang, voice, opts)?;
         Ok(TtsStream::new(audio_info, stream))
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::language_code_to_name;
     use super::talker_languages;
     use super::TalkerConfig;
+
+    #[test]
+    fn language_code_to_name_known_codes() {
+        assert_eq!(language_code_to_name("zh"), "chinese");
+        assert_eq!(language_code_to_name("en"), "english");
+        assert_eq!(language_code_to_name("de"), "german");
+        assert_eq!(language_code_to_name("ja"), "japanese");
+        assert_eq!(language_code_to_name("ko"), "korean");
+        assert_eq!(language_code_to_name("fr"), "french");
+        assert_eq!(language_code_to_name("ru"), "russian");
+        assert_eq!(language_code_to_name("it"), "italian");
+        assert_eq!(language_code_to_name("pt"), "portuguese");
+        assert_eq!(language_code_to_name("es"), "spanish");
+    }
+
+    #[test]
+    fn language_code_to_name_passthrough() {
+        // Full names pass through unchanged (backwards compatibility).
+        assert_eq!(language_code_to_name("english"), "english");
+        assert_eq!(language_code_to_name("chinese"), "chinese");
+        // "auto" passes through.
+        assert_eq!(language_code_to_name("auto"), "auto");
+        // Unknown codes pass through.
+        assert_eq!(language_code_to_name("xx"), "xx");
+    }
 
     fn talker_config(codec_language_id: &str, spk_is_dialect: &str) -> TalkerConfig {
         let json = format!(


### PR DESCRIPTION
Qwen3-TTS's codec_language_id table is keyed by full English names ("german"), while crane-serve's API uses ISO 639-1 codes ("de") externally.

Move the ISO-code-to-name conversion into the Qwen3 Tts impl itself, so the Tts trait boundary (and everything above it) can consistently speak ISO 639-1 or "auto".