### PR TITLE
data: add Qwen 3.5 4B GGUF entry to crane-model-download

### DIFF
--- a/data/crane-model-download
+++ b/data/crane-model-download
@@ -87,6 +87,13 @@ MODELS = {
         "quant_template": "Qwen3.5-0.8B-{quant}.gguf",
         "description": "Qwen 3.5 0.8B, hybrid GDN + attention, GGUF quant (Apache-2.0)",
     },
+    "qwen3.5-4b-gguf": {
+        "repo_id": "unsloth/Qwen3.5-4B-GGUF",
+        "dirname": "Qwen3.5-4B-GGUF",
+        "kind": "llm",
+        "quant_template": "Qwen3.5-4B-{quant}.gguf",
+        "description": "Qwen 3.5 4B, hybrid GDN + attention, GGUF quant (Apache-2.0)",
+    },
     "qwen3.5-9b-gguf": {
         "repo_id": "unsloth/Qwen3.5-9B-GGUF",
         "dirname": "Qwen3.5-9B-GGUF",


### PR DESCRIPTION
The downloader only offered 0.8B and 9B Qwen 3.5 GGUF sizes, leaving no middle ground for GPUs where the 9B model's VRAM footprint leaves too little headroom for KV cache during inference.