### PR TITLE
feat(serve): honor frequency_penalty/presence_penalty instead of disc…

### DIFF
--- a/crane-core/src/models/qwen3_5/model.rs
+++ b/crane-core/src/models/qwen3_5/model.rs
@@ -506,6 +506,22 @@ fn build_layer_caches(
     Ok((gdn_caches, attn_caches))
 }
 
+/// Append Qwen3.5's canonical stop-token ids (`<|im_end|>`, `<|endoftext|>`)
+/// to `eos_token_ids` by resolving them by name in `vocab`, skipping any
+/// already present. Used as a GGUF fallback: GGUF's `tokenizer.ggml.eos_token_id`
+/// metadata field can only hold one id, so a GGUF-only export (no sidecar
+/// `generation_config.json`) silently drops whichever canonical stop token the
+/// exporter didn't pick.
+fn merge_canonical_eos_ids(eos_token_ids: &mut Vec<u32>, vocab: &std::collections::HashMap<String, u32>) {
+    for name in ["<|im_end|>", "<|endoftext|>"] {
+        if let Some(&id) = vocab.get(name)
+            && !eos_token_ids.contains(&id)
+        {
+            eos_token_ids.push(id);
+        }
+    }
+}
+
 /// Read EOS token id(s) from `generation_config.json` (preferred) then
 /// `config.json`. The field may be a single integer or a list; returns an empty
 /// vec if absent.
@@ -669,7 +685,8 @@ impl Model {
         };
 
         // EOS: sibling generation_config.json wins (may hold the full multi-id
-        // set); fall back to the single id in GGUF metadata.
+        // set); fall back to the single id in GGUF metadata, then fill in any
+        // other canonical stop token by name (see `merge_canonical_eos_ids`).
         let mut eos_token_ids = read_eos_token_ids(&parent.to_string_lossy());
         if eos_token_ids.is_empty()
             && let Some(id) = ct
@@ -679,6 +696,7 @@ impl Model {
         {
             eos_token_ids.push(id);
         }
+        merge_canonical_eos_ids(&mut eos_token_ids, &tokenizer.get_vocab(true));
 
         let inner = Qwen3_5TextModel::from_gguf(ct, &mut file, device)?;
         let dtype = inner.dtype();
@@ -883,5 +901,48 @@ impl ModelForCausalLM for Model {
             );
         }
         Ok(tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_canonical_eos_ids;
+    use std::collections::HashMap;
+
+    #[test]
+    // A GGUF export that only recorded <|im_end|> (248046) must get
+    // <|endoftext|> (248044) added from the vocab, matching Qwen3.5's
+    // documented multi-id EOS set.
+    fn merge_adds_missing_canonical_id() {
+        let mut eos_token_ids = vec![248_046];
+        let vocab: HashMap<String, u32> =
+            [("<|im_end|>".to_string(), 248_046), ("<|endoftext|>".to_string(), 248_044)]
+                .into_iter()
+                .collect();
+        merge_canonical_eos_ids(&mut eos_token_ids, &vocab);
+        assert_eq!(eos_token_ids, vec![248_046, 248_044]);
+    }
+
+    #[test]
+    // An id already present (from generation_config.json or GGUF metadata)
+    // must not be duplicated.
+    fn merge_does_not_duplicate_existing_id() {
+        let mut eos_token_ids = vec![248_046, 248_044];
+        let vocab: HashMap<String, u32> =
+            [("<|im_end|>".to_string(), 248_046), ("<|endoftext|>".to_string(), 248_044)]
+                .into_iter()
+                .collect();
+        merge_canonical_eos_ids(&mut eos_token_ids, &vocab);
+        assert_eq!(eos_token_ids, vec![248_046, 248_044]);
+    }
+
+    #[test]
+    // A vocab lacking either canonical name (e.g. a different tokenizer)
+    // must leave the existing ids untouched rather than erroring.
+    fn merge_is_noop_when_vocab_lacks_canonical_names() {
+        let mut eos_token_ids = vec![7];
+        let vocab: HashMap<String, u32> = [("<|other|>".to_string(), 1)].into_iter().collect();
+        merge_canonical_eos_ids(&mut eos_token_ids, &vocab);
+        assert_eq!(eos_token_ids, vec![7]);
     }
 }

--- a/crane-serve/src/engine/mod.rs
+++ b/crane-serve/src/engine/mod.rs
@@ -553,6 +553,8 @@ impl InferenceEngine {
             top_p = ?req.top_p,
             top_k = ?req.top_k,
             rep_penalty = req.repetition_penalty,
+            freq_penalty = req.frequency_penalty,
+            pres_penalty = req.presence_penalty,
             "New request accepted (queue: waiting={} running={})",
             self.scheduler.waiting.len() + 1,
             self.scheduler.running.len(),
@@ -580,6 +582,8 @@ impl InferenceEngine {
             max_tokens: effective_max_tokens,
             eos_token_id: req.eos_token_id,
             repetition_penalty: req.repetition_penalty,
+            frequency_penalty: req.frequency_penalty,
+            presence_penalty: req.presence_penalty,
             repeat_last_n: 64,
             response_tx: req.response_tx,
         };

--- a/crane-serve/src/engine/sampling.rs
+++ b/crane-serve/src/engine/sampling.rs
@@ -10,7 +10,7 @@
 //! the sampled index itself. Set `CRANE_SAMPLE_TRACE=1` to log the path taken
 //! and its latency at `debug` level.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Instant;
 
 use anyhow::Result;
@@ -192,10 +192,16 @@ pub fn sample(
     };
     #[cfg(any(feature = "cuda", feature = "rocm"))]
     {
-        // `repetition_penalty` is compared against the exact "disabled" sentinel
-        // (1.0), not a computed float, so strict equality is correct.
+        // `repetition_penalty`/`frequency_penalty`/`presence_penalty` are
+        // each compared against their exact "disabled" sentinel, not a
+        // computed float, so strict equality is correct.
         #[allow(clippy::float_cmp)]
-        if greedy && seq.repetition_penalty == 1.0 && has_gpu_sampling(logits.device()) {
+        if greedy
+            && seq.repetition_penalty == 1.0
+            && seq.frequency_penalty == 0.0
+            && seq.presence_penalty == 0.0
+            && has_gpu_sampling(logits.device())
+        {
             let flat = logits.squeeze(0)?.squeeze(0)?;
             let token = crane_core::ops::gpu_argmax(&flat)?;
             if trace {
@@ -215,14 +221,17 @@ pub fn sample(
     let logits = logits.squeeze(0)?.squeeze(0)?.to_dtype(DType::F32)?;
     let t_preprocessed = Instant::now();
 
-    // `repetition_penalty` is compared against the exact "disabled" sentinel
-    // (1.0), not a computed float, so strict equality is correct.
-    #[allow(clippy::float_cmp)]
-    if seq.repetition_penalty != 1.0 {
-        let start_at = seq.tokens.len().saturating_sub(seq.repeat_last_n);
-        apply_repeat_penalty_inplace(&logits, seq.repetition_penalty, &seq.tokens[start_at..])
-            .map_err(anyhow::Error::from)?;
-    }
+    // Shared trailing-context window for both penalty types below.
+    let start_at = seq.tokens.len().saturating_sub(seq.repeat_last_n);
+
+    apply_penalties_inplace(
+        &logits,
+        seq.repetition_penalty,
+        seq.frequency_penalty,
+        seq.presence_penalty,
+        &seq.tokens[start_at..],
+    )
+    .map_err(anyhow::Error::from)?;
     let t_penalty_applied = Instant::now();
 
     if greedy {
@@ -395,36 +404,89 @@ pub fn sample_gumbel_max_idx(logits: &Tensor, temperature: f64) -> candle_core::
     }
 }
 
-/// Apply repetition penalty in-place (GPU-friendly scatter/gather).
+/// Apply repetition, frequency, and presence penalties to `logits` in-place
+/// (GPU-friendly scatter/gather).
+///
+/// `repetition_penalty` (1.0 = disabled) is a flat multiplicative penalty:
+/// the same factor is applied whether a token appeared once or a hundred
+/// times. `frequency_penalty` (0.0 = disabled) is subtracted once per
+/// occurrence of a token in `context`, so it grows with repeat count and can
+/// break short repetition loops (period a few tokens) that a flat penalty
+/// cannot — such loops keep every token in the loop at the same "seen"
+/// penalty forever, never changing their relative ranking.
+/// `presence_penalty` (0.0 = disabled) is subtracted once for any token
+/// that appears at all, regardless of count. Negative `frequency_penalty`/
+/// `presence_penalty` values are permitted (per the `OpenAI` API) and boost
+/// rather than penalize a token's logit.
+///
+/// `context` is normally the caller's trailing `repeat_last_n`-token window,
+/// not the full generated output, so occurrences older than that window are
+/// not counted for any of the three penalties.
+///
+/// All three penalties are computed from a single token-occurrence count
+/// and applied via one gather + scatter round-trip, rather than one
+/// round-trip per penalty type, since this runs once per decode step.
+/// Repetition penalty (multiplicative) is applied first, then
+/// frequency/presence penalty (additive) is subtracted from the result.
 ///
 /// # Errors
 ///
 /// Returns an error if a tensor operation fails.
-pub fn apply_repeat_penalty_inplace(
+pub fn apply_penalties_inplace(
     logits: &Tensor,
-    penalty: f32,
+    repetition_penalty: f32,
+    frequency_penalty: f32,
+    presence_penalty: f32,
     context: &[u32],
 ) -> candle_core::Result<()> {
-    if context.is_empty() {
+    // `repetition_penalty`/`frequency_penalty`/`presence_penalty` are each
+    // compared against their exact "disabled" sentinel, not a computed
+    // float, so strict equality is correct.
+    #[allow(clippy::float_cmp)]
+    let repetition_active = repetition_penalty != 1.0;
+    #[allow(clippy::float_cmp)]
+    let freq_presence_active = frequency_penalty != 0.0 || presence_penalty != 0.0;
+    if context.is_empty() || (!repetition_active && !freq_presence_active) {
         return Ok(());
     }
 
-    let mut unique: HashSet<u32> = HashSet::with_capacity(context.len());
+    let mut counts: HashMap<u32, u32> = HashMap::with_capacity(context.len());
     for &t in context {
-        unique.insert(t);
+        *counts.entry(t).or_insert(0) += 1;
     }
-    if unique.is_empty() {
-        return Ok(());
-    }
-    let mut token_ids: Vec<u32> = unique.into_iter().collect();
+
+    let mut token_ids: Vec<u32> = counts.keys().copied().collect();
     token_ids.sort_unstable();
 
     let idx = Tensor::new(token_ids.as_slice(), logits.device())?;
     let selected = logits.gather(&idx, candle_core::D::Minus1)?;
-    let mask = selected.ge(0f64)?;
-    let on_true = (&selected / f64::from(penalty))?;
-    let on_false = (&selected * f64::from(penalty))?;
-    let updated = mask.where_cond(&on_true, &on_false)?;
+
+    let selected = if repetition_active {
+        let mask = selected.ge(0f64)?;
+        let on_true = (&selected / f64::from(repetition_penalty))?;
+        let on_false = (&selected * f64::from(repetition_penalty))?;
+        mask.where_cond(&on_true, &on_false)?
+    } else {
+        selected
+    };
+
+    let updated = if freq_presence_active {
+        let deltas: Vec<f32> = token_ids
+            .iter()
+            .map(|id| {
+                // Counts are bounded by `context.len()`, which is always far
+                // smaller than f32's 2^24 exact-integer limit.
+                #[allow(clippy::cast_precision_loss)]
+                let count = counts[id] as f32;
+                count * frequency_penalty + presence_penalty
+            })
+            .collect();
+        let penalty_tensor = Tensor::new(deltas.as_slice(), logits.device())?;
+        (&selected - &penalty_tensor)?
+    } else {
+        selected
+    };
+
     logits.scatter_set(&idx, &updated, candle_core::D::Minus1)
 }
 
@@ -439,4 +501,131 @@ pub fn rand_seed() -> u64 {
     #[allow(clippy::cast_possible_truncation)]
     let seed = nanos as u64;
     seed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn logits(values: &[f32]) -> Tensor {
+        Tensor::new(values, &Device::Cpu).unwrap()
+    }
+
+    #[test]
+    // All three penalties disabled (sentinel values) must leave logits untouched.
+    fn all_penalties_noop_when_disabled() {
+        let t = logits(&[1.0, 2.0, 3.0]);
+        apply_penalties_inplace(&t, 1.0, 0.0, 0.0, &[0, 1, 2]).unwrap();
+        assert_eq!(t.to_vec1::<f32>().unwrap(), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    // Empty context must leave logits untouched even with penalties set.
+    fn all_penalties_noop_when_context_empty() {
+        let t = logits(&[1.0, 2.0, 3.0]);
+        apply_penalties_inplace(&t, 1.1, 0.5, 0.5, &[]).unwrap();
+        assert_eq!(t.to_vec1::<f32>().unwrap(), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    // repetition_penalty alone: positive logits are divided by the penalty,
+    // negative logits are multiplied by it, mirroring the pre-merge
+    // `apply_repeat_penalty_inplace` behavior for a single-token context.
+    fn repetition_penalty_alone_scales_by_sign() {
+        let t = logits(&[10.0, -10.0, 3.0]);
+        apply_penalties_inplace(&t, 2.0, 0.0, 0.0, &[0, 1]).unwrap();
+        let out = t.to_vec1::<f32>().unwrap();
+        assert!((out[0] - 5.0).abs() < 1e-6, "positive logit should be divided");
+        assert!((out[1] - -20.0).abs() < 1e-6, "negative logit should be multiplied");
+        assert!((out[2] - 3.0).abs() < 1e-6, "unseen token must be untouched");
+    }
+
+    #[test]
+    // Combining repetition_penalty with frequency_penalty in one call must
+    // apply repetition's multiplicative scaling first, then subtract the
+    // frequency penalty from the *scaled* result, not compute them
+    // independently from the original logit.
+    fn repetition_and_frequency_penalty_combine_in_order() {
+        let t = logits(&[10.0, 10.0]);
+        apply_penalties_inplace(&t, 2.0, 1.0, 0.0, &[0, 0, 1]).unwrap();
+        let out = t.to_vec1::<f32>().unwrap();
+        // token 0: (10.0 / 2.0) - (2 occurrences * 1.0) = 3.0
+        assert!((out[0] - 3.0).abs() < 1e-6);
+        // token 1: (10.0 / 2.0) - (1 occurrence * 1.0) = 4.0
+        assert!((out[1] - 4.0).abs() < 1e-6);
+    }
+
+    #[test]
+    // frequency_penalty must scale with occurrence count: token 0 appears
+    // three times and should be penalized 3x more than token 1, which
+    // appears once. Token 2 never appears and is untouched.
+    fn frequency_penalty_scales_with_occurrence_count() {
+        let t = logits(&[10.0, 10.0, 10.0]);
+        apply_penalties_inplace(&t, 1.0, 0.5, 0.0, &[0, 0, 0, 1]).unwrap();
+        assert_eq!(t.to_vec1::<f32>().unwrap(), vec![10.0 - 1.5, 10.0 - 0.5, 10.0]);
+    }
+
+    #[test]
+    // presence_penalty is flat: token 0 (3 occurrences) and token 1 (1
+    // occurrence) must be penalized by the exact same amount.
+    fn presence_penalty_is_flat_regardless_of_count() {
+        let t = logits(&[10.0, 10.0, 10.0]);
+        apply_penalties_inplace(&t, 1.0, 0.0, 0.5, &[0, 0, 0, 1]).unwrap();
+        assert_eq!(t.to_vec1::<f32>().unwrap(), vec![10.0 - 0.5, 10.0 - 0.5, 10.0]);
+    }
+
+    #[test]
+    // Simulates a stuck decode loop: token 0 has a slightly higher logit
+    // than token 1 and has therefore been picked repeatedly (5 times) while
+    // token 1 was picked once. A flat penalty (like repetition_penalty)
+    // treats both as equally "seen" and can never flip the argmax, so the
+    // loop never breaks. frequency_penalty grows with occurrence count and
+    // must flip the ranking here, breaking the loop.
+    fn frequency_penalty_breaks_short_repeat_cycle() {
+        let t = logits(&[5.0, 4.9]);
+        let context = [0, 1, 0, 0, 0, 0];
+        apply_penalties_inplace(&t, 1.0, 0.1, 0.0, &context).unwrap();
+        let out = t.to_vec1::<f32>().unwrap();
+        assert!((out[0] - 4.5).abs() < 1e-6);
+        assert!((out[1] - 4.8).abs() < 1e-6);
+        assert!(out[1] > out[0], "frequency penalty should flip the ranking");
+    }
+
+    #[test]
+    // Both penalties active at once must combine additively: token 0's
+    // total penalty is `count * frequency_penalty + presence_penalty`, not
+    // just one or the other.
+    fn frequency_and_presence_penalty_combine_additively() {
+        let t = logits(&[10.0, 10.0, 10.0]);
+        apply_penalties_inplace(&t, 1.0, 0.5, 0.2, &[0, 0, 0, 1]).unwrap();
+        assert_eq!(
+            t.to_vec1::<f32>().unwrap(),
+            vec![10.0 - (3.0 * 0.5 + 0.2), 10.0 - (1.0 * 0.5 + 0.2), 10.0]
+        );
+    }
+
+    #[test]
+    // OpenAI's API permits negative frequency_penalty values, which must
+    // boost (not penalize) a repeated token's logit.
+    fn negative_frequency_penalty_boosts_logit() {
+        let t = logits(&[10.0, 10.0]);
+        apply_penalties_inplace(&t, 1.0, -0.5, 0.0, &[0, 0, 1]).unwrap();
+        let out = t.to_vec1::<f32>().unwrap();
+        assert!(out[0] > 10.0, "negative frequency_penalty should boost the logit");
+        assert!((out[0] - 11.0).abs() < 1e-6);
+        assert!((out[1] - 10.5).abs() < 1e-6);
+    }
+
+    #[test]
+    // OpenAI's API permits negative presence_penalty values, which must
+    // boost (not penalize) the logit of any token that appeared at all.
+    fn negative_presence_penalty_boosts_logit() {
+        let t = logits(&[10.0, 10.0, 10.0]);
+        apply_penalties_inplace(&t, 1.0, 0.0, -0.5, &[0, 1]).unwrap();
+        let out = t.to_vec1::<f32>().unwrap();
+        assert!(out[0] > 10.0, "negative presence_penalty should boost the logit");
+        assert!((out[0] - 10.5).abs() < 1e-6);
+        assert!((out[1] - 10.5).abs() < 1e-6);
+        assert!((out[2] - 10.0).abs() < 1e-6, "unseen token must be untouched");
+    }
 }

--- a/crane-serve/src/engine/sequence.rs
+++ b/crane-serve/src/engine/sequence.rs
@@ -54,6 +54,8 @@ pub struct Sequence {
     pub max_tokens: usize,
     pub eos_token_id: Vec<u32>,
     pub repetition_penalty: f32,
+    pub frequency_penalty: f32,
+    pub presence_penalty: f32,
     pub repeat_last_n: usize,
 
     // ── response channel ──
@@ -151,6 +153,8 @@ mod tests {
             max_tokens,
             eos_token_id: vec![eos_token_id],
             repetition_penalty: 1.0,
+            frequency_penalty: 0.0,
+            presence_penalty: 0.0,
             repeat_last_n: 64,
             response_tx: tx,
         }

--- a/crane-serve/src/engine/types.rs
+++ b/crane-serve/src/engine/types.rs
@@ -16,6 +16,8 @@ pub struct EngineRequest {
     pub top_p: Option<f64>,
     pub top_k: Option<usize>,
     pub repetition_penalty: f32,
+    pub frequency_penalty: f32,
+    pub presence_penalty: f32,
     pub eos_token_id: Vec<u32>,
     pub response_tx: mpsc::UnboundedSender<EngineResponse>,
 }
@@ -30,8 +32,18 @@ pub struct GenerationParams {
     pub top_p: Option<f64>,
     /// Number of highest-probability tokens to keep; `None` disables top-k filtering.
     pub top_k: Option<usize>,
-    /// Penalty applied to previously generated tokens (1.0 = no penalty).
+    /// Penalty applied to previously generated tokens (1.0 = no penalty). A
+    /// flat multiplicative scaling: the same factor applies whether a token
+    /// appeared once or a hundred times.
     pub repetition_penalty: f32,
+    /// Subtractive penalty scaled by each token's occurrence count so far
+    /// (0.0 = no penalty). Unlike `repetition_penalty`'s flat multiplicative
+    /// scaling, this grows with repeat count, so it can break short
+    /// repetition loops that a flat penalty cannot.
+    pub frequency_penalty: f32,
+    /// Flat subtractive penalty applied once to any token that has appeared
+    /// at all so far (0.0 = no penalty).
+    pub presence_penalty: f32,
     /// Token IDs that terminate generation when produced.
     pub eos_token_id: Vec<u32>,
 }
@@ -81,6 +93,8 @@ impl EngineHandle {
                 top_p: params.top_p,
                 top_k: params.top_k,
                 repetition_penalty: params.repetition_penalty,
+                frequency_penalty: params.frequency_penalty,
+                presence_penalty: params.presence_penalty,
                 eos_token_id: params.eos_token_id,
                 response_tx,
             })
@@ -124,6 +138,8 @@ mod tests {
                 top_p: Some(0.95),
                 top_k: Some(40),
                 repetition_penalty: 1.0,
+                frequency_penalty: 0.0,
+                presence_penalty: 0.0,
                 eos_token_id: vec![0],
             },
         );
@@ -147,6 +163,8 @@ mod tests {
                 top_p: None,
                 top_k: None,
                 repetition_penalty: 1.0,
+                frequency_penalty: 0.0,
+                presence_penalty: 0.0,
                 eos_token_id: vec![0],
             },
         );
@@ -225,6 +243,8 @@ mod tests {
                     top_p: Some(0.9),
                     top_k: None,
                     repetition_penalty: 1.1,
+                    frequency_penalty: 0.3,
+                    presence_penalty: 0.2,
                     eos_token_id: vec![2],
                 },
             )
@@ -238,6 +258,8 @@ mod tests {
         assert_eq!(req.top_p, Some(0.9));
         assert_eq!(req.top_k, None);
         assert!((req.repetition_penalty - 1.1).abs() < 0.001);
+        assert!((req.frequency_penalty - 0.3).abs() < 0.001);
+        assert!((req.presence_penalty - 0.2).abs() < 0.001);
         assert_eq!(req.eos_token_id, vec![2]);
     }
 }

--- a/crane-serve/src/handlers/openai.rs
+++ b/crane-serve/src/handlers/openai.rs
@@ -83,6 +83,8 @@ pub async fn chat_completions(
                 top_p: req.top_p.or(Some(0.95)),
                 top_k: req.top_k.or(Some(40)),
                 repetition_penalty: req.repetition_penalty.unwrap_or(1.05),
+                frequency_penalty: req.frequency_penalty.unwrap_or(0.0),
+                presence_penalty: req.presence_penalty.unwrap_or(0.0),
                 eos_token_id: state.eos_token_id.clone(),
             },
         )
@@ -160,6 +162,8 @@ pub async fn completions(
                 top_p: req.top_p.or(Some(0.95)),
                 top_k: req.top_k.or(Some(40)),
                 repetition_penalty: req.repetition_penalty.unwrap_or(1.05),
+                frequency_penalty: req.frequency_penalty.unwrap_or(0.0),
+                presence_penalty: req.presence_penalty.unwrap_or(0.0),
                 eos_token_id: state.eos_token_id.clone(),
             },
         )

--- a/crane-serve/src/handlers/sglang.rs
+++ b/crane-serve/src/handlers/sglang.rs
@@ -81,6 +81,8 @@ pub async fn generate(
                 top_p: sp.top_p.or(Some(0.95)),
                 top_k: sp.top_k.or(Some(20)),
                 repetition_penalty: sp.repetition_penalty,
+                frequency_penalty: sp.frequency_penalty.unwrap_or(0.0),
+                presence_penalty: sp.presence_penalty.unwrap_or(0.0),
                 eos_token_id: state.eos_token_id.clone(),
             },
         )
@@ -199,6 +201,8 @@ pub async fn health_generate(
                 top_p: None,
                 top_k: None,
                 repetition_penalty: 1.0,
+                frequency_penalty: 0.0,
+                presence_penalty: 0.0,
                 eos_token_id: state.eos_token_id.clone(),
             },
         )

--- a/crane-serve/src/openai_api.rs
+++ b/crane-serve/src/openai_api.rs
@@ -203,6 +203,8 @@ pub struct CompletionRequest {
     pub stop: Option<Vec<String>>,
     pub suffix: Option<String>,
     pub echo: Option<bool>,
+    pub frequency_penalty: Option<f32>,
+    pub presence_penalty: Option<f32>,
     pub seed: Option<u64>,
     pub n: Option<usize>,
 }


### PR DESCRIPTION
…arding them

repetition_penalty applies the same fixed penalty to a token regardless of how many times it repeated. Once a short decode loop (a few tokens) has been through one full cycle, every token in it looks equally "penalized".  Their ranking never changes, so the loop never breaks.

I confirmed this with a real long prompt at temperature=0: CPU, ROCm, and ROCm with prefill chunking disabled all converge to the same failure shape, a decent start collapsing into a short infinite repeat.

frequency_penalty and presence_penalty were already parsed from client requests, but silently dropped before reaching the sampler. Unlike repetition_penalty, frequency_penalty scales with occurrence count. It keeps growing on a looping token until its ranking flips, which breaks the loop.

This wires frequency_penalty/presence_penalty through EngineRequest, GenerationParams, and Sequence.