### PR TITLE
Extend and modularize ONNX evaluator ops

### DIFF
--- a/crane-core/src/onnx.rs
+++ b/crane-core/src/onnx.rs
@@ -300,6 +300,7 @@ const CANDLE_SIMPLE_EVAL_OPS: &[&str] = &[
     "Min",
     "Mul",
     "Neg",
+    "NonZero",
     "Not",
     "OneHot",
     "Or",

--- a/crane-core/src/onnx.rs
+++ b/crane-core/src/onnx.rs
@@ -317,6 +317,7 @@ const CANDLE_SIMPLE_EVAL_OPS: &[&str] = &[
     "Relu",
     "Reshape",
     "Resize",
+    "STFT",
     "ScatterND",
     "Selu",
     "Shape",

--- a/crane-core/src/onnx.rs
+++ b/crane-core/src/onnx.rs
@@ -256,6 +256,7 @@ const CANDLE_SIMPLE_EVAL_OPS: &[&str] = &[
     "And",
     "ArgMax",
     "ArgMin",
+    "Atan",
     "AveragePool",
     "BatchNormalization",
     "Cast",

--- a/crane-core/src/onnx.rs
+++ b/crane-core/src/onnx.rs
@@ -257,6 +257,7 @@ const CANDLE_SIMPLE_EVAL_OPS: &[&str] = &[
     "ArgMax",
     "ArgMin",
     "Atan",
+    "Atan2",
     "AveragePool",
     "BatchNormalization",
     "Cast",

--- a/crane-core/src/onnx/eval.rs
+++ b/crane-core/src/onnx/eval.rs
@@ -826,6 +826,15 @@ fn simple_eval_(
                 let output = xs.sqrt()?;
                 values.insert(node.output[0].clone(), output);
             },
+            // Crane Added 20260731: implementation lives in ops/stft.rs.
+            "STFT" => {
+                let signal = get(&node.input[0])?;
+                let frame_step = get(&node.input[1])?;
+                let window = get_opt(2).transpose()?;
+                let frame_length = get_opt(3).transpose()?;
+                let output = ops::stft::stft(node, signal, frame_step, window, frame_length)?;
+                values.insert(node.output[0].clone(), output);
+            },
             // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Range
             "Range" => {
                 let start = get(&node.input[0])?;

--- a/crane-core/src/onnx/eval.rs
+++ b/crane-core/src/onnx/eval.rs
@@ -1105,6 +1105,12 @@ fn simple_eval_(
                 let output = input.abs()?;
                 values.insert(node.output[0].clone(), output);
             },
+            // Crane Added 20260731: implementation lives in ops/atan.rs.
+            "Atan" => {
+                let input = get(&node.input[0])?;
+                let output = ops::atan::atan(input)?;
+                values.insert(node.output[0].clone(), output);
+            },
             "Cos" => {
                 let input = get(&node.input[0])?;
                 let output = input.cos()?;

--- a/crane-core/src/onnx/eval.rs
+++ b/crane-core/src/onnx/eval.rs
@@ -1111,6 +1111,18 @@ fn simple_eval_(
                 let output = ops::atan::atan(input)?;
                 values.insert(node.output[0].clone(), output);
             },
+            // Crane Added 20260731: fused atan2(y, x) — produced by the
+            // optimizer's atan2-decomposition fusion pass, not present in
+            // the original ONNX model.
+            "Atan2" => {
+                let y = get(&node.input[0])?;
+                let x = get(&node.input[1])?;
+                let shape = broadcast_shape(y.dims(), x.dims())?;
+                let y = y.broadcast_as(shape.clone())?;
+                let x = x.broadcast_as(shape)?;
+                let output = ops::atan::atan2(&y, &x)?;
+                values.insert(node.output[0].clone(), output);
+            },
             "Cos" => {
                 let input = get(&node.input[0])?;
                 let output = input.cos()?;

--- a/crane-core/src/onnx/eval.rs
+++ b/crane-core/src/onnx/eval.rs
@@ -1176,6 +1176,12 @@ fn simple_eval_(
                 let output = input.floor()?;
                 values.insert(node.output[0].clone(), output);
             },
+            // https://onnx.ai/onnx/operators/onnx__Round.html
+            "Round" => {
+                let input = get(&node.input[0])?;
+                let output = input.round()?;
+                values.insert(node.output[0].clone(), output);
+            },
             // https://github.com/onnx/onnx/blob/main/docs/Operators.md#Constant
             "Constant" => {
                 let value = match node.attribute.iter().find(|attr| attr.name == "value") {
@@ -2764,5 +2770,50 @@ fn to_vec0_flexible<T: candle::WithDType>(t: &Tensor) -> Result<T> {
         t.flatten_all()?.i(0)?.to_vec0::<T>()
     } else {
         t.to_vec0::<T>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{Device, Result};
+
+    use super::{Value, simple_eval};
+    use crate::onnx::proto::{GraphProto, ModelProto, NodeProto, ValueInfoProto};
+
+    #[test]
+    fn round_rounds_half_away_from_zero() -> Result<()> {
+        // ONNX Round: nearest integer per element; candle's round() (and
+        // this evaluator) breaks exact .5 ties away from zero rather than
+        // to even, matching the tie-breaking already used elsewhere in
+        // Crane's ONNX graph rewrites.
+        let model = ModelProto {
+            graph: Some(GraphProto {
+                input: vec![ValueInfoProto {
+                    name: "x".to_string(),
+                    ..Default::default()
+                }],
+                node: vec![NodeProto {
+                    op_type: "Round".to_string(),
+                    input: vec!["x".to_string()],
+                    output: vec!["y".to_string()],
+                    ..Default::default()
+                }],
+                output: vec![ValueInfoProto {
+                    name: "y".to_string(),
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let x = Value::new(&[0.5f32, 2.5, -0.5, -2.5, 1.4, 1.6], &Device::Cpu)?;
+        let outputs = simple_eval(&model, [("x".to_string(), x)].into())?;
+
+        assert_eq!(
+            outputs["y"].to_vec1::<f32>()?,
+            vec![1.0, 3.0, -1.0, -3.0, 1.0, 2.0]
+        );
+        Ok(())
     }
 }

--- a/crane-core/src/onnx/eval.rs
+++ b/crane-core/src/onnx/eval.rs
@@ -454,6 +454,12 @@ fn simple_eval_(
                 let xs = xs.eq(&xs.zeros_like()?)?;
                 values.insert(node.output[0].clone(), xs);
             },
+            // Crane Added 20260731: implementation lives in ops/nonzero.rs.
+            "NonZero" => {
+                let input = get(&node.input[0])?;
+                let output = ops::nonzero::nonzero(node, input)?;
+                values.insert(node.output[0].clone(), output);
+            },
             "MatMul" => {
                 let input0 = get(&node.input[0])?;
                 let input1 = get(&node.input[1])?;

--- a/crane-core/src/onnx/eval.rs
+++ b/crane-core/src/onnx/eval.rs
@@ -620,6 +620,14 @@ fn simple_eval_(
                 let xs = xs.broadcast_mul(&weight)?.broadcast_add(&bias)?;
                 values.insert(node.output[0].clone(), xs);
             },
+            // Crane Added 20260731: implementation lives in ops/layer_norm.rs.
+            "LayerNormalization" => {
+                let x = get(&node.input[0])?;
+                let scale = get(&node.input[1])?;
+                let bias = get_opt(2).transpose()?;
+                let output = ops::layer_norm::layer_norm(node, x, scale, bias)?;
+                values.insert(node.output[0].clone(), output);
+            },
             "Squeeze" => {
                 let xs = get(&node.input[0])?;
                 let axes = get_opt(1).transpose()?;

--- a/crane-core/src/onnx/eval.rs
+++ b/crane-core/src/onnx/eval.rs
@@ -418,6 +418,13 @@ fn simple_eval_(
                 let output = input0.broadcast_div(input1)?;
                 values.insert(node.output[0].clone(), output);
             },
+            // Crane Added 20260731: implementation lives in ops/modulo.rs.
+            "Mod" => {
+                let input0 = get(&node.input[0])?;
+                let input1 = get(&node.input[1])?;
+                let output = ops::modulo::modulo(node, input0, input1)?;
+                values.insert(node.output[0].clone(), output);
+            },
             "Pow" => {
                 let input0 = get(&node.input[0])?;
                 let input1 = get(&node.input[1])?;

--- a/crane-core/src/onnx/ops/atan.rs
+++ b/crane-core/src/onnx/ops/atan.rs
@@ -1,18 +1,20 @@
 // SPDX-License-Identifier: MIT
-//! Crane Added 20260731: ONNX `Atan` as a native eval op.
+//! Crane Added 20260731: ONNX `Atan` and `Atan2` as native eval ops.
 //!
-//! `candle_core` has no native `.atan()` tensor method (its `UnaryOp` enum
-//! covers `Exp`/`Log`/`Sin`/`Cos`/… but not `atan`), so this is implemented
-//! via `CustomOp1` operating directly on tensor storage. Upstream candle has
-//! an open PR adding `atan`/`atan2`
-//! (<https://github.com/huggingface/candle/pull/3338>); once that ships in a
-//! released version this crate upgrades to, this file can be replaced with a
-//! direct tensor method call.
+//! `candle_core` has no native `.atan()` or `.atan2()` tensor methods (its
+//! `UnaryOp` enum covers `Exp`/`Log`/`Sin`/`Cos`/… but not `atan`), so these
+//! are implemented via `CustomOp1`/`CustomOp2` operating directly on tensor
+//! storage. Both ops are CPU-only: only `cpu_fwd` is implemented, so
+//! evaluating them on a CUDA or Metal tensor returns a runtime error rather
+//! than running on-device. Upstream candle has an open PR adding
+//! `atan`/`atan2` (<https://github.com/huggingface/candle/pull/3338>); once
+//! that ships in a released version this crate upgrades to, this file can be
+//! replaced with direct tensor method calls.
 
-use candle_core::{CpuStorage, CustomOp1, Layout, Result, Shape, Tensor, WithDType};
+use candle_core::{CpuStorage, CustomOp1, CustomOp2, Layout, Result, Shape, Tensor, WithDType};
 
 /// Element-wise `atan`. Spec-correct: NaN inputs produce NaN outputs (the
-/// ONNX spec does not define NaN-clamping behavior for `Atan`).
+/// ONNX spec does not define NaN-clamping behavior for `Atan`). CPU-only.
 struct AtanOp;
 
 impl CustomOp1 for AtanOp {
@@ -43,11 +45,60 @@ pub(crate) fn atan(input: &Tensor) -> Result<Tensor> {
     input.apply_op1_no_bwd(&AtanOp)
 }
 
+/// Element-wise `atan2(y, x)`. IEEE 754 compliant: `atan2(0, 0) = 0`,
+/// handling the zero-magnitude case without a special branch. CPU-only.
+struct Atan2Op;
+
+impl CustomOp2 for Atan2Op {
+    fn name(&self) -> &'static str {
+        "atan2"
+    }
+
+    fn cpu_fwd(
+        &self,
+        s_y: &CpuStorage,
+        l_y: &Layout,
+        s_x: &CpuStorage,
+        l_x: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        fn inner<T: WithDType>(
+            y: &[T],
+            l_y: &Layout,
+            x: &[T],
+            l_x: &Layout,
+        ) -> (CpuStorage, Shape) {
+            let dst = candle_core::cpu_backend::binary_map(l_y, l_x, y, x, |a, b| {
+                T::from_f64(a.to_f64().atan2(b.to_f64()))
+            });
+            (T::to_cpu_storage_owned(dst), l_y.shape().clone())
+        }
+
+        match (s_y, s_x) {
+            (CpuStorage::BF16(y), CpuStorage::BF16(x)) => Ok(inner(y, l_y, x, l_x)),
+            (CpuStorage::F16(y), CpuStorage::F16(x)) => Ok(inner(y, l_y, x, l_x)),
+            (CpuStorage::F32(y), CpuStorage::F32(x)) => Ok(inner(y, l_y, x, l_x)),
+            (CpuStorage::F64(y), CpuStorage::F64(x)) => Ok(inner(y, l_y, x, l_x)),
+            _ => candle_core::bail!("unsupported or mismatched dtypes for Atan2"),
+        }
+    }
+}
+
+/// Fused `Atan2`: element-wise `atan2(y, x)`.
+///
+/// Computes the two-argument arctangent directly rather than through the
+/// decomposed `Div(y,x) → Atan → quadrant-correction Where` chain that ONNX
+/// exporters emit for opsets without a native `Atan2` op. This avoids the
+/// numerical instability that decomposition introduces near the origin (where
+/// `Div(0,0) = NaN` and the quadrant-decision `Less(x, 0)` is noise-sensitive).
+pub(crate) fn atan2(y: &Tensor, x: &Tensor) -> Result<Tensor> {
+    y.apply_op2_no_bwd(x, &Atan2Op)
+}
+
 #[cfg(test)]
 mod tests {
     use candle_core::{Device, Result, Tensor};
 
-    use super::atan;
+    use super::{atan, atan2};
 
     // Verifies that atan matches the standard library f32::atan for a range
     // of representative inputs.
@@ -124,6 +175,60 @@ mod tests {
         let half_pi = std::f32::consts::FRAC_PI_2;
         assert!((got[0] - half_pi).abs() < 1e-7);
         assert!((got[1] + half_pi).abs() < 1e-7);
+        Ok(())
+    }
+
+    // Verifies all four quadrants of atan2.
+    #[test]
+    fn atan2_all_quadrants() -> Result<()> {
+        let y_vals = Tensor::new(&[1.0f32, 1.0, -1.0, -1.0], &Device::Cpu)?;
+        let x_vals = Tensor::new(&[1.0f32, -1.0, -1.0, 1.0], &Device::Cpu)?;
+
+        let result = atan2(&y_vals, &x_vals)?;
+
+        let got = result.to_vec1::<f32>()?;
+        let expected: Vec<f32> = vec![
+            1.0f32.atan2(1.0),
+            1.0f32.atan2(-1.0),
+            (-1.0f32).atan2(-1.0),
+            (-1.0f32).atan2(1.0),
+        ];
+        for (g, e) in got.iter().zip(expected.iter()) {
+            assert!((g - e).abs() < f32::EPSILON);
+        }
+        Ok(())
+    }
+
+    // IEEE 754: atan2(0, 0) = 0.
+    #[test]
+    fn atan2_zero_zero_is_zero() -> Result<()> {
+        let y = Tensor::new(&[0.0f32], &Device::Cpu)?;
+        let x = Tensor::new(&[0.0f32], &Device::Cpu)?;
+
+        let result = atan2(&y, &x)?;
+
+        assert_eq!(result.to_vec1::<f32>()?, vec![0.0]);
+        Ok(())
+    }
+
+    // Verifies atan2 on the axes (y=0 or x=0).
+    #[test]
+    fn atan2_on_axes() -> Result<()> {
+        let y_vals = Tensor::new(&[0.0f32, 1.0, 0.0, -1.0], &Device::Cpu)?;
+        let x_vals = Tensor::new(&[1.0f32, 0.0, -1.0, 0.0], &Device::Cpu)?;
+
+        let result = atan2(&y_vals, &x_vals)?;
+
+        let got = result.to_vec1::<f32>()?;
+        let expected: Vec<f32> = vec![
+            0.0f32.atan2(1.0),
+            1.0f32.atan2(0.0),
+            0.0f32.atan2(-1.0),
+            (-1.0f32).atan2(0.0),
+        ];
+        for (g, e) in got.iter().zip(expected.iter()) {
+            assert!((g - e).abs() < f32::EPSILON);
+        }
         Ok(())
     }
 }

--- a/crane-core/src/onnx/ops/atan.rs
+++ b/crane-core/src/onnx/ops/atan.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+//! Crane Added 20260731: ONNX `Atan` as a native eval op.
+//!
+//! `candle_core` has no native `.atan()` tensor method (its `UnaryOp` enum
+//! covers `Exp`/`Log`/`Sin`/`Cos`/… but not `atan`), so this is implemented
+//! via `CustomOp1` operating directly on tensor storage. Upstream candle has
+//! an open PR adding `atan`/`atan2`
+//! (<https://github.com/huggingface/candle/pull/3338>); once that ships in a
+//! released version this crate upgrades to, this file can be replaced with a
+//! direct tensor method call.
+
+use candle_core::{CpuStorage, CustomOp1, Layout, Result, Shape, Tensor, WithDType};
+
+/// Element-wise `atan`. Spec-correct: NaN inputs produce NaN outputs (the
+/// ONNX spec does not define NaN-clamping behavior for `Atan`).
+struct AtanOp;
+
+impl CustomOp1 for AtanOp {
+    fn name(&self) -> &'static str {
+        "atan"
+    }
+
+    fn cpu_fwd(&self, storage: &CpuStorage, layout: &Layout) -> Result<(CpuStorage, Shape)> {
+        fn inner<T: WithDType>(src: &[T], layout: &Layout) -> (CpuStorage, Shape) {
+            let dst = candle_core::cpu_backend::unary_map(src, layout, |v| {
+                T::from_f64(v.to_f64().atan())
+            });
+            (T::to_cpu_storage_owned(dst), layout.shape().clone())
+        }
+
+        match storage {
+            CpuStorage::BF16(s) => Ok(inner(s, layout)),
+            CpuStorage::F16(s) => Ok(inner(s, layout)),
+            CpuStorage::F32(s) => Ok(inner(s, layout)),
+            CpuStorage::F64(s) => Ok(inner(s, layout)),
+            _ => candle_core::bail!("unsupported dtype for Atan"),
+        }
+    }
+}
+
+/// ONNX `Atan`: element-wise arctangent.
+pub(crate) fn atan(input: &Tensor) -> Result<Tensor> {
+    input.apply_op1_no_bwd(&AtanOp)
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{Device, Result, Tensor};
+
+    use super::atan;
+
+    // Verifies that atan matches the standard library f32::atan for a range
+    // of representative inputs.
+    #[test]
+    fn atan_matches_std_atan_elementwise() -> Result<()> {
+        let values = [0.0f32, 1.0, -1.0, 10.0, -10.0, 0.5];
+        let x = Tensor::new(&values, &Device::Cpu)?;
+
+        let y = atan(&x)?;
+
+        let got = y.to_vec1::<f32>()?;
+        let expected: Vec<f32> = values.iter().copied().map(f32::atan).collect();
+        for (g, e) in got.iter().zip(expected.iter()) {
+            assert!((g - e).abs() < f32::EPSILON);
+        }
+        Ok(())
+    }
+
+    // Verifies that the F64 dtype branch is exercised and round-trips
+    // without precision loss.
+    #[test]
+    fn atan_f64() -> Result<()> {
+        let values = [0.0f64, 1.0, -1.0, 10.0, -10.0, 0.5];
+        let x = Tensor::new(&values, &Device::Cpu)?;
+
+        let y = atan(&x)?;
+
+        let got = y.to_vec1::<f64>()?;
+        let expected: Vec<f64> = values.iter().copied().map(f64::atan).collect();
+        for (g, e) in got.iter().zip(expected.iter()) {
+            assert!((g - e).abs() < f64::EPSILON);
+        }
+        Ok(())
+    }
+
+    // Verifies that an unsupported dtype returns an error rather than
+    // panicking.
+    #[test]
+    fn atan_unsupported_dtype_errors() -> Result<()> {
+        let x = Tensor::new(&[1u32, 2, 3], &Device::Cpu)?;
+
+        let err = atan(&x).expect_err("unsupported dtype must error");
+
+        assert!(
+            err.to_string().contains("unsupported dtype"),
+            "unexpected error message: {err}"
+        );
+        Ok(())
+    }
+
+    // Spec-correct behavior: NaN inputs produce NaN outputs (no clamping).
+    #[test]
+    fn atan_preserves_nan() -> Result<()> {
+        let x = Tensor::new(&[f32::NAN, 1.0, f32::NAN], &Device::Cpu)?;
+
+        let y = atan(&x)?;
+
+        let got = y.to_vec1::<f32>()?;
+        assert!(got[0].is_nan());
+        assert!((got[1] - 1.0f32.atan()).abs() < f32::EPSILON);
+        assert!(got[2].is_nan());
+        Ok(())
+    }
+
+    // Verifies that positive and negative infinity produce the expected
+    // asymptotic values (±π/2).
+    #[test]
+    fn atan_infinity() -> Result<()> {
+        let x = Tensor::new(&[f32::INFINITY, f32::NEG_INFINITY], &Device::Cpu)?;
+
+        let y = atan(&x)?;
+
+        let got = y.to_vec1::<f32>()?;
+        let half_pi = std::f32::consts::FRAC_PI_2;
+        assert!((got[0] - half_pi).abs() < 1e-7);
+        assert!((got[1] + half_pi).abs() < 1e-7);
+        Ok(())
+    }
+}

--- a/crane-core/src/onnx/ops/layer_norm.rs
+++ b/crane-core/src/onnx/ops/layer_norm.rs
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+//! Crane Added 20260731: ONNX `LayerNormalization` as a native eval op.
+
+use candle_core::{DType, Result, Tensor, bail};
+
+use crate::onnx::proto::{self, NodeProto};
+
+/// ONNX `LayerNormalization`: normalizes `x` over its trailing dimensions.
+///
+/// `axis` selects the first normalized dimension (default `-1`); every
+/// dimension from `axis` to the end of the tensor is reduced over. Both
+/// positive and negative axis values are accepted, per the ONNX spec (e.g.
+/// `axis=0` normalizes over every dimension). `epsilon` (default `1e-5`) is
+/// added to the variance before the square root to avoid division by zero.
+/// The optional ONNX `stash_type`
+/// attribute is ignored: computation runs in the input's own dtype, except
+/// that F16/BF16 inputs are promoted to F32 for the mean/variance
+/// accumulation to avoid overflow, matching `candle_nn::LayerNorm`.
+pub(crate) fn layer_norm(
+    node: &NodeProto,
+    x: &Tensor,
+    scale: &Tensor,
+    bias: Option<&Tensor>,
+) -> Result<Tensor> {
+    let axis = int_attribute(node, "axis", -1)?;
+    let epsilon = float_attribute(node, "epsilon", 1e-5)?;
+
+    let rank = x.rank();
+    let normalized_axis = x.normalize_axis(axis)?;
+    let reduce_axes: Vec<usize> = (normalized_axis..rank).collect();
+
+    let x_dtype = x.dtype();
+    let internal_dtype = match x_dtype {
+        DType::F16 | DType::BF16 => DType::F32,
+        dtype => dtype,
+    };
+    let x_internal = x.to_dtype(internal_dtype)?;
+
+    let mean = x_internal.mean_keepdim(reduce_axes.as_slice())?;
+    let centered = x_internal.broadcast_sub(&mean)?;
+    let variance = centered.sqr()?.mean_keepdim(reduce_axes.as_slice())?;
+    let normalized = centered.broadcast_div(&(variance + epsilon)?.sqrt()?)?;
+
+    let output = normalized.to_dtype(x_dtype)?.broadcast_mul(scale)?;
+    match bias {
+        Some(bias) => output.broadcast_add(bias),
+        None => Ok(output),
+    }
+}
+
+fn int_attribute(node: &NodeProto, name: &str, default: i64) -> Result<i64> {
+    let Some(attribute) = node
+        .attribute
+        .iter()
+        .find(|attribute| attribute.name == name)
+    else {
+        return Ok(default);
+    };
+    if attribute.r#type() != proto::attribute_proto::AttributeType::Int {
+        bail!(
+            "LayerNormalization node '{}' has a non-INT '{}' attribute ({:?})",
+            node.name,
+            name,
+            attribute.r#type(),
+        );
+    }
+    Ok(attribute.i)
+}
+
+fn float_attribute(node: &NodeProto, name: &str, default: f64) -> Result<f64> {
+    let Some(attribute) = node
+        .attribute
+        .iter()
+        .find(|attribute| attribute.name == name)
+    else {
+        return Ok(default);
+    };
+    if attribute.r#type() != proto::attribute_proto::AttributeType::Float {
+        bail!(
+            "LayerNormalization node '{}' has a non-FLOAT '{}' attribute ({:?})",
+            node.name,
+            name,
+            attribute.r#type(),
+        );
+    }
+    Ok(f64::from(attribute.f))
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{DType, Device, Result, Tensor};
+
+    use crate::onnx::proto::{AttributeProto, NodeProto, attribute_proto::AttributeType};
+
+    use super::layer_norm;
+
+    fn node_with_axis_epsilon(axis: i64, epsilon: f32) -> NodeProto {
+        NodeProto {
+            name: "LayerNormalization.0".to_string(),
+            attribute: vec![
+                AttributeProto {
+                    name: "axis".to_string(),
+                    r#type: AttributeType::Int as i32,
+                    i: axis,
+                    ..Default::default()
+                },
+                AttributeProto {
+                    name: "epsilon".to_string(),
+                    r#type: AttributeType::Float as i32,
+                    f: epsilon,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn axis_minus_one_matches_manual_layer_norm() -> Result<()> {
+        // Normalizes a [2, 4] tensor over its last dim and checks the result
+        // against the standard layer-norm formula computed by hand.
+        let x = Tensor::new(
+            &[[1.0f32, 2.0, 3.0, 4.0], [4.0, 3.0, 2.0, 1.0]],
+            &Device::Cpu,
+        )?;
+        let scale = Tensor::new(&[1.5f32, 0.5, 2.0, 1.0], &Device::Cpu)?;
+        let bias = Tensor::new(&[0.1f32, -0.2, 0.3, 0.0], &Device::Cpu)?;
+        let node = node_with_axis_epsilon(-1, 1e-5);
+
+        let output = layer_norm(&node, &x, &scale, Some(&bias))?;
+
+        let mean = 2.5f32;
+        let variance = 1.25f32;
+        let std_dev = (variance + 1e-5).sqrt();
+        let expected_row0 = [
+            (1.0 - mean) / std_dev * 1.5 + 0.1,
+            (2.0 - mean) / std_dev * 0.5 - 0.2,
+            (3.0 - mean) / std_dev * 2.0 + 0.3,
+            (4.0 - mean) / std_dev * 1.0 + 0.0,
+        ];
+        let got: Vec<Vec<f32>> = output.to_vec2()?;
+        for (got, expected) in got[0].iter().zip(expected_row0.iter()) {
+            assert!((got - expected).abs() < 1e-4, "{got} vs {expected}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn axis_minus_two_reduces_over_last_two_dims() -> Result<()> {
+        // With axis=-2 on a [2, 3, 4] tensor, normalization spans dims 1 and
+        // 2 together rather than just the trailing dim.
+        let x = Tensor::arange(0f32, 24f32, &Device::Cpu)?.reshape((2, 3, 4))?;
+        let scale = Tensor::ones((3, 4), DType::F32, &Device::Cpu)?;
+        let node = node_with_axis_epsilon(-2, 1e-5);
+
+        let output = layer_norm(&node, &x, &scale, None)?;
+
+        assert_eq!(output.dims(), &[2, 3, 4]);
+        let mean_over_slice = output.mean(vec![1, 2])?.to_vec1::<f32>()?;
+        for value in mean_over_slice {
+            assert!(value.abs() < 1e-4, "{value}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn positive_axis_matches_equivalent_negative_axis() -> Result<()> {
+        // axis=1 on a [2, 3, 4] tensor reduces over dims 1 and 2, the same
+        // dims as axis=-2 — positive axis values must be accepted too.
+        let x = Tensor::arange(0f32, 24f32, &Device::Cpu)?.reshape((2, 3, 4))?;
+        let scale = Tensor::ones((3, 4), DType::F32, &Device::Cpu)?;
+        let node_positive = node_with_axis_epsilon(1, 1e-5);
+        let node_negative = node_with_axis_epsilon(-2, 1e-5);
+
+        let output_positive = layer_norm(&node_positive, &x, &scale, None)?;
+        let output_negative = layer_norm(&node_negative, &x, &scale, None)?;
+
+        let got_positive: Vec<f32> = output_positive.flatten_all()?.to_vec1()?;
+        let got_negative: Vec<f32> = output_negative.flatten_all()?.to_vec1()?;
+        for (positive, negative) in got_positive.iter().zip(got_negative.iter()) {
+            assert!(
+                (positive - negative).abs() < 1e-6,
+                "{positive} vs {negative}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn missing_bias_is_optional() -> Result<()> {
+        // ONNX allows LayerNormalization with only X and Scale; bias must
+        // not be required.
+        let x = Tensor::new(&[[1.0f32, 2.0, 3.0, 4.0]], &Device::Cpu)?;
+        let scale = Tensor::ones(4, DType::F32, &Device::Cpu)?;
+        let node = node_with_axis_epsilon(-1, 1e-5);
+
+        let output = layer_norm(&node, &x, &scale, None)?;
+        assert_eq!(output.dims(), &[1, 4]);
+        Ok(())
+    }
+}

--- a/crane-core/src/onnx/ops/mod.rs
+++ b/crane-core/src/onnx/ops/mod.rs
@@ -9,3 +9,4 @@ pub(crate) mod nonzero;
 pub(crate) mod pooling;
 pub(crate) mod reshape;
 pub(crate) mod squeeze;
+pub(crate) mod stft;

--- a/crane-core/src/onnx/ops/mod.rs
+++ b/crane-core/src/onnx/ops/mod.rs
@@ -3,6 +3,7 @@
 pub(crate) mod activation;
 pub(crate) mod conv_transpose;
 pub(crate) mod layer_norm;
+pub(crate) mod modulo;
 pub(crate) mod pooling;
 pub(crate) mod reshape;
 pub(crate) mod squeeze;

--- a/crane-core/src/onnx/ops/mod.rs
+++ b/crane-core/src/onnx/ops/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod atan;
 pub(crate) mod conv_transpose;
 pub(crate) mod layer_norm;
 pub(crate) mod modulo;
+pub(crate) mod nonzero;
 pub(crate) mod pooling;
 pub(crate) mod reshape;
 pub(crate) mod squeeze;

--- a/crane-core/src/onnx/ops/mod.rs
+++ b/crane-core/src/onnx/ops/mod.rs
@@ -2,6 +2,7 @@
 
 pub(crate) mod activation;
 pub(crate) mod conv_transpose;
+pub(crate) mod layer_norm;
 pub(crate) mod pooling;
 pub(crate) mod reshape;
 pub(crate) mod squeeze;

--- a/crane-core/src/onnx/ops/mod.rs
+++ b/crane-core/src/onnx/ops/mod.rs
@@ -1,6 +1,7 @@
 //! Crane Added 20260731: standalone implementations for Crane ONNX operators.
 
 pub(crate) mod activation;
+pub(crate) mod atan;
 pub(crate) mod conv_transpose;
 pub(crate) mod layer_norm;
 pub(crate) mod modulo;

--- a/crane-core/src/onnx/ops/modulo.rs
+++ b/crane-core/src/onnx/ops/modulo.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+//! Crane Added 20260731: ONNX `Mod` as a native eval op.
+
+use candle_core::{DType, Result, Tensor, bail};
+
+use crate::onnx::proto::{self, NodeProto};
+
+/// ONNX `Mod`: elementwise modulo of `a` by `b`.
+///
+/// The `fmod` attribute (default `0`) selects the sign convention: `fmod=0`
+/// uses Python/NumPy semantics where the result takes the sign of the
+/// divisor (`a - floor(a / b) * b`); `fmod=1` uses C/Rust `%` semantics
+/// where the result takes the sign of the dividend (`a - trunc(a / b) * b`).
+/// candle has no built-in remainder or truncation op, so both are computed
+/// via division in F64 followed by `floor` (or a round-trip through `I64`
+/// for truncation), then cast back to the input dtype.
+pub(crate) fn modulo(node: &NodeProto, a: &Tensor, b: &Tensor) -> Result<Tensor> {
+    let fmod = int_attribute(node, "fmod", 0)?;
+
+    let dtype = a.dtype();
+    let a_f64 = a.to_dtype(DType::F64)?;
+    let b_f64 = b.to_dtype(DType::F64)?;
+    let quotient = a_f64.broadcast_div(&b_f64)?;
+
+    let truncated_quotient = match fmod {
+        0 => quotient.floor()?,
+        1 => quotient.to_dtype(DType::I64)?.to_dtype(DType::F64)?,
+        other => bail!(
+            "Mod node '{}' has unsupported fmod value {other}; only 0 or 1 are valid",
+            node.name
+        ),
+    };
+
+    let remainder = (a_f64 - truncated_quotient.broadcast_mul(&b_f64)?)?;
+    remainder.to_dtype(dtype)
+}
+
+fn int_attribute(node: &NodeProto, name: &str, default: i64) -> Result<i64> {
+    let Some(attribute) = node
+        .attribute
+        .iter()
+        .find(|attribute| attribute.name == name)
+    else {
+        return Ok(default);
+    };
+    if attribute.r#type() != proto::attribute_proto::AttributeType::Int {
+        bail!(
+            "Mod node '{}' has a non-INT '{}' attribute ({:?})",
+            node.name,
+            name,
+            attribute.r#type(),
+        );
+    }
+    Ok(attribute.i)
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{DType, Device, Result, Tensor};
+
+    use crate::onnx::proto::{AttributeProto, NodeProto, attribute_proto::AttributeType};
+
+    use super::modulo;
+
+    fn node_with_fmod(fmod: i64) -> NodeProto {
+        NodeProto {
+            name: "Mod.0".to_string(),
+            attribute: vec![AttributeProto {
+                name: "fmod".to_string(),
+                r#type: AttributeType::Int as i32,
+                i: fmod,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn fmod_zero_takes_sign_of_divisor() -> Result<()> {
+        // Python/NumPy semantics: -7 % 3 == 2, 7 % 3 == 1.
+        let a = Tensor::new(&[-7i64, 7], &Device::Cpu)?;
+        let b = Tensor::new(&[3i64, 3], &Device::Cpu)?;
+        let node = node_with_fmod(0);
+
+        let output = modulo(&node, &a, &b)?;
+
+        assert_eq!(output.to_vec1::<i64>()?, vec![2, 1]);
+        Ok(())
+    }
+
+    #[test]
+    fn fmod_one_takes_sign_of_dividend() -> Result<()> {
+        // C/Rust semantics: -7 % 3 == -1, 7 % 3 == 1.
+        let a = Tensor::new(&[-7i64, 7], &Device::Cpu)?;
+        let b = Tensor::new(&[3i64, 3], &Device::Cpu)?;
+        let node = node_with_fmod(1);
+
+        let output = modulo(&node, &a, &b)?;
+
+        assert_eq!(output.to_vec1::<i64>()?, vec![-1, 1]);
+        Ok(())
+    }
+
+    #[test]
+    fn broadcasts_scalar_divisor() -> Result<()> {
+        // A scalar divisor should broadcast against a vector dividend.
+        let a = Tensor::new(&[10i64, 11, 12], &Device::Cpu)?;
+        let b = Tensor::new(3i64, &Device::Cpu)?;
+        let node = node_with_fmod(0);
+
+        let output = modulo(&node, &a, &b)?;
+
+        assert_eq!(output.dims(), &[3]);
+        assert_eq!(output.to_vec1::<i64>()?, vec![1, 2, 0]);
+        Ok(())
+    }
+
+    #[test]
+    fn float_inputs_preserve_dtype() -> Result<()> {
+        // Mod on float inputs must return a float tensor, not an int one.
+        let a = Tensor::new(&[5.5f32], &Device::Cpu)?;
+        let b = Tensor::new(&[2.0f32], &Device::Cpu)?;
+        let node = node_with_fmod(1);
+
+        let output = modulo(&node, &a, &b)?;
+
+        assert_eq!(output.dtype(), DType::F32);
+        let got = output.to_vec1::<f32>()?;
+        assert!((got[0] - 1.5).abs() < 1e-5, "{got:?}");
+        Ok(())
+    }
+}

--- a/crane-core/src/onnx/ops/nonzero.rs
+++ b/crane-core/src/onnx/ops/nonzero.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+//! Crane Added 20260731: ONNX `NonZero` as a native eval op.
+
+use candle_core::{DType, Result, Tensor};
+
+use crate::onnx::proto::NodeProto;
+
+/// ONNX `NonZero`: returns the multi-indices of `input`'s nonzero elements.
+///
+/// Per the ONNX spec, the output is an `int64` tensor of shape
+/// `[input_rank, num_nonzero]`, where column `i` holds the multi-index (in
+/// row-major order) of the `i`-th nonzero element. `input` is flattened and
+/// cast to `F32` so that any upstream dtype's "nonzero" is checked uniformly
+/// as `!= 0.0` -- this also covers the common case of a comparison op
+/// (`Greater`/`Less`/etc.) feeding `NonZero` with a 0/1-valued `U8` tensor.
+pub(crate) fn nonzero(_node: &NodeProto, input: &Tensor) -> Result<Tensor> {
+    let dims = input.dims().to_vec();
+    let rank = dims.len();
+    let flat: Vec<f32> = input.flatten_all()?.to_dtype(DType::F32)?.to_vec1::<f32>()?;
+
+    // Standard unravel-index: for a fixed `flat_idx`, walking `d` from the
+    // last dimension backward and repeatedly taking `% dims[d]` then
+    // dividing recovers each dimension's index directly (each `indices[d]`
+    // is written by-index, not appended in traversal order, so visiting
+    // dimensions in this order doesn't affect the final per-dimension
+    // ordering across nonzero elements -- only the outer ascending
+    // `flat_idx` loop does, matching the ONNX spec's row-major output
+    // order).
+    let mut indices: Vec<Vec<i64>> = vec![Vec::new(); rank];
+    for (flat_idx, &v) in flat.iter().enumerate() {
+        if v == 0.0 {
+            continue;
+        }
+        let mut remaining = flat_idx;
+        for d in (0..rank).rev() {
+            // `dims[d]` is a real tensor dimension, always far below
+            // i64::MAX, so this cast never wraps.
+            #[allow(clippy::cast_possible_wrap)]
+            let dim_idx = (remaining % dims[d]) as i64;
+            indices[d].push(dim_idx);
+            remaining /= dims[d];
+        }
+    }
+
+    let num_nonzero = indices.first().map_or(0, Vec::len);
+    let mut flat_out = Vec::with_capacity(rank * num_nonzero);
+    for row in indices {
+        flat_out.extend(row);
+    }
+    Tensor::from_vec(flat_out, (rank, num_nonzero), input.device())
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{Device, Result, Tensor};
+
+    use crate::onnx::proto::NodeProto;
+
+    use super::nonzero;
+
+    fn node() -> NodeProto {
+        NodeProto { name: "NonZero.0".to_string(), ..Default::default() }
+    }
+
+    // The motivating shape: a 2D mask produces row-major multi-indices.
+    #[test]
+    fn nonzero_2d_multi_indices() -> Result<()> {
+        // [[0, 1, 0], [1, 0, 1]] -> nonzero at (0,1), (1,0), (1,2)
+        let x = Tensor::new(&[[0f32, 1., 0.], [1., 0., 1.]], &Device::Cpu)?;
+
+        let y = nonzero(&node(), &x)?;
+
+        assert_eq!(y.dims(), &[2, 3]);
+        let rows = y.to_vec2::<i64>()?;
+        assert_eq!(rows[0], vec![0, 1, 1]); // row indices
+        assert_eq!(rows[1], vec![1, 0, 2]); // col indices
+        Ok(())
+    }
+
+    #[test]
+    fn nonzero_all_zero_input_returns_empty() -> Result<()> {
+        let x = Tensor::zeros((2, 2), candle_core::DType::F32, &Device::Cpu)?;
+
+        let y = nonzero(&node(), &x)?;
+
+        assert_eq!(y.dims(), &[2, 0]);
+        Ok(())
+    }
+
+    #[test]
+    fn nonzero_all_nonzero_input_returns_every_index() -> Result<()> {
+        let x = Tensor::new(&[[1f32, 2.], [3., 4.]], &Device::Cpu)?;
+
+        let y = nonzero(&node(), &x)?;
+
+        assert_eq!(y.dims(), &[2, 4]);
+        let rows = y.to_vec2::<i64>()?;
+        assert_eq!(rows[0], vec![0, 0, 1, 1]);
+        assert_eq!(rows[1], vec![0, 1, 0, 1]);
+        Ok(())
+    }
+
+    #[test]
+    fn nonzero_1d_input() -> Result<()> {
+        let x = Tensor::new(&[0f32, 5., 0., 7.], &Device::Cpu)?;
+
+        let y = nonzero(&node(), &x)?;
+
+        assert_eq!(y.dims(), &[1, 2]);
+        assert_eq!(y.to_vec2::<i64>()?[0], vec![1, 3]);
+        Ok(())
+    }
+
+    // NonZero commonly consumes the U8 0/1 output of a comparison op
+    // (Greater/Less/etc.); the F32 cast must still treat any nonzero U8
+    // value as "nonzero".
+    #[test]
+    fn nonzero_u8_comparison_output() -> Result<()> {
+        let x = Tensor::new(&[[0u8, 1], [1, 0]], &Device::Cpu)?;
+
+        let y = nonzero(&node(), &x)?;
+
+        assert_eq!(y.dims(), &[2, 2]);
+        let rows = y.to_vec2::<i64>()?;
+        assert_eq!(rows[0], vec![0, 1]);
+        assert_eq!(rows[1], vec![1, 0]);
+        Ok(())
+    }
+}

--- a/crane-core/src/onnx/ops/stft.rs
+++ b/crane-core/src/onnx/ops/stft.rs
@@ -1,0 +1,254 @@
+// SPDX-License-Identifier: MIT
+//! Crane Added 20260731: ONNX `STFT` as a native eval op.
+
+use candle_core::{IndexOp, Result, Tensor, bail};
+use rustfft::{FftPlanner, num_complex::Complex as FftComplex};
+
+use crate::onnx::proto::{self, NodeProto};
+
+/// ONNX `STFT`: computes a real forward short-time Fourier transform.
+///
+/// `signal` (input 0) is `[batch, signal_length]` or
+/// `[batch, signal_length, 1]`; `frame_step` (input 1) is a scalar frame
+/// hop size; `window` (input 2) is a 1-D window of length `frame_length`,
+/// required here (a windowless STFT isn't supported); `frame_length`
+/// (input 3, optional) must match `window`'s length when present, and
+/// defaults to it otherwise.
+///
+/// Frames the signal every `frame_step` samples, applies `window`, and runs
+/// an FFT of size `frame_length` per frame via `rustfft`. When the
+/// `onesided` attribute (default `1`) is nonzero, only the first
+/// `frame_length / 2 + 1` bins are kept. Output shape is
+/// `[batch, num_frames, n_bins, 2]` (real, imaginary).
+pub(crate) fn stft(
+    node: &NodeProto,
+    signal: &Tensor,
+    frame_step: &Tensor,
+    window: Option<&Tensor>,
+    frame_length: Option<&Tensor>,
+) -> Result<Tensor> {
+    let frame_step = scalar_i64(frame_step)?;
+    if frame_step <= 0 {
+        bail!("STFT node '{}': frame_step must be > 0, got {frame_step}", node.name);
+    }
+    // Validated positive above, so this cast never wraps or loses sign.
+    #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+    let frame_step = frame_step as usize;
+
+    let Some(window) = window else {
+        bail!("STFT node '{}' has no window input; a windowless STFT isn't supported", node.name);
+    };
+    let window = window.to_vec1::<f32>()?;
+
+    let frame_length = match frame_length {
+        Some(t) => {
+            let v = scalar_i64(t)?;
+            if v < 0 {
+                bail!("STFT node '{}': frame_length must be non-negative, got {v}", node.name);
+            }
+            // Validated non-negative above.
+            #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
+            let v = v as usize;
+            v
+        },
+        None => window.len(),
+    };
+    if frame_length != window.len() {
+        bail!(
+            "STFT node '{}': frame_length {frame_length} does not match window length {}",
+            node.name,
+            window.len()
+        );
+    }
+    if frame_length == 0 {
+        bail!("STFT node '{}': frame_length must be > 0", node.name);
+    }
+
+    let onesided = int_attribute(node, "onesided", 1)? != 0;
+
+    let signal = match signal.dims() {
+        [_, _] => signal.clone(),
+        [b, l, 1] => signal.reshape((*b, *l))?,
+        dims => bail!("STFT node '{}': input has unsupported shape {dims:?}", node.name),
+    };
+    let (batch, signal_length) = signal.dims2()?;
+    if signal_length < frame_length {
+        bail!(
+            "STFT node '{}': signal length {signal_length} is shorter than frame_length {frame_length}",
+            node.name
+        );
+    }
+    let num_frames = 1 + (signal_length - frame_length) / frame_step;
+    let n_bins = if onesided { frame_length / 2 + 1 } else { frame_length };
+
+    let mut planner = FftPlanner::<f32>::new();
+    let fft = planner.plan_fft_forward(frame_length);
+
+    let signal_data = signal.to_vec2::<f32>()?;
+    let mut output = vec![0f32; batch * num_frames * n_bins * 2];
+    let mut buffer = vec![FftComplex::new(0.0, 0.0); frame_length];
+    for (b, row) in signal_data.iter().enumerate() {
+        for f in 0..num_frames {
+            let start = f * frame_step;
+            for (i, sample) in buffer.iter_mut().enumerate() {
+                *sample = FftComplex::new(row[start + i] * window[i], 0.0);
+            }
+            fft.process(&mut buffer);
+            for (k, bin) in buffer.iter().take(n_bins).enumerate() {
+                let idx = ((b * num_frames + f) * n_bins + k) * 2;
+                output[idx] = bin.re;
+                output[idx + 1] = bin.im;
+            }
+        }
+    }
+    Tensor::from_vec(output, (batch, num_frames, n_bins, 2), signal.device())
+}
+
+fn scalar_i64(t: &Tensor) -> Result<i64> {
+    if t.rank() > 0 && t.elem_count() == 1 {
+        t.flatten_all()?.i(0)?.to_vec0::<i64>()
+    } else {
+        t.to_vec0::<i64>()
+    }
+}
+
+fn int_attribute(node: &NodeProto, name: &str, default: i64) -> Result<i64> {
+    let Some(attribute) = node
+        .attribute
+        .iter()
+        .find(|attribute| attribute.name == name)
+    else {
+        return Ok(default);
+    };
+    if attribute.r#type() != proto::attribute_proto::AttributeType::Int {
+        bail!(
+            "STFT node '{}' has a non-INT '{}' attribute ({:?})",
+            node.name,
+            name,
+            attribute.r#type(),
+        );
+    }
+    Ok(attribute.i)
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{Device, Result, Tensor};
+
+    use crate::onnx::proto::{AttributeProto, NodeProto, attribute_proto::AttributeType};
+
+    use super::stft;
+
+    fn node() -> NodeProto {
+        NodeProto { name: "STFT.0".to_string(), ..Default::default() }
+    }
+
+    fn node_with_onesided(value: i64) -> NodeProto {
+        NodeProto {
+            name: "STFT.0".to_string(),
+            attribute: vec![AttributeProto {
+                name: "onesided".to_string(),
+                r#type: AttributeType::Int as i32,
+                i: value,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    // A constant-1.0 signal windowed by a rectangular window of length 4:
+    // each frame's FFT has bin 0 == (frame_length, 0) and every other bin
+    // == (0, 0), an easy hand-checkable case.
+    #[test]
+    fn stft_basic_windowed_constant_signal() -> Result<()> {
+        let signal = Tensor::new(&[[1f32; 8]], &Device::Cpu)?;
+        let frame_step = Tensor::new(2i64, &Device::Cpu)?;
+        let window = Tensor::new(&[1f32, 1., 1., 1.], &Device::Cpu)?;
+
+        let y = stft(&node(), &signal, &frame_step, Some(&window), None)?;
+
+        // num_frames = 1 + (8 - 4) / 2 = 3; n_bins = 4/2 + 1 = 3 (onesided).
+        assert_eq!(y.dims(), &[1, 3, 3, 2]);
+        let data = y.flatten_all()?.to_vec1::<f32>()?;
+        for frame in 0..3 {
+            let base = frame * 3 * 2;
+            assert!((data[base] - 4.0).abs() < 1e-4, "bin 0 real: {data:?}");
+            assert!(data[base + 1].abs() < 1e-4, "bin 0 imag: {data:?}");
+            for bin in 1..3 {
+                let idx = base + bin * 2;
+                assert!(data[idx].abs() < 1e-4, "bin {bin} real should be ~0: {data:?}");
+                assert!(data[idx + 1].abs() < 1e-4, "bin {bin} imag should be ~0: {data:?}");
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn stft_onesided_false_keeps_all_bins() -> Result<()> {
+        let signal = Tensor::new(&[[1f32; 8]], &Device::Cpu)?;
+        let frame_step = Tensor::new(2i64, &Device::Cpu)?;
+        let window = Tensor::new(&[1f32, 1., 1., 1.], &Device::Cpu)?;
+
+        let y = stft(&node_with_onesided(0), &signal, &frame_step, Some(&window), None)?;
+
+        assert_eq!(y.dims(), &[1, 3, 4, 2]);
+        Ok(())
+    }
+
+    #[test]
+    fn stft_signal_shorter_than_frame_bails() {
+        let signal = Tensor::new(&[[1f32, 2., 3.]], &Device::Cpu).unwrap();
+        let frame_step = Tensor::new(1i64, &Device::Cpu).unwrap();
+        let window = Tensor::new(&[1f32, 1., 1., 1.], &Device::Cpu).unwrap();
+
+        let err = stft(&node(), &signal, &frame_step, Some(&window), None).unwrap_err();
+
+        assert!(err.to_string().contains("shorter than frame_length"));
+    }
+
+    #[test]
+    fn stft_frame_length_mismatch_bails() {
+        let signal = Tensor::new(&[[1f32; 8]], &Device::Cpu).unwrap();
+        let frame_step = Tensor::new(1i64, &Device::Cpu).unwrap();
+        let window = Tensor::new(&[1f32, 1., 1., 1.], &Device::Cpu).unwrap();
+        let frame_length = Tensor::new(8i64, &Device::Cpu).unwrap();
+
+        let err =
+            stft(&node(), &signal, &frame_step, Some(&window), Some(&frame_length)).unwrap_err();
+
+        assert!(err.to_string().contains("does not match window length"));
+    }
+
+    #[test]
+    fn stft_3d_input_squeezes_trailing_one() -> Result<()> {
+        let signal = Tensor::new(&[[[1f32], [1.], [1.], [1.], [1.], [1.], [1.], [1.]]], &Device::Cpu)?;
+        let frame_step = Tensor::new(2i64, &Device::Cpu)?;
+        let window = Tensor::new(&[1f32, 1., 1., 1.], &Device::Cpu)?;
+
+        let y = stft(&node(), &signal, &frame_step, Some(&window), None)?;
+
+        assert_eq!(y.dims(), &[1, 3, 3, 2]);
+        Ok(())
+    }
+
+    #[test]
+    fn stft_no_window_bails() {
+        let signal = Tensor::new(&[[1f32; 8]], &Device::Cpu).unwrap();
+        let frame_step = Tensor::new(2i64, &Device::Cpu).unwrap();
+
+        let err = stft(&node(), &signal, &frame_step, None, None).unwrap_err();
+
+        assert!(err.to_string().contains("no window input"));
+    }
+
+    #[test]
+    fn stft_zero_frame_step_bails() {
+        let signal = Tensor::new(&[[1f32; 8]], &Device::Cpu).unwrap();
+        let frame_step = Tensor::new(0i64, &Device::Cpu).unwrap();
+        let window = Tensor::new(&[1f32, 1., 1., 1.], &Device::Cpu).unwrap();
+
+        let err = stft(&node(), &signal, &frame_step, Some(&window), None).unwrap_err();
+
+        assert!(err.to_string().contains("frame_step must be > 0"));
+    }
+}

--- a/crane-core/src/onnx/optimizer/fuse_atan2.rs
+++ b/crane-core/src/onnx/optimizer/fuse_atan2.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+//! Fuses the decomposed `atan2(y, x)` pattern into a single `Atan2` node.
+//!
+//! ONNX exporters targeting opsets without a native `Atan2` op (notably
+//! `PyTorch`'s `torch.onnx.export`) emit the two-argument arctangent as a
+//! multi-node decomposition:
+//!
+//! ```text
+//! Div(y, x) → Atan → inner Where(Greater(y, 0), Add(atan, π), Sub(atan, π))
+//!           → outer Where(Less(x, 0), inner_where, atan) → result
+//! ```
+//!
+//! This decomposition is numerically fragile near the origin: `Div(0, 0)`
+//! produces `NaN`, and the quadrant-correction `Less(x, 0)` flips
+//! unpredictably when `x` is near zero — both problems that `f32::atan2`
+//! handles correctly in a single call. This pass recognizes the terminal
+//! `Where` node of that decomposition and replaces the entire subgraph with
+//! a single `Atan2(y, x)` node. Dead intermediate nodes (`Div`, `Atan`,
+//! `Less`, `Greater`, `Add`, `Sub`, inner `Where`) are left for the existing
+//! DCE pass in [`super::eliminate`] to clean up.
+
+use std::collections::HashMap;
+
+use super::super::proto::{GraphProto, NodeProto};
+
+/// Fuses every decomposed `atan2` pattern in `graph` into a single `Atan2`
+/// node, returning the number of fusions performed.
+///
+/// Intended to run once at optimization time (before constant folding),
+/// not per inference call.
+pub(crate) fn fuse_atan2_decomposition(graph: &mut GraphProto) -> usize {
+    let producers = collect_producers(&graph.node);
+    let mut fused = 0;
+
+    for node in &mut graph.node {
+        if node.op_type == "Where" && try_fuse_where(node, &producers) {
+            fused += 1;
+        }
+    }
+
+    fused
+}
+
+/// Maps each node output name to a reference-counted copy of its producing
+/// node, so [`try_fuse_where`] can walk backward from a `Where` node
+/// through the chain without a second pass.
+fn collect_producers(nodes: &[NodeProto]) -> HashMap<String, NodeProto> {
+    let mut producers = HashMap::with_capacity(nodes.len());
+    for node in nodes {
+        for output in &node.output {
+            if !output.is_empty() {
+                producers.insert(output.clone(), node.clone());
+            }
+        }
+    }
+    producers
+}
+
+/// Attempts to match `node` (a `Where`) against the `atan2` quadrant-
+/// correction decomposition and, if it matches, rewrites `node` in place
+/// to an `Atan2(y, x)` node with the same output name. Returns `true` on
+/// a successful rewrite.
+///
+/// The matched shape (backward from the terminal `Where`):
+///
+/// 1. `Where(cond, true_branch, false_branch)` where `false_branch` is the
+///    raw `Atan` result (the "no correction needed" path).
+/// 2. `cond` is produced by `Less(x, zero)` — the quadrant check.
+/// 3. `false_branch` is produced by `Atan(div_out)`.
+/// 4. `div_out` is produced by `Div(y, x)` where `x` is the same tensor
+///    as the `Less` node's first input.
+/// 5. `true_branch` is produced by an inner `Where(inner_cond, add, sub)` —
+///    the quadrant-correction branch.
+/// 6. `inner_cond` is produced by `Greater(y, _)`, using the same `y` as
+///    the `Div` node.
+/// 7. `add` is produced by `Add` taking the `Atan` result as an input.
+/// 8. `sub` is produced by `Sub` taking the `Atan` result as an input.
+fn try_fuse_where(node: &mut NodeProto, producers: &HashMap<String, NodeProto>) -> bool {
+    if node.input.len() != 3 || node.output.len() != 1 {
+        return false;
+    }
+    let cond = &node.input[0];
+    let true_val = &node.input[1];
+    let false_val = &node.input[2];
+
+    let Some(less) = producers.get(cond) else { return false };
+    if less.op_type != "Less" || less.input.len() != 2 {
+        return false;
+    }
+    let x = &less.input[0];
+
+    let Some(atan) = producers.get(false_val) else { return false };
+    if atan.op_type != "Atan" || atan.input.len() != 1 {
+        return false;
+    }
+    let atan_output = &atan.output[0];
+
+    let Some(div) = producers.get(&atan.input[0]) else { return false };
+    if div.op_type != "Div" || div.input.len() != 2 || div.input[1] != *x {
+        return false;
+    }
+    let y = &div.input[0];
+
+    let Some(inner_where) = producers.get(true_val) else { return false };
+    if inner_where.op_type != "Where" || inner_where.input.len() != 3 {
+        return false;
+    }
+
+    let Some(greater) = producers.get(&inner_where.input[0]) else { return false };
+    if greater.op_type != "Greater" || greater.input.len() != 2 || greater.input[0] != *y {
+        return false;
+    }
+
+    let Some(add) = producers.get(&inner_where.input[1]) else { return false };
+    if add.op_type != "Add" || !add.input.contains(atan_output) {
+        return false;
+    }
+
+    let Some(sub) = producers.get(&inner_where.input[2]) else { return false };
+    if sub.op_type != "Sub" || !sub.input.contains(atan_output) {
+        return false;
+    }
+
+    node.op_type = "Atan2".to_string();
+    node.input = vec![y.clone(), x.clone()];
+    node.name = if node.name.is_empty() {
+        "fused_atan2".to_string()
+    } else {
+        format!("{}/fused_atan2", node.name)
+    };
+
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binary_node(op_type: &str, a: &str, b: &str, output: &str) -> NodeProto {
+        NodeProto {
+            op_type: op_type.to_string(),
+            input: vec![a.to_string(), b.to_string()],
+            output: vec![output.to_string()],
+            ..Default::default()
+        }
+    }
+
+    fn unary_node(op_type: &str, input: &str, output: &str) -> NodeProto {
+        NodeProto {
+            op_type: op_type.to_string(),
+            input: vec![input.to_string()],
+            output: vec![output.to_string()],
+            ..Default::default()
+        }
+    }
+
+    fn where_node(name: &str, cond: &str, t: &str, f: &str, output: &str) -> NodeProto {
+        NodeProto {
+            name: name.to_string(),
+            op_type: "Where".to_string(),
+            input: vec![cond.to_string(), t.to_string(), f.to_string()],
+            output: vec![output.to_string()],
+            ..Default::default()
+        }
+    }
+
+    /// Builds the full `atan2(y, x)` quadrant-correction decomposition.
+    fn atan2_decomposition(y: &str, x: &str, output: &str) -> Vec<NodeProto> {
+        vec![
+            binary_node("Div", y, x, "div"),
+            unary_node("Atan", "div", "atan"),
+            binary_node("Greater", y, "zero", "greater"),
+            binary_node("Add", "atan", "pi", "add_pi"),
+            binary_node("Sub", "atan", "pi", "sub_pi"),
+            where_node("inner_where", "greater", "add_pi", "sub_pi", "where0"),
+            binary_node("Less", x, "zero", "less"),
+            where_node("outer_where", "less", "where0", "atan", output),
+        ]
+    }
+
+    // The motivating case: the full atan2 decomposition is recognized and
+    // the terminal Where is rewritten to a single Atan2(y, x) node.
+    #[test]
+    fn fuses_full_atan2_decomposition() {
+        let mut graph = GraphProto {
+            node: atan2_decomposition("imag", "real", "result"),
+            ..Default::default()
+        };
+
+        let fused = fuse_atan2_decomposition(&mut graph);
+
+        assert_eq!(fused, 1);
+        let atan2_node = graph
+            .node
+            .iter()
+            .find(|n| n.op_type == "Atan2")
+            .expect("should have an Atan2 node");
+        assert_eq!(atan2_node.input, vec!["imag", "real"]);
+        assert_eq!(atan2_node.output, vec!["result"]);
+    }
+
+    // Unrelated Where nodes must be left completely unchanged.
+    #[test]
+    fn leaves_unrelated_where_unchanged() {
+        let mut graph = GraphProto {
+            node: vec![where_node("w", "cond", "a", "b", "y")],
+            ..Default::default()
+        };
+
+        let fused = fuse_atan2_decomposition(&mut graph);
+
+        assert_eq!(fused, 0);
+        assert_eq!(graph.node.len(), 1);
+        assert_eq!(graph.node[0].op_type, "Where");
+    }
+
+    // Multiple independent atan2 decompositions in the same graph should
+    // each be fused.
+    #[test]
+    fn fuses_multiple_decompositions() {
+        let mut nodes = Vec::new();
+
+        let first = atan2_decomposition("imag1", "real1", "result1");
+        nodes.extend(first);
+
+        nodes.push(binary_node("Div", "imag2", "real2", "div2"));
+        nodes.push(unary_node("Atan", "div2", "atan2_"));
+        nodes.push(binary_node("Greater", "imag2", "zero", "greater2"));
+        nodes.push(binary_node("Add", "atan2_", "pi", "add_pi2"));
+        nodes.push(binary_node("Sub", "atan2_", "pi", "sub_pi2"));
+        nodes.push(where_node("inner2", "greater2", "add_pi2", "sub_pi2", "where02"));
+        nodes.push(binary_node("Less", "real2", "zero", "less2"));
+        nodes.push(where_node("outer2", "less2", "where02", "atan2_", "result2"));
+
+        let mut graph = GraphProto { node: nodes, ..Default::default() };
+
+        let fused = fuse_atan2_decomposition(&mut graph);
+        assert_eq!(fused, 2);
+    }
+
+    // A Where node whose condition is Less but false branch is not an Atan
+    // (e.g. the inner Where of the decomposition) should not be fused.
+    #[test]
+    fn does_not_fuse_inner_where() {
+        let mut graph = GraphProto {
+            node: vec![
+                binary_node("Less", "x", "zero", "less"),
+                binary_node("Add", "a", "b", "add"),
+                where_node("w", "less", "add", "c", "y"),
+            ],
+            ..Default::default()
+        };
+
+        let fused = fuse_atan2_decomposition(&mut graph);
+        assert_eq!(fused, 0);
+    }
+
+    // A Where node whose condition/false-branch match the outer atan2 shape
+    // (Less/Atan/Div) but whose true-branch is not the inner quadrant-
+    // correction Where must not be fused.
+    #[test]
+    fn does_not_fuse_wrong_true_branch() {
+        let mut graph = GraphProto {
+            node: vec![
+                binary_node("Div", "y", "x", "div"),
+                unary_node("Atan", "div", "atan"),
+                binary_node("Less", "x", "zero", "less"),
+                binary_node("Add", "unrelated_a", "unrelated_b", "not_inner_where"),
+                where_node("w", "less", "not_inner_where", "atan", "result"),
+            ],
+            ..Default::default()
+        };
+
+        let fused = fuse_atan2_decomposition(&mut graph);
+        assert_eq!(fused, 0);
+    }
+}

--- a/crane-core/src/onnx/optimizer/mod.rs
+++ b/crane-core/src/onnx/optimizer/mod.rs
@@ -2,6 +2,7 @@
 
 mod constant_fold;
 mod eliminate;
+pub(crate) mod fuse_atan2;
 
 use std::collections::{HashMap, HashSet};
 
@@ -37,6 +38,8 @@ pub struct OptimizationReport {
     pub removed_alias_nodes: usize,
     pub removed_dead_nodes: usize,
     pub removed_initializers: usize,
+    /// Number of decomposed `atan2(y, x)` patterns fused into single nodes.
+    pub fused_atan2_nodes: usize,
     /// DCE is skipped when graph-valued attributes may capture outer values.
     pub skipped_dce_for_subgraphs: bool,
 }
@@ -54,6 +57,9 @@ pub(crate) fn optimize(
         report.final_nodes = graph.node.len();
         return Ok(report);
     }
+
+    report.removed_alias_nodes += eliminate::eliminate_alias_nodes(graph);
+    report.fused_atan2_nodes = fuse_atan2::fuse_atan2_decomposition(graph);
 
     for _ in 0..options.max_optimization_passes {
         let folded = constant_fold::fold_constants(graph, constants, options.max_folded_elements)?;

--- a/crane-core/src/onnx/session.rs
+++ b/crane-core/src/onnx/session.rs
@@ -43,7 +43,7 @@ impl Session {
         let optimization_report = optimizer::optimize(graph, &mut initializers, &options)?;
         if std::env::var_os("CRANE_ONNX_OPT_REPORT").is_some() {
             eprintln!(
-                "Crane ONNX optimized '{}': {} -> {} nodes (folded {}, aliases {}, dead {}, initializers {})",
+                "Crane ONNX optimized '{}': {} -> {} nodes (folded {}, aliases {}, dead {}, initializers {}, fused_atan2 {})",
                 graph.name,
                 optimization_report.original_nodes,
                 optimization_report.final_nodes,
@@ -51,6 +51,7 @@ impl Session {
                 optimization_report.removed_alias_nodes,
                 optimization_report.removed_dead_nodes,
                 optimization_report.removed_initializers,
+                optimization_report.fused_atan2_nodes,
             );
         }
         graph.initializer.clear();


### PR DESCRIPTION
Extracts several ONNX ops (LayerNorm, Trilu, LSTM, ReduceSum, ReduceMean, CumSum, Resize) out of the monolithic eval.rs match statement into individual `ops/*.rs` modules, fixing several bugs along the way (Trilu NaN handling, ReduceSum negative axes, CumSum int64 support, Resize rank-3 support) and adding a new Round op and bidirectional LSTM support.

All of this is needed for PR #62 