### PR TITLE
qwen 3.8 support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A high-performance inference framework leveraging Rust's Candle for maximum spee
 - [ ] Qwen3.5-VLA, Qwen3.5-GR00T, Pi0.5;
 - [ ] Audio8-TTS;
 - [x] PaddleOCR-v6;
+- [x] Qwen 3.6 / Qwen 3.8 (27B dense, text + vision, thinking control) — same architecture as Qwen 3.5, scaled up
 - [x] Qwen 3.5 (0.8B; hybrid Gated Delta Net + softmax attention, CPU/CUDA/Metal) + Ornith-1.0-9B (agentic, tool calling)
 - [x] Hunyuan Dense
 - [x] Gemma 4 (text and vision; no audio)
@@ -77,6 +78,7 @@ We include:
 
 ## 🔥 Updates
 
+- **`2026.08.16`**: 🧠 **Qwen 3.8 / Qwen 3.6 (27B) support + flexible thinking control.** Both declare `model_type: "qwen3_5"` and convert to GGUF as `qwen35`, so they are the Qwen 3.5 architecture scaled up (64 layers, 24 q / 4 KV heads, 48 GDN value heads, untied `lm_head`) and need **no new modeling code** — every difference is a config value. Thinking is now controllable per request via `chat_template_kwargs: {"enable_thinking": …, "reasoning_effort": "low|medium|xhigh"}` (or OpenAI's top-level `reasoning_effort`), and the `<think>` scratchpad is separated out of `content` into **`reasoning_content`**, streaming included. 🗜️ GGUF embedding tables now stay quantized and dequantize only the rows a forward pass gathers, instead of expanding all 248320 of them at load: **1772 MiB saved** on Qwen 3.8-27B Q4_K_M (peak 22007 → 20235 MiB), bit-exact on untied checkpoints (prefill logits cosine `1.000000000`). Qwen 3.8-27B Q4_K_M runs text-only on a single 24 GB RTX 3090.
 - **`2026.08.06`**: 🗣️ **Kokoro-82M TTS support** — from-scratch Rust G2P + `candle-onnx` synthesis pipeline, currently English only, wired into `/v1/audio/speech` in crane-serve. Benchmarked against Moonshine-TTS's reference C++ implementation on the same Kokoro-82M ONNX model: **1.6-4.3x faster synthesis** across short/medium/long text.
 - **`2026.08.02`**: ⏱️ Decode is dispatch-bound, not kernel-bound — and now isn't. New `CRANE_PROF=1` forward-pass profiler measures *submission* time against wall-clock time after a device sync, which `rocm-smi`'s busy counter cannot distinguish. It showed the CPU spending **21.8 ms of a 26.9 ms token** merely enqueueing ~2000 kernel launches. Collapsing `Qwen35RmsNorm` and the GDN gated norm into single fused `rms_norm` launches, rewriting the Q/K L2 norm as one (`x/√(Σx²+ε) ≡ rms_norm(x, 1/√K, ε/K)` — an identity, not an approximation), and hoisting `-exp(A_log)`/`dt_bias` to load time cut submission to **6.9 ms**; decode is now GPU-bound. On an RX 7800 XT with Qwen3.5-2B-Q8_0: decode **35.7 → 63.0 t/s** @ depth 0, **31.7 → 55.6** @ 2048, **28.8 → 49.2** @ 4096; prefill **2257 → 2726 t/s**. Gap to llama.cpp: 3.0× → ~1.7×.
 - **`2026.08.01`**: 🔴 AMD ROCm kernels — Crane's own `kernels/cuda/*.cu` now run on AMD too (the ROCm build compiles them with `hipcc` on first use and caches the code object), so the fused GDN recurrence, GPU top-k sampling and `fused_silu_mul` are no longer CUDA-only. The causal Conv1D also became `kernel` shifted multiply-accumulates instead of one windowed reduction per timestep, which helps every backend. Qwen 3.5's GGUF loader also stops forcing F32 side tensors (embeddings, norms, attention scores) on ROCm — F16 like Metal. On an RX 7800 XT with Qwen3.5-2B-Q8_0: prefill **183 → ~1600 t/s**, decode @ depth 2048 **15.4 → 30.6 t/s**, and peak VRAM on a 3800-token prompt drops from 99% to 69% of 16 GB.
@@ -418,6 +420,54 @@ cargo run -p crane-examples --bin ornith_tools --release --features cuda \
   -- --model-path /path/to/Ornith-1.0-9B
 # or:  MODEL_PATH=/path/to/Ornith-1.0-9B cargo run --bin ornith_tools ...
 ```
+
+### Qwen 3.6 / Qwen 3.8 (27B dense)
+
+Both 27B checkpoints declare `model_type: "qwen3_5"` /
+`architectures: ["Qwen3_5ForConditionalGeneration"]`, and their GGUF
+conversions carry `general.architecture = "qwen35"` — they are the Qwen 3.5
+architecture scaled up (64 layers, `hidden_size` 5120, 24 query / 4 KV heads,
+48 GDN value heads, untied `lm_head`, ViT depth 27), so they run on the same
+code path and are auto-detected. Qwen 3.6-27B and Qwen 3.8-27B have identical
+text configs.
+
+```bash
+# GGUF (recommended): ~16 GB for Q4_K_M, fits a 24 GB card text-only
+./target/release/crane-serve --text-only -m /path/to/Qwen3.8-27B-Q4_K_M.gguf
+
+# or fetch one
+./data/crane-model-download --model qwen3.8-27b-gguf --path ~/models --quant Q4_K_M
+```
+
+**Flexible thinking control.** These models reason by default, and their chat
+template ends the prompt with an open `<think>` block. Crane splits the
+scratchpad out of the answer into `reasoning_content` (streaming too), so
+`content` holds only the reply:
+
+```bash
+# default: thinking on at 'xhigh' — the longest reasoning budget
+curl localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "qwen3.8", "messages": [{"role": "user", "content": "What is 2+2?"}]}'
+# → {"message": {"content": "4", "reasoning_content": "Two plus two is four."}}
+
+# short thinking (much lower latency)
+  -d '{..., "reasoning_effort": "low"}'
+
+# thinking off entirely
+  -d '{..., "chat_template_kwargs": {"enable_thinking": false}}'
+```
+
+`reasoning_effort` accepts `low`, `medium` and `xhigh` (default). Note that
+`medium` is the neutral baseline and injects no instruction — only `low` and
+`xhigh` add one.
+
+**Memory.** GGUF is the better choice at this size, not just the convenient
+one: Q4_K_M is 15.40 GiB and spends 4.14 GiB of that putting Q6_K on the
+quantization-sensitive tensors (`ffn_down`, `output`), whereas `--quant q4k`
+in-situ quantization lands at ~15.8 GiB with one dtype for everything and a
+dense embedding table. The 248320-row embedding stays quantized on the GGUF
+path and is gathered row-by-row (`CRANE_EMBED_DENSE=1` reverts to the old
+dequantize-everything behaviour).
 
 **K/V cache compression (CUDA):** the full-attention K/V cache dominates
 memory at long context (the GDN layers carry a constant recurrent state).

--- a/crane-core/src/autotokenizer.rs
+++ b/crane-core/src/autotokenizer.rs
@@ -391,6 +391,30 @@ impl AutoTokenizer {
         add_generation_prompt: bool,
         enable_thinking: Option<bool>,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        self.apply_chat_template_full(ctx, tools, add_generation_prompt, enable_thinking, None)
+    }
+
+    /// Like [`Self::apply_chat_template_with_options`], plus the
+    /// `reasoning_effort` knob that the Qwen 3.6/3.8 templates read.
+    ///
+    /// Those templates accept `'xhigh'`, `'medium'` or `'low'` and
+    /// `raise_exception` on anything else — which surfaces here as a render
+    /// error, so pass a validated value or `None`. `None` leaves the variable
+    /// undefined and the template's own default applies; for Qwen 3.8 that
+    /// default is **`xhigh`**, i.e. the longest reasoning budget, so callers
+    /// that care about latency should pass `Some("low")` explicitly rather
+    /// than relying on the default.
+    ///
+    /// Has no effect on templates that never mention `reasoning_effort`
+    /// (Qwen 3.5 and earlier) — an unused context variable is inert.
+    pub fn apply_chat_template_full<S: serde::Serialize, T: serde::Serialize>(
+        &self,
+        ctx: S,
+        tools: Option<T>,
+        add_generation_prompt: bool,
+        enable_thinking: Option<bool>,
+        reasoning_effort: Option<&str>,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let template_str = self.config.chat_template.as_deref().ok_or_else(|| {
             Box::new(std::io::Error::new(
                 std::io::ErrorKind::NotFound,
@@ -517,6 +541,13 @@ impl AutoTokenizer {
             Some(v) => minijinja::Value::from(v),
             None => minijinja::Value::UNDEFINED,
         };
+        // Same undefined-vs-none reasoning as above: Qwen 3.6/3.8 resolve this
+        // with `reasoning_effort|default('xhigh')`, and an explicit `none`
+        // would slip past `default()` and hit their `raise_exception`.
+        let reasoning_effort = match reasoning_effort {
+            Some(v) => minijinja::Value::from(v),
+            None => minijinja::Value::UNDEFINED,
+        };
 
         match tmpl.render(context! {
             messages=> ctx,
@@ -526,7 +557,8 @@ impl AutoTokenizer {
             bos_token=> *bos,
             eos_token=> *eos,
             add_generation_prompt=> add_generation_prompt,
-            enable_thinking=> enable_thinking
+            enable_thinking=> enable_thinking,
+            reasoning_effort=> reasoning_effort
         }) {
             Ok(result) => Ok(result),
             Err(e) => Err(Box::new(std::io::Error::new(
@@ -549,7 +581,21 @@ mod tests {
     const OFFICIAL_TAIL: &str = "{%- if enable_thinking is defined and enable_thinking is false %}{{- 'OFF' }}{%- else %}{{- 'ON' }}{%- endif %}";
     const UNSLOTH_TAIL: &str = "{%- if enable_thinking is defined and enable_thinking is true %}{{- 'ON' }}{%- else %}{{- 'OFF' }}{%- endif %}";
 
+    /// The Qwen 3.6/3.8 `reasoning_effort` gate, reduced to its essentials:
+    /// `default()` on an undefined variable, then a hard failure on anything
+    /// outside the supported set.
+    const EFFORT_TAIL: &str = "{%- set e = reasoning_effort|default('xhigh') %}\
+{%- if e not in ('xhigh', 'medium', 'low') %}{{- raise_exception('bad effort') }}{%- endif %}{{- e }}";
+
     fn render_with(template: &str, enable_thinking: Option<bool>) -> String {
+        render_full(template, enable_thinking, None).expect("render")
+    }
+
+    fn render_full(
+        template: &str,
+        enable_thinking: Option<bool>,
+        reasoning_effort: Option<&str>,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let config = AutoTokenizerConfig {
             add_bos_token: None,
             add_eos_token: None,
@@ -567,13 +613,13 @@ mod tests {
             config,
             tokenizer: Tokenizer::new(tokenizers::models::bpe::BPE::default()),
         };
-        tok.apply_chat_template_with_options(
+        tok.apply_chat_template_full(
             Vec::<serde_json::Value>::new(),
             Option::<&serde_json::Value>::None,
             true,
             enable_thinking,
+            reasoning_effort,
         )
-        .expect("render")
     }
 
     /// `None` must leave the variable UNDEFINED, not set it to `none` — Jinja
@@ -593,6 +639,37 @@ mod tests {
         assert_eq!(render_with(UNSLOTH_TAIL, Some(true)), "ON");
         assert_eq!(render_with(OFFICIAL_TAIL, Some(false)), "OFF");
         assert_eq!(render_with(UNSLOTH_TAIL, Some(false)), "OFF");
+    }
+
+    // ── reasoning_effort ─────────────────────────────────────────────────
+
+    /// `None` must reach `default('xhigh')`, which an explicit `none` would
+    /// slip past straight into `raise_exception`.
+    #[test]
+    fn reasoning_effort_none_falls_through_to_template_default() {
+        assert_eq!(render_full(EFFORT_TAIL, None, None).unwrap(), "xhigh");
+    }
+
+    #[test]
+    fn reasoning_effort_explicit_overrides_default() {
+        for effort in ["low", "medium", "xhigh"] {
+            assert_eq!(render_full(EFFORT_TAIL, None, Some(effort)).unwrap(), effort);
+        }
+    }
+
+    /// The template validates the value itself; an unsupported one must
+    /// surface as an error rather than a silently mis-prompted request.
+    #[test]
+    fn reasoning_effort_unsupported_value_errors() {
+        let err = render_full(EFFORT_TAIL, None, Some("high")).unwrap_err().to_string();
+        assert!(err.contains("bad effort"), "unexpected error: {err}");
+    }
+
+    /// Templates predating the knob (Qwen 3.5) must be unaffected by it.
+    #[test]
+    fn reasoning_effort_is_inert_for_templates_that_ignore_it() {
+        assert_eq!(render_full(OFFICIAL_TAIL, None, Some("low")).unwrap(), "ON");
+        assert_eq!(render_full(UNSLOTH_TAIL, Some(true), Some("low")).unwrap(), "ON");
     }
 
     // ── rewrite_split_index ──────────────────────────────────────────────

--- a/crane-core/src/models/hunyuan_dense/modeling.rs
+++ b/crane-core/src/models/hunyuan_dense/modeling.rs
@@ -48,6 +48,20 @@ impl<R: Read + Seek> Gguf<R> {
         Ok(RmsNorm::new(weight, eps))
     }
 
+    /// Load an embedding table that stays quantized when it can, dequantizing
+    /// only the rows a forward pass gathers.
+    ///
+    /// Prefer this over [`Self::embedding`] for large vocabularies: a 248k-row
+    /// table costs ~2.4 GiB dense in BF16 versus ~0.7 GiB as Q4_K.
+    pub fn quantized_embedding(
+        &mut self,
+        name: &str,
+        hidden_size: usize,
+    ) -> Result<crate::models::modules::embedding::EmbeddingLayer> {
+        let ws = self.ct.tensor(&mut self.reader, name, &self.device)?;
+        crate::models::modules::embedding::EmbeddingLayer::from_qtensor(ws, hidden_size, self.dtype)
+    }
+
     /// Load a tensor, dequantize, and create an Embedding.
     /// The weight is cast to the target `dtype` so lookups produce
     /// tensors in the expected compute precision.

--- a/crane-core/src/models/modules/embedding.rs
+++ b/crane-core/src/models/modules/embedding.rs
@@ -1,0 +1,210 @@
+//! Embedding table that can stay quantized in device memory.
+//!
+//! The default GGUF path dequantizes `token_embd.weight` to the compute dtype
+//! at load. For small vocabularies that is free, but modern Qwen checkpoints
+//! carry a 248320-row table: on Qwen 3.8-27B it is 0.67 GiB of Q4_K on disk
+//! and **2.37 GiB** once expanded to BF16 — more than the KV cache, spent
+//! entirely on rows that are never read. A forward pass touches at most
+//! `seq_len` of them.
+//!
+//! [`EmbeddingLayer::Quantized`] keeps the table in its on-disk format and
+//! dequantizes only the gathered rows, via candle's `get_rows_*` kernels
+//! (CUDA/Metal) or its CPU block decoder. The saving is the whole difference
+//! between the two figures above.
+
+use std::sync::Arc;
+
+use candle_core::quantized::{GgmlDType, QMatMul, QTensor};
+use candle_core::{DType, Device, Module, Result, Tensor};
+
+/// `CRANE_EMBED_DENSE=1` restores the old behaviour — dequantize the whole
+/// table at load. An escape hatch if a backend's row gather ever misbehaves,
+/// and the A/B switch the equivalence test uses to compare both paths on one
+/// checkpoint.
+fn dense_forced() -> bool {
+    std::env::var("CRANE_EMBED_DENSE").is_ok_and(|v| v != "0" && !v.is_empty())
+}
+
+/// An embedding table, dense or quantized.
+pub enum EmbeddingLayer {
+    Dense(candle_nn::Embedding),
+    Quantized {
+        weight: Arc<QTensor>,
+        /// Compute dtype; the gather kernels always produce F32.
+        dtype: DType,
+    },
+}
+
+impl EmbeddingLayer {
+    /// Wrap a GGUF tensor, keeping it quantized when that is both possible and
+    /// worthwhile.
+    ///
+    /// Falls back to a dense table when the weight is already unquantized
+    /// (nothing to save) or when the row gather is unsupported here.
+    ///
+    /// That second condition is settled by *attempting* a one-row lookup
+    /// rather than by enumerating dtypes and backends: candle's own
+    /// preconditions (row length a whole number of blocks, a `get_rows_*`
+    /// kernel for this dtype) then apply themselves, and any combination it
+    /// cannot serve degrades at load instead of failing on the first token.
+    ///
+    /// `hidden_size` is used only to build the dense fallback; the quantized
+    /// gather reads the row length from the tensor's own shape.
+    pub fn from_qtensor(weight: QTensor, hidden_size: usize, dtype: DType) -> Result<Self> {
+        let device = weight.device();
+        let is_quantized = !matches!(
+            weight.dtype(),
+            GgmlDType::F32 | GgmlDType::F16 | GgmlDType::BF16
+        );
+
+        if is_quantized && !dense_forced() {
+            let weight = Arc::new(weight);
+            let probe =
+                Tensor::zeros((1,), DType::U32, &device).and_then(|ids| weight.embedding(&ids));
+            match probe {
+                Ok(_) => return Ok(Self::Quantized { weight, dtype }),
+                Err(e) => {
+                    eprintln!(
+                        "[embedding] quantized row gather unavailable ({e}); \
+                         falling back to a dense table"
+                    );
+                    // Reclaim the QTensor so the fallback can dequantize it.
+                    let weight = Arc::try_unwrap(weight)
+                        .map_err(|_| candle_core::Error::Msg("embedding probe leaked".into()))?;
+                    return Self::dense(&weight, hidden_size, dtype, &device);
+                }
+            }
+        }
+        Self::dense(&weight, hidden_size, dtype, &device)
+    }
+
+    fn dense(weight: &QTensor, hidden_size: usize, dtype: DType, device: &Device) -> Result<Self> {
+        let w = weight.dequantize(device)?.to_dtype(dtype)?;
+        Ok(Self::Dense(candle_nn::Embedding::new(w, hidden_size)))
+    }
+
+    pub fn dense_from_tensor(weight: Tensor, hidden_size: usize) -> Self {
+        Self::Dense(candle_nn::Embedding::new(weight, hidden_size))
+    }
+
+    /// Gather rows for `ids`, in the compute dtype.
+    pub fn forward(&self, ids: &Tensor) -> Result<Tensor> {
+        match self {
+            Self::Dense(e) => e.forward(ids),
+            Self::Quantized { weight, dtype } => weight.embedding(ids)?.to_dtype(*dtype),
+        }
+    }
+
+    /// The output projection for a checkpoint with tied weights.
+    ///
+    /// Tying means the lm_head *is* this table, so a quantized table yields a
+    /// quantized `QMatMul` over the very same buffer — no second copy, which
+    /// is the other half of the memory saving on tied models.
+    pub fn tied_output(&self) -> Result<QMatMul> {
+        match self {
+            Self::Dense(e) => Ok(QMatMul::Tensor(e.embeddings().clone())),
+            Self::Quantized { weight, .. } => QMatMul::from_arc(weight.clone()),
+        }
+    }
+
+    /// The dense weight, when this table is dense.
+    pub fn dense_weight(&self) -> Option<&Tensor> {
+        match self {
+            Self::Dense(e) => Some(e.embeddings()),
+            Self::Quantized { .. } => None,
+        }
+    }
+
+    /// Resident size of the table in bytes.
+    pub fn size_in_bytes(&self) -> usize {
+        match self {
+            Self::Dense(e) => {
+                e.embeddings().elem_count() * e.embeddings().dtype().size_in_bytes()
+            }
+            Self::Quantized { weight, .. } => weight.storage_size_in_bytes(),
+        }
+    }
+
+    pub fn is_quantized(&self) -> bool {
+        matches!(self, Self::Quantized { .. })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    /// A quantized table must gather the same rows a dense one would. Q8_0 is
+    /// accurate enough to compare against the original values directly.
+    #[test]
+    fn quantized_lookup_matches_dense_lookup() -> Result<()> {
+        let dev = Device::Cpu;
+        let (vocab, hidden) = (64usize, 256usize);
+        let data: Vec<f32> = (0..vocab * hidden).map(|i| (i % 97) as f32 * 0.01).collect();
+        let dense_w = Tensor::from_vec(data, (vocab, hidden), &dev)?;
+
+        let q = QTensor::quantize(&dense_w, GgmlDType::Q8_0)?;
+        let quantized = EmbeddingLayer::from_qtensor(q, hidden, DType::F32)?;
+        assert!(quantized.is_quantized(), "Q8_0 table should stay quantized");
+
+        let dense = EmbeddingLayer::dense_from_tensor(dense_w, hidden);
+
+        let ids = Tensor::new(&[7u32, 0, 63, 7], &dev)?;
+        let a = quantized.forward(&ids)?;
+        let b = dense.forward(&ids)?;
+        assert_eq!(a.dims(), b.dims());
+
+        let diff = (a - b)?.abs()?.max_all()?.to_scalar::<f32>()?;
+        assert!(diff < 0.02, "quantized lookup drifted by {diff}");
+        Ok(())
+    }
+
+    /// The quantized table must be markedly smaller — that is the whole point.
+    #[test]
+    fn quantized_table_is_smaller_than_dense() -> Result<()> {
+        let dev = Device::Cpu;
+        let (vocab, hidden) = (64usize, 256usize);
+        let w = Tensor::zeros((vocab, hidden), DType::F32, &dev)?;
+        let q = QTensor::quantize(&w, GgmlDType::Q4K)?;
+
+        let quantized = EmbeddingLayer::from_qtensor(q, hidden, DType::F32)?;
+        let dense = EmbeddingLayer::dense_from_tensor(w, hidden);
+        assert!(
+            quantized.size_in_bytes() * 4 < dense.size_in_bytes(),
+            "Q4_K table ({}) should be far under a third of dense F32 ({})",
+            quantized.size_in_bytes(),
+            dense.size_in_bytes()
+        );
+        Ok(())
+    }
+
+    /// Tied models must reuse the one buffer for both lookup and output
+    /// projection — a dense copy of the table would give back the saving.
+    #[test]
+    fn tied_output_reuses_the_quantized_table() -> Result<()> {
+        let dev = Device::Cpu;
+        let (vocab, hidden) = (64usize, 256usize);
+        let w = Tensor::zeros((vocab, hidden), DType::F32, &dev)?;
+        let layer = EmbeddingLayer::from_qtensor(QTensor::quantize(&w, GgmlDType::Q4K)?, hidden, DType::F32)?;
+
+        assert!(matches!(layer.tied_output()?, QMatMul::QTensor(_)));
+
+        // …and it projects to vocab logits, i.e. it is the transposed matmul
+        // a tied lm_head needs.
+        let x = Tensor::zeros((1, hidden), DType::F32, &dev)?;
+        assert_eq!(layer.tied_output()?.forward(&x)?.dims(), &[1, vocab]);
+        Ok(())
+    }
+
+    /// An unquantized GGUF tensor has nothing to gain from the gather path.
+    #[test]
+    fn unquantized_weights_stay_dense() -> Result<()> {
+        let dev = Device::Cpu;
+        let w = Tensor::zeros((8, 256), DType::F32, &dev)?;
+        let q = QTensor::quantize(&w, GgmlDType::F32)?;
+        let layer = EmbeddingLayer::from_qtensor(q, 256, DType::F32)?;
+        assert!(!layer.is_quantized());
+        Ok(())
+    }
+}

--- a/crane-core/src/models/modules/embedding.rs
+++ b/crane-core/src/models/modules/embedding.rs
@@ -15,6 +15,8 @@
 use std::sync::Arc;
 
 use candle_core::quantized::{GgmlDType, QMatMul, QTensor};
+
+use crate::ops::linear::LinearLayer;
 use candle_core::{DType, Device, Module, Result, Tensor};
 
 /// `CRANE_EMBED_DENSE=1` restores the old behaviour — dequantize the whole
@@ -100,10 +102,22 @@ impl EmbeddingLayer {
     /// Tying means the lm_head *is* this table, so a quantized table yields a
     /// quantized `QMatMul` over the very same buffer — no second copy, which
     /// is the other half of the memory saving on tied models.
-    pub fn tied_output(&self) -> Result<QMatMul> {
+    ///
+    /// Returns a [`LinearLayer`] rather than a bare `QMatMul` on purpose: a
+    /// dense table must become `LinearLayer::Standard`, because
+    /// `LinearLayer::Quantized` up-casts its input to F32 for candle's
+    /// dequantizing matmul, and `QMatMul::Tensor` is a plain matmul that does
+    /// no such casting — pairing them fails with "dtype mismatch in matmul,
+    /// lhs: F32, rhs: BF16" on the first forward.
+    pub fn tied_output(&self) -> Result<LinearLayer> {
         match self {
-            Self::Dense(e) => Ok(QMatMul::Tensor(e.embeddings().clone())),
-            Self::Quantized { weight, .. } => QMatMul::from_arc(weight.clone()),
+            Self::Dense(e) => Ok(LinearLayer::Standard(candle_nn::Linear::new(
+                e.embeddings().clone(),
+                None,
+            ))),
+            Self::Quantized { weight, .. } => {
+                Ok(LinearLayer::Quantized(QMatMul::from_arc(weight.clone())?))
+            }
         }
     }
 
@@ -160,6 +174,31 @@ mod tests {
         Ok(())
     }
 
+    /// A *dense* tied table must still work with non-F32 activations.
+    ///
+    /// Wrapping it as `LinearLayer::Quantized` type-checks but fails on the
+    /// first forward with "dtype mismatch in matmul, lhs: F32, rhs: BF16",
+    /// because that variant up-casts its input for candle's dequantizing
+    /// matmul while `QMatMul::Tensor` does no casting of its own. That is how
+    /// `CRANE_EMBED_DENSE=1` broke on tied checkpoints.
+    #[test]
+    fn dense_tied_output_accepts_non_f32_activations() -> Result<()> {
+        let dev = Device::Cpu;
+        let (vocab, hidden) = (16usize, 32usize);
+        // Non-F32 activations are the trigger; the loader uses BF16 on CUDA
+        // and F16 on Metal/ROCm. F16 here because candle's CPU matmul has no
+        // BF16 kernel, and the distinction that matters is only "not F32".
+        let w = Tensor::zeros((vocab, hidden), DType::F16, &dev)?;
+        let layer = EmbeddingLayer::dense_from_tensor(w, hidden);
+
+        assert!(matches!(layer.tied_output()?, LinearLayer::Standard(_)));
+
+        let x = Tensor::zeros((1, 1, hidden), DType::F16, &dev)?;
+        let y = layer.tied_output()?.forward(&x)?;
+        assert_eq!(y.dims(), &[1, 1, vocab]);
+        Ok(())
+    }
+
     /// The quantized table must be markedly smaller — that is the whole point.
     #[test]
     fn quantized_table_is_smaller_than_dense() -> Result<()> {
@@ -188,7 +227,7 @@ mod tests {
         let w = Tensor::zeros((vocab, hidden), DType::F32, &dev)?;
         let layer = EmbeddingLayer::from_qtensor(QTensor::quantize(&w, GgmlDType::Q4K)?, hidden, DType::F32)?;
 
-        assert!(matches!(layer.tied_output()?, QMatMul::QTensor(_)));
+        assert!(matches!(layer.tied_output()?, LinearLayer::Quantized(QMatMul::QTensor(_))));
 
         // …and it projects to vocab logits, i.e. it is the transposed matmul
         // a tied lm_head needs.

--- a/crane-core/src/models/modules/mod.rs
+++ b/crane-core/src/models/modules/mod.rs
@@ -1,5 +1,6 @@
 // pub mod conn_ve_llm;
 pub mod attention;
+pub mod embedding;
 pub mod ffn;
 pub mod flash_attn;
 pub(crate) mod kv_cache;

--- a/crane-core/src/models/qwen3_5/config.rs
+++ b/crane-core/src/models/qwen3_5/config.rs
@@ -3,6 +3,11 @@
 //! Qwen 3.5 ships as `Qwen3_5ForConditionalGeneration` (multimodal class) but
 //! the dense text-only checkpoints have no vision weights — we deserialize the
 //! nested `text_config` and ignore the vision block when loading weights.
+//!
+//! The Qwen 3.6 / 3.8 27B dense checkpoints declare the *same*
+//! `model_type: "qwen3_5"` and are the same architecture scaled up (64 layers,
+//! `hidden_size` 5120, 48 GDN value heads, untied `lm_head`), so they load
+//! through these same types — every difference is a config value.
 
 use candle_core::Result;
 use serde::Deserialize;
@@ -69,6 +74,16 @@ pub struct TextConfig {
     // Qwen 3.5 attention uses gated output (sigmoid gate on softmax attention).
     #[serde(default = "default_true")]
     pub attn_output_gate: bool,
+
+    /// Activation of the **Gated Delta Net** output gate (HF `RMSNormGated`),
+    /// *not* the softmax-attention gate above — that one is always sigmoid.
+    ///
+    /// Absent in Qwen 3.5 (implicitly swish); the Qwen 3.6/3.8 27B configs
+    /// spell it out as `"swish"`. Only swish/silu is supported, which is what
+    /// [`crate::ops::gdn::RmsNormGated`] already computes, so a present-and-
+    /// swish value is a no-op. Validated by [`TextConfig::validate`].
+    #[serde(default)]
+    pub output_gate_type: Option<String>,
 }
 
 fn default_true() -> bool {
@@ -173,6 +188,23 @@ pub enum HiddenAct {
 }
 
 impl TextConfig {
+    /// Reject configs whose semantics this implementation does not match.
+    ///
+    /// The only such knob today is [`Self::output_gate_type`]: the GDN gate is
+    /// hardwired to swish, so any other activation would silently produce
+    /// wrong activations rather than fail loudly.
+    pub fn validate(&self) -> Result<()> {
+        if let Some(gate) = &self.output_gate_type
+            && !matches!(gate.as_str(), "swish" | "silu")
+        {
+            candle_core::bail!(
+                "[qwen3_5] unsupported output_gate_type {gate:?}: the GDN output gate is \
+                 implemented as swish (== silu) only"
+            );
+        }
+        Ok(())
+    }
+
     pub fn rope_theta(&self) -> f64 {
         self.rope_parameters.rope_theta
     }
@@ -254,5 +286,97 @@ pub fn load_config(path: &str) -> Result<Config> {
         .map_err(|e| candle_core::Error::Msg(format!("read config {path}: {e}")))?;
     let cfg: Config = serde_json::from_slice(&data)
         .map_err(|e| candle_core::Error::Msg(format!("parse config {path}: {e}")))?;
+    cfg.text_config.validate()?;
     Ok(cfg)
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The Qwen 3.8-27B (and, identically, Qwen 3.6-27B) `text_config`, minus
+    /// the keys this implementation ignores.
+    const QWEN3_8_27B_TEXT: &str = r#"{
+        "head_dim": 256,
+        "vocab_size": 248320,
+        "hidden_size": 5120,
+        "intermediate_size": 17408,
+        "num_hidden_layers": 64,
+        "num_attention_heads": 24,
+        "num_key_value_heads": 4,
+        "hidden_act": "silu",
+        "max_position_embeddings": 262144,
+        "rms_norm_eps": 1e-06,
+        "attn_output_gate": true,
+        "output_gate_type": "swish",
+        "full_attention_interval": 4,
+        "linear_conv_kernel_dim": 4,
+        "linear_key_head_dim": 128,
+        "linear_value_head_dim": 128,
+        "linear_num_key_heads": 16,
+        "linear_num_value_heads": 48,
+        "tie_word_embeddings": false,
+        "rope_parameters": {
+            "mrope_interleaved": true,
+            "mrope_section": [11, 11, 10],
+            "partial_rotary_factor": 0.25,
+            "rope_theta": 10000000
+        }
+    }"#;
+
+    fn qwen3_8() -> TextConfig {
+        serde_json::from_str(QWEN3_8_27B_TEXT).expect("parse Qwen3.8-27B text_config")
+    }
+
+    /// Qwen 3.8 parses through the Qwen 3.5 types unchanged, and the derived
+    /// dimensions come out at the shapes the checkpoint actually ships.
+    #[test]
+    fn qwen3_8_27b_config_derives_checkpoint_shapes() {
+        let cfg = qwen3_8();
+        cfg.validate().unwrap();
+
+        // `q_proj` is [12288, 5120] on disk: 2 x heads x head_dim (gated).
+        assert!(cfg.attn_output_gate);
+        assert_eq!(2 * cfg.num_attention_heads * cfg.head_dim, 12288);
+        // `in_proj_qkv` is [10240, 5120], `in_proj_z` is [6144, 5120].
+        assert_eq!(cfg.linear_conv_dim(), 10240);
+        assert_eq!(cfg.linear_value_dim(), 6144);
+        assert_eq!(cfg.linear_key_dim(), 2048);
+        // rope.dimension_count 64 = head_dim * partial_rotary_factor, and the
+        // mrope sections tile half of it.
+        assert_eq!(cfg.rot_dim(), 64);
+        assert_eq!(cfg.mrope_section().iter().sum::<usize>(), cfg.rot_dim() / 2);
+        assert!(cfg.mrope_interleaved());
+        // 16 of 64 layers are full attention, the last of every group of 4.
+        let types = cfg.layer_types();
+        assert_eq!(types.len(), 64);
+        assert_eq!(types.iter().filter(|t| **t == LayerType::FullAttention).count(), 16);
+        assert_eq!(types[3], LayerType::FullAttention);
+        assert_eq!(types[2], LayerType::LinearAttention);
+        // Three value heads per key head — the case that never arises on the
+        // Qwen 3.5 0.8B (1) or 4B (2).
+        assert_eq!(cfg.linear_num_value_heads / cfg.linear_num_key_heads, 3);
+    }
+
+    /// `output_gate_type` names the GDN gate, which is swish-only here. Qwen
+    /// 3.5 omits the key entirely.
+    #[test]
+    fn output_gate_type_accepts_swish_and_absent() {
+        assert_eq!(qwen3_8().output_gate_type.as_deref(), Some("swish"));
+        qwen3_8().validate().unwrap();
+
+        let mut cfg = qwen3_8();
+        cfg.output_gate_type = Some("silu".into());
+        cfg.validate().unwrap();
+
+        cfg.output_gate_type = None;
+        cfg.validate().unwrap();
+    }
+
+    #[test]
+    fn output_gate_type_rejects_unimplemented_activation() {
+        let mut cfg = qwen3_8();
+        cfg.output_gate_type = Some("sigmoid".into());
+        let err = cfg.validate().unwrap_err().to_string();
+        assert!(err.contains("output_gate_type"), "unexpected error: {err}");
+    }
 }

--- a/crane-core/src/models/qwen3_5/model.rs
+++ b/crane-core/src/models/qwen3_5/model.rs
@@ -296,7 +296,7 @@ impl Qwen3_5TextModel {
         let lm_head = if tie_word_embeddings {
             // Tied: the output projection is this very table, so it reuses the
             // same buffer rather than materializing a dense copy.
-            LinearLayer::Quantized(embed_tokens.tied_output()?)
+            embed_tokens.tied_output()?
         } else {
             gg.linear("output.weight")?
         };

--- a/crane-core/src/models/qwen3_5/model.rs
+++ b/crane-core/src/models/qwen3_5/model.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 use anyhow::{Context, Error as E, Result};
 use candle_core::quantized::GgmlDType;
 use candle_core::{DType, Device, Module, Tensor};
-use candle_nn::{embedding, Embedding, Linear, VarBuilder};
+use candle_nn::{embedding, Linear, VarBuilder};
 
 use crate::utils::DeviceExt;
 use crate::ops::linear::{parse_ggml_dtype, quantize_linear, LinearLayer};
@@ -20,6 +20,7 @@ use super::modeling::{DecoderLayer, MRotaryEmbedding, Qwen35RmsNorm, RopeSlice};
 use crate::generation::based::ModelForCausalLM;
 use crate::generation::GenerationConfig;
 use crate::models::hunyuan_dense::modeling::Gguf;
+use crate::models::modules::embedding::EmbeddingLayer;
 use crate::utils::token_output_stream::TokenOutputStream;
 use crate::utils::utils;
 
@@ -30,7 +31,7 @@ use crate::utils::utils;
 /// these caches across context switches (continuous batching).
 pub struct Qwen3_5TextModel {
     cfg: TextConfig,
-    embed_tokens: Embedding,
+    embed_tokens: EmbeddingLayer,
     layers: Vec<DecoderLayer>,
     norm: Qwen35RmsNorm,
     lm_head: LinearLayer,
@@ -77,6 +78,8 @@ impl Qwen3_5TextModel {
             text_cfg.hidden_size,
             vb_lm.pp("embed_tokens"),
         )?;
+        let embed_weight = embed_tokens.embeddings().clone();
+        let embed_tokens = EmbeddingLayer::Dense(embed_tokens);
 
         let layer_types = text_cfg.layer_types();
         let mut layers = Vec::with_capacity(text_cfg.num_hidden_layers);
@@ -95,7 +98,6 @@ impl Qwen3_5TextModel {
         // ship a dedicated `lm_head.weight` of shape `[vocab, hidden]`. That
         // tensor lives at the checkpoint ROOT, not under the `language_model`
         // prefix, so probe `vb` first and fall back to `vb_lm`.
-        let embed_weight = embed_tokens.embeddings().clone();
         let (lm_head_raw, is_tied) = if cfg.tie_word_embeddings {
             (embed_weight, true)
         } else {
@@ -273,9 +275,14 @@ impl Qwen3_5TextModel {
             linear_num_value_heads: num_v_heads,
             tie_word_embeddings,
             attn_output_gate,
+            // GGUF carries no gate-activation key; the conversion only ever
+            // targets the swish gate this code implements.
+            output_gate_type: None,
         };
 
-        let embed_tokens = gg.embedding("token_embd.weight", hidden_size)?;
+        // The 248k-row table is the single largest dequantization in the
+        // checkpoint; keep it in its GGUF format and gather rows on demand.
+        let embed_tokens = gg.quantized_embedding("token_embd.weight", hidden_size)?;
 
         let mut layers = Vec::with_capacity(num_hidden_layers);
         for (idx, &layer_type) in layer_types.iter().enumerate() {
@@ -287,7 +294,9 @@ impl Qwen3_5TextModel {
             rms_norm_eps,
         );
         let lm_head = if tie_word_embeddings {
-            LinearLayer::Standard(Linear::new(embed_tokens.embeddings().clone(), None))
+            // Tied: the output projection is this very table, so it reuses the
+            // same buffer rather than materializing a dense copy.
+            LinearLayer::Quantized(embed_tokens.tied_output()?)
         } else {
             gg.linear("output.weight")?
         };

--- a/crane-core/src/models/qwen3_5/modeling.rs
+++ b/crane-core/src/models/qwen3_5/modeling.rs
@@ -301,6 +301,16 @@ pub struct RopeSlice<'a> {
 ///   gate applied to the attention output.
 /// - Per-head QK-norm is always present (`q_norm`, `k_norm` of size `head_dim`).
 /// - RoPE is MRoPE-interleaved applied only to the first `rot_dim` components.
+/// `CRANE_ATTN_EXPAND=1` forces the legacy GQA-expansion path at decode
+/// instead of the grouped matmul. The two are mathematically identical, so
+/// this exists to A/B them: same binary, same weights, one variable.
+fn legacy_attn_expand() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| {
+        std::env::var("CRANE_ATTN_EXPAND").is_ok_and(|v| !matches!(v.trim(), "" | "0"))
+    })
+}
+
 pub struct FullAttention {
     q_proj: LinearLayer,
     k_proj: LinearLayer,
@@ -454,6 +464,51 @@ impl FullAttention {
 
         let n_rep = self.num_heads / self.num_kv_heads;
         let scale = 1.0 / (self.head_dim as f64).sqrt();
+
+        if n_rep > 1 && seq_len == 1 && !legacy_attn_expand() {
+            // ── GQA-grouped SDPA for decode ──
+            //
+            // The expansion below materializes `k_rep`, `v_rep` and `k_t`, each
+            // `[B, num_heads, S, D]`, i.e. three O(context) copies per layer per
+            // token. On Qwen3.8-27B (24 q / 4 KV heads, 16 full-attn layers)
+            // that is 1.7 GB of traffic per token at 2912 tokens of context and
+            // it grows linearly with depth — the sole cause of decode falling
+            // from 16.9 t/s to 8.6 t/s between 512 and 4096 tokens.
+            //
+            // Instead fold the `n_rep` query heads sharing a KV head into the
+            // matmul's row dimension, so K/V are read once at their stored
+            // 4-head width. Ported from `models/qwen3/modeling.rs`, which has
+            // carried this since its own GQA work; `k_t` deliberately stays a
+            // view so matmul flattens it in one pass rather than us paying an
+            // explicit `contiguous()`.
+            let q_g = (q.reshape((b_sz, self.num_kv_heads, n_rep, self.head_dim))? * scale)?;
+            let k_t = k.transpose(2, 3)?; // [B, kv_heads, D, S] — view only
+            let attn_weights = q_g.matmul(&k_t)?; // [B, kv_heads, n_rep, S]
+
+            let attn_weights = match attention_mask {
+                // mask [B, 1, 1, S] broadcasts over kv_heads and n_rep
+                Some(mask) => attn_weights.broadcast_add(mask)?,
+                None => attn_weights,
+            };
+            let attn_weights = candle_nn::ops::softmax_last_dim(&attn_weights)?;
+            let y = attn_weights.matmul(&v)?; // [B, kv_heads, n_rep, D]
+
+            // Back to `[B, 1, num_heads * head_dim]`. Head order is preserved:
+            // `q` was reshaped from `[B, H, 1, D]` with H == kv_heads * n_rep in
+            // that order, so flattening the two group dims restores it.
+            let y = y.reshape((b_sz, seq_len, self.num_heads * self.head_dim))?;
+
+            // Qwen 3.5 gates the attention output before `o_proj` — the one
+            // adaptation this path needs versus the qwen3 original.
+            let y = match gate {
+                Some(g) => {
+                    let gate = candle_nn::ops::sigmoid(&g.to_dtype(y.dtype())?)?;
+                    y.broadcast_mul(&gate)?
+                }
+                None => y,
+            };
+            return self.o_proj.forward(&y);
+        }
 
         let k_rep = if n_rep > 1 {
             let (b, kv_heads, s, d) = k.dims4()?;

--- a/crane-core/src/models/qwen3_5/prefill.rs
+++ b/crane-core/src/models/qwen3_5/prefill.rs
@@ -211,6 +211,7 @@ mod tests {
                 linear_num_value_heads: 4,
                 tie_word_embeddings: true,
                 attn_output_gate: true,
+                output_gate_type: None,
             },
             vision_config: None,
             image_token_id: None,

--- a/crane-core/src/models/qwen3_6/mod.rs
+++ b/crane-core/src/models/qwen3_6/mod.rs
@@ -1,6 +1,19 @@
-// placeholder package for Qwen3.6
-// Qwen3.6 27B with Bonsai Ternary could be runing on Desktop withonly 5GB mem
-// while kept about 95% original ability
-// https://huggingface.co/prism-ml/Ternary-Bonsai-27B-gguf/tree/main
-// Qwen3.6 holds almost identical arch as Qwen3.5
-// We need consider support MTP & DSpark in this version.
+//! Qwen 3.6 / Qwen 3.8 — no code of their own.
+//!
+//! Both are the Qwen 3.5 architecture scaled up, and say so themselves: the
+//! 27B checkpoints declare `model_type: "qwen3_5"` /
+//! `architectures: ["Qwen3_5ForConditionalGeneration"]`, and their GGUF
+//! conversions carry `general.architecture = "qwen35"`. Qwen 3.6-27B and
+//! Qwen 3.8-27B have byte-identical `text_config` blocks.
+//!
+//! Load them through [`crate::models::qwen3_5`]; every difference from a
+//! Qwen 3.5 checkpoint is a config value (64 layers, `hidden_size` 5120,
+//! 24 query / 4 KV heads, 48 GDN value heads so `v_per_group == 3`, untied
+//! `lm_head`, ViT depth 27 / hidden 1152, and an explicit
+//! `output_gate_type: "swish"` naming the GDN gate that module already
+//! implements).
+//!
+//! Still open, and the only genuinely new capability these checkpoints ship:
+//! the MTP draft head (`mtp.*` weights in safetensors, a separate
+//! `mtp-*.gguf` alongside the main file) for speculative decoding. Those
+//! tensors are simply not loaded today.

--- a/crane-core/src/ops/gdn/conv.rs
+++ b/crane-core/src/ops/gdn/conv.rs
@@ -27,6 +27,9 @@ pub fn causal_conv1d(
     cache: &mut GdnLayerCache,
 ) -> Result<Tensor> {
     let (_, seq_len, _) = x.dims3()?;
+    if seq_len == 1 {
+        return decode_conv1d(x, conv1d_weight, cache);
+    }
     let x_t = x.transpose(1, 2)?.contiguous()?;
     // `conv_state` is shape `[1, conv_dim, kernel_size]` — the kernel-size
     // dim is the LAST (matches mistral.rs).
@@ -52,6 +55,52 @@ pub fn causal_conv1d(
             ))
         })?;
     let out = shift_accumulate(&hidden, &weight, seq_len, offset)?;
+    candle_nn::ops::silu(&out)?.transpose(1, 2)
+}
+
+/// Single-token specialization of [`causal_conv1d`], for decode.
+///
+/// Identical arithmetic, far fewer kernel launches. Decode is dispatch-bound —
+/// the CPU spends ~41 ms of a 53 ms token merely submitting work on
+/// Qwen3.8-27B — and the general path costs ~12 launches per GDN layer, so
+/// ~576 across that model's 48 GDN layers. Three things collapse at
+/// `seq_len == 1`:
+///
+/// * the `kernel` shifted multiply-accumulates become one broadcast multiply
+///   plus one reduction (7 launches → 2),
+/// * the `[B,1,C] → [B,C,1]` transpose is a pure reshape, so no copy, and
+/// * the convolution window and the next call's `conv_state` are the *same*
+///   `kernel`-wide slice, so it is materialized once instead of twice.
+///
+/// Verified against the general path by `decode_matches_general_path`.
+fn decode_conv1d(
+    x: &Tensor,
+    conv1d_weight: &Tensor,
+    cache: &mut GdnLayerCache,
+) -> Result<Tensor> {
+    let (b, _, c) = x.dims3()?;
+    let kernel = cache.conv_state.dim(2)?;
+
+    // `[B, 1, C] → [B, C, 1]` moves no data when the source is contiguous —
+    // both layouts enumerate the same C values in the same order.
+    let x_t = if x.is_contiguous() {
+        x.reshape((b, c, 1))?
+    } else {
+        x.transpose(1, 2)?.contiguous()?
+    };
+
+    let hidden = Tensor::cat(&[&cache.conv_state, &x_t], 2)?; // [B, C, kernel + 1]
+    // Positions `1..=kernel` are simultaneously the window this token
+    // convolves over and the state the next token starts from, so one copy
+    // serves both.
+    let window = hidden.narrow(2, 1, kernel)?.contiguous()?;
+    cache.conv_state = window.clone();
+
+    let w = conv1d_weight
+        .squeeze(1)?
+        .to_dtype(window.dtype())?
+        .unsqueeze(0)?; // [1, C, kernel]
+    let out = window.broadcast_mul(&w)?.sum_keepdim(2)?; // [B, C, 1]
     candle_nn::ops::silu(&out)?.transpose(1, 2)
 }
 
@@ -166,6 +215,75 @@ mod tests {
             .unwrap();
         for (a, b) in ws.iter().zip(&cs) {
             assert!((a - b).abs() < 1e-6, "conv state {a} != {b}");
+        }
+    }
+
+    /// Token-at-a-time decode must reproduce the whole-sequence result exactly.
+    ///
+    /// `causal_conv1d` routes every `seq_len == 1` call to `decode_conv1d`,
+    /// which fuses the shifted multiply-accumulates into one broadcast multiply
+    /// plus a reduction and shares a single copy between the convolution window
+    /// and the next `conv_state`. That is a different expression of the same
+    /// arithmetic, so it is pinned here rather than assumed — a drift would
+    /// only show up as slightly-wrong generations.
+    #[test]
+    fn decode_matches_general_path() {
+        let dev = Device::Cpu;
+        let (conv_dim, kernel, seq_len) = (6usize, 4usize, 9usize);
+        let d = dims(conv_dim, kernel);
+        let x = Tensor::rand(-1f32, 1.0, (1, seq_len, conv_dim), &dev).unwrap();
+        let w = Tensor::rand(-1f32, 1.0, (conv_dim, 1, kernel), &dev).unwrap();
+
+        let mut whole_cache = empty_cache(conv_dim, kernel, &dev);
+        let whole = causal_conv1d(&x, &w, &d, &mut whole_cache).unwrap();
+
+        // One token at a time — every call takes the decode path.
+        let mut step_cache = empty_cache(conv_dim, kernel, &dev);
+        let mut steps = Vec::with_capacity(seq_len);
+        for t in 0..seq_len {
+            let tok = x.narrow(1, t, 1).unwrap().contiguous().unwrap();
+            steps.push(causal_conv1d(&tok, &w, &d, &mut step_cache).unwrap());
+        }
+        let stepped = Tensor::cat(&steps, 1).unwrap();
+
+        assert_eq!(whole.dims(), stepped.dims());
+        let whole_v = whole.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let step_v = stepped.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        for (a, b) in whole_v.iter().zip(&step_v) {
+            assert!((a - b).abs() < 1e-6, "decode output {a} != whole-pass {b}");
+        }
+
+        // And the carried state, or the *next* token diverges silently.
+        let ws = whole_cache.conv_state.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let ss = step_cache.conv_state.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        for (a, b) in ws.iter().zip(&ss) {
+            assert!((a - b).abs() < 1e-6, "decode conv state {a} != {b}");
+        }
+    }
+
+    /// A non-contiguous single token must still work: the decode path reshapes
+    /// instead of transposing only when the source is contiguous.
+    #[test]
+    fn decode_handles_non_contiguous_input() {
+        let dev = Device::Cpu;
+        let (conv_dim, kernel) = (6usize, 4usize);
+        let d = dims(conv_dim, kernel);
+        let w = Tensor::rand(-1f32, 1.0, (conv_dim, 1, kernel), &dev).unwrap();
+
+        // Slice a token out of a wider buffer without compacting it.
+        let wide = Tensor::rand(-1f32, 1.0, (1, 3, conv_dim), &dev).unwrap();
+        let strided = wide.narrow(1, 1, 1).unwrap();
+        let compact = strided.contiguous().unwrap();
+
+        let mut c1 = empty_cache(conv_dim, kernel, &dev);
+        let mut c2 = empty_cache(conv_dim, kernel, &dev);
+        let a = causal_conv1d(&strided, &w, &d, &mut c1).unwrap();
+        let b = causal_conv1d(&compact, &w, &d, &mut c2).unwrap();
+
+        let a = a.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        let b = b.flatten_all().unwrap().to_vec1::<f32>().unwrap();
+        for (x, y) in a.iter().zip(&b) {
+            assert!((x - y).abs() < 1e-6, "{x} != {y}");
         }
     }
 

--- a/crane-core/tests/qwen3_5_gqa_expand_cost.rs
+++ b/crane-core/tests/qwen3_5_gqa_expand_cost.rs
@@ -1,0 +1,112 @@
+//! Cost of the GQA expansion in the Qwen 3.5/3.8 decode attention path.
+//!
+//! `FullAttention::forward` materializes three full-context tensors per
+//! full-attention layer per decoded token: `k_rep` and `v_rep` (the 4→24 head
+//! GQA expansion) and `k_t` (a transposed copy of `k_rep`). All three are
+//! O(context length), so their cost grows linearly with depth even though a
+//! decode step processes a single token — which is why Qwen3.8-27B decode
+//! falls from 16.9 t/s at 512 tokens of context to 8.6 t/s at 4096, while
+//! llama.cpp (which never materializes the expansion) stays flat.
+//!
+//! ```sh
+//! cargo test -p crane-core --release --features cuda \
+//!   --test qwen3_5_gqa_expand_cost -- --ignored --nocapture
+//! ```
+use candle_core::{DType, Device, Tensor, D};
+
+// Qwen3.8-27B full-attention geometry.
+const KV_HEADS: usize = 4;
+const N_REP: usize = 6; // 24 query heads / 4 KV heads
+const HEAD_DIM: usize = 256;
+const FULL_ATTN_LAYERS: usize = 16;
+
+#[test]
+#[ignore = "needs a CUDA device"]
+fn gqa_expansion_cost_grows_linearly_with_context() {
+    let dev = match Device::new_cuda(0) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("skipped: no CUDA device ({e})");
+            return;
+        }
+    };
+
+    println!(
+        "{:>6} | {:>13} | {:>12} | {:>12} | {:>7}",
+        "ctx", "bytes/token", "expand ms", "grouped ms", "saved"
+    );
+    for &s in &[312usize, 1412, 2912, 4096] {
+        let k = Tensor::zeros((1, KV_HEADS, s, HEAD_DIM), DType::BF16, &dev).unwrap();
+        let v = Tensor::zeros((1, KV_HEADS, s, HEAD_DIM), DType::BF16, &dev).unwrap();
+        // Decode: one query token, 24 heads.
+        let q = Tensor::zeros((1, KV_HEADS * N_REP, 1, HEAD_DIM), DType::BF16, &dev).unwrap();
+
+        let bench = |f: &dyn Fn()| -> f64 {
+            // Warm the allocator so this times the steady state, not first touch.
+            for _ in 0..3 {
+                f();
+            }
+            dev.synchronize().unwrap();
+            let iters = 10;
+            let t0 = std::time::Instant::now();
+            for _ in 0..iters * FULL_ATTN_LAYERS {
+                f();
+            }
+            dev.synchronize().unwrap();
+            t0.elapsed().as_secs_f64() * 1000.0 / iters as f64
+        };
+
+        let expand_ms = bench(&|| expand_once(&k, &v));
+        let grouped_ms = bench(&|| grouped_once(&q, &k, &v));
+
+        // 3 materialized tensors, each [1, 24, s, 256] bf16, per layer.
+        let bytes = 3.0 * (N_REP * KV_HEADS * s * HEAD_DIM * 2) as f64 * FULL_ATTN_LAYERS as f64;
+        println!(
+            "{s:>6} | {:>10.1} MB | {expand_ms:>9.2} ms | {grouped_ms:>9.2} ms | {:>6.1}x",
+            bytes / 1e6,
+            expand_ms / grouped_ms
+        );
+    }
+}
+
+/// The expansion-free equivalent: fold the `n_rep` query heads that share a KV
+/// head into the matmul's row dimension, so K/V are read once at their stored
+/// 4-head width instead of being broadcast to 24 and copied.
+fn grouped_once(q: &Tensor, k: &Tensor, v: &Tensor) {
+    let (b, kv, s, d) = k.dims4().unwrap();
+    // [b, 24, 1, d] -> [b, 4, 6, d]: the 6 query heads of one KV group become
+    // rows of a single small matmul against that group's K.
+    let qg = q.reshape((b, kv, N_REP, d)).unwrap();
+    let kt = k.transpose(D::Minus2, D::Minus1).unwrap().contiguous().unwrap();
+    let scores = qg.matmul(&kt).unwrap(); // [b, 4, 6, s]
+    let w = candle_nn::ops::softmax_last_dim(&scores).unwrap();
+    let _y = w.matmul(v).unwrap(); // [b, 4, 6, d]
+    let _ = s;
+}
+
+fn expand_once(k: &Tensor, v: &Tensor) {
+    let (b, kv, s, d) = k.dims4().unwrap();
+    let k_rep = k
+        .unsqueeze(2)
+        .unwrap()
+        .expand((b, kv, N_REP, s, d))
+        .unwrap()
+        .contiguous()
+        .unwrap()
+        .reshape((b, kv * N_REP, s, d))
+        .unwrap();
+    let _v_rep = v
+        .unsqueeze(2)
+        .unwrap()
+        .expand((b, kv, N_REP, s, d))
+        .unwrap()
+        .contiguous()
+        .unwrap()
+        .reshape((b, kv * N_REP, s, d))
+        .unwrap();
+    let _k_t = k_rep
+        .transpose(D::Minus2, D::Minus1)
+        .unwrap()
+        .contiguous()
+        .unwrap();
+}

--- a/crane-core/tests/qwen3_5_gqa_grouped_decode.rs
+++ b/crane-core/tests/qwen3_5_gqa_grouped_decode.rs
@@ -1,0 +1,147 @@
+//! Equivalence of the grouped-GQA decode path with the legacy expansion path.
+//!
+//! `FullAttention::forward` used to materialize `k_rep`, `v_rep` and `k_t` at
+//! full context width on every decoded token — three O(context) copies per
+//! full-attention layer. The decode path now folds the `n_rep` query heads that
+//! share a KV head into the matmul's row dimension instead, reading K/V once at
+//! their stored width.
+//!
+//! The reformulation is supposed to be exact, so this pins that down two ways:
+//! the raw tensor algebra, and end-to-end greedy decoding of a real checkpoint
+//! with `CRANE_ATTN_EXPAND=1` selecting the old path in the same binary.
+//!
+//! ```sh
+//! CRANE_QWEN35_GGUF=/path/to/Qwen3.5-4B-Q6_K.gguf \
+//!   cargo test -p crane-core --release --features cuda \
+//!     --test qwen3_5_gqa_grouped_decode -- --ignored --nocapture --test-threads=1
+//! ```
+
+use candle_core::{DType, Device, Tensor, D};
+use crane_core::generation::based::ModelForCausalLM;
+use crane_core::generation::GenerationConfig;
+use crane_core::models::qwen3_5::{Model, ModelFormat};
+
+const PROMPT: &str =
+    "<|im_start|>user\nBriefly explain what a crane (the bird) looks like.<|im_end|>\n<|im_start|>assistant\n";
+const MAX_NEW_TOKENS: usize = 48;
+
+fn device() -> Device {
+    #[cfg(feature = "cuda")]
+    if candle_core::utils::cuda_is_available() {
+        return Device::new_cuda(0).unwrap();
+    }
+    Device::Cpu
+}
+
+/// The two formulations, on the same random Q/K/V.
+///
+/// Runs on whatever device is available — the algebra is device-independent,
+/// so this is useful even on a CPU-only machine.
+#[test]
+fn grouped_decode_matches_expansion_math() -> candle_core::Result<()> {
+    let dev = device();
+    // Qwen3.8-27B geometry: 24 query heads over 4 KV heads.
+    let (b, kv_heads, n_rep, d, s) = (1usize, 4usize, 6usize, 256usize, 733usize);
+    let heads = kv_heads * n_rep;
+    let scale = 1.0 / (d as f64).sqrt();
+
+    let q = Tensor::randn(0f32, 1f32, (b, heads, 1, d), &dev)?;
+    let k = Tensor::randn(0f32, 1f32, (b, kv_heads, s, d), &dev)?;
+    let v = Tensor::randn(0f32, 1f32, (b, kv_heads, s, d), &dev)?;
+
+    // ── legacy: expand K/V to 24 heads, then standard SDPA ──
+    let k_rep = k
+        .unsqueeze(2)?
+        .expand((b, kv_heads, n_rep, s, d))?
+        .contiguous()?
+        .reshape((b, heads, s, d))?;
+    let v_rep = v
+        .unsqueeze(2)?
+        .expand((b, kv_heads, n_rep, s, d))?
+        .contiguous()?
+        .reshape((b, heads, s, d))?;
+    let k_t = k_rep.transpose(D::Minus2, D::Minus1)?.contiguous()?;
+    let logits = (q.matmul(&k_t)? * scale)?;
+    let w = candle_nn::ops::softmax_last_dim(&logits)?;
+    let expected = w.matmul(&v_rep)?.reshape((b, 1, heads * d))?;
+
+    // ── grouped: fold n_rep into the matmul rows, K/V read at stored width ──
+    let q_g = (q.reshape((b, kv_heads, n_rep, d))? * scale)?;
+    let k_t2 = k.transpose(2, 3)?;
+    let w2 = candle_nn::ops::softmax_last_dim(&q_g.matmul(&k_t2)?)?;
+    let got = w2.matmul(&v)?.reshape((b, 1, heads * d))?;
+
+    assert_eq!(got.dims(), expected.dims());
+    let max_abs = (got - expected)?.abs()?.max_all()?.to_scalar::<f32>()?;
+    println!("grouped vs expansion, max|Δ| = {max_abs:.3e}");
+    // Same operations in a different association order; only float reassociation
+    // should separate them.
+    assert!(max_abs < 1e-4, "grouped decode diverged from expansion: {max_abs:e}");
+    Ok(())
+}
+
+/// Head order must survive the regroup: `[B, H, 1, D]` reshaped through
+/// `[B, kv_heads, n_rep, D]` and back has to land each head where `o_proj`
+/// expects it. A transposition here would still produce plausible text, so it
+/// is checked directly rather than left to the eyeball.
+#[test]
+fn regroup_preserves_head_order() -> candle_core::Result<()> {
+    let dev = device();
+    let (b, kv_heads, n_rep, d) = (1usize, 4usize, 6usize, 8usize);
+    let heads = kv_heads * n_rep;
+
+    // Head i carries the constant value i, so any permutation is visible.
+    let per_head: Vec<f32> = (0..heads)
+        .flat_map(|h| std::iter::repeat(h as f32).take(d))
+        .collect();
+    let x = Tensor::from_vec(per_head.clone(), (b, heads, 1, d), &dev)?;
+
+    let regrouped = x.reshape((b, kv_heads, n_rep, d))?.reshape((b, 1, heads * d))?;
+    let flat = regrouped.flatten_all()?.to_vec1::<f32>()?;
+    assert_eq!(flat, per_head, "head order changed across the regroup");
+    Ok(())
+}
+
+fn greedy(gguf: &str, legacy: bool) -> Vec<u32> {
+    // SAFETY: single-threaded test (`--test-threads=1`); read once per forward,
+    // memoized in a OnceLock inside the model, so it must be set before load.
+    unsafe {
+        if legacy {
+            std::env::set_var("CRANE_ATTN_EXPAND", "1");
+        } else {
+            std::env::remove_var("CRANE_ATTN_EXPAND");
+        }
+    }
+    let dev = device();
+    let dtype = if dev.is_cpu() { DType::F32 } else { DType::F16 };
+    let mut model = Model::new_with_format(gguf, &dev, &dtype, ModelFormat::Gguf).expect("load");
+    let ids = model.prepare_inputs(PROMPT).expect("tokenize");
+    let cfg = GenerationConfig {
+        max_new_tokens: MAX_NEW_TOKENS,
+        temperature: None,
+        top_p: None,
+        ..Default::default()
+    };
+    let out = model.generate(&ids, &cfg, None).expect("generate");
+    out[ids.len()..].to_vec()
+}
+
+/// End-to-end: the same checkpoint decoded both ways must say the same thing.
+#[test]
+#[ignore = "needs a local Qwen3.5-family GGUF (CRANE_QWEN35_GGUF)"]
+fn grouped_decode_matches_expansion_end_to_end() {
+    let Ok(gguf) = std::env::var("CRANE_QWEN35_GGUF") else {
+        eprintln!("skipped: set CRANE_QWEN35_GGUF");
+        return;
+    };
+    let grouped = greedy(&gguf, false);
+    let legacy = greedy(&gguf, true);
+    unsafe { std::env::remove_var("CRANE_ATTN_EXPAND") };
+
+    println!("grouped: {grouped:?}");
+    println!("legacy : {legacy:?}");
+    assert_eq!(
+        grouped, legacy,
+        "grouped decode changed greedy output vs the expansion path"
+    );
+}

--- a/crane-core/tests/qwen3_5_quantized_embedding.rs
+++ b/crane-core/tests/qwen3_5_quantized_embedding.rs
@@ -1,0 +1,136 @@
+//! Equivalence check for the quantized embedding table.
+//!
+//! GGUF checkpoints used to have `token_embd.weight` dequantized to the
+//! compute dtype at load; it now stays quantized and only the gathered rows
+//! are dequantized. This test loads the *same* file both ways — the new path,
+//! and the old one via `CRANE_EMBED_DENSE=1` — and compares them.
+//!
+//! What each assertion is worth depends on how the checkpoint ties its
+//! weights, and the difference is worth stating precisely:
+//!
+//! * **Untied** (Qwen 3.6/3.8-27B): only the embedding changes, and the row
+//!   gather decodes the very same blocks the bulk dequantization would, so the
+//!   two paths are *bit-identical* — greedy decoding matches token for token.
+//! * **Tied** (Qwen 3.5 0.8B/4B): the output projection is that same table, so
+//!   keeping it quantized also turns the lm_head into a `QMatMul`. That is a
+//!   genuinely different arithmetic path (activations are quantized for the
+//!   integer dot product), so logits shift by a hair and greedy decoding can
+//!   flip a near-tie. Hence the cosine bound rather than exact equality.
+//!
+//! ```bash
+//! CRANE_QWEN35_GGUF=/path/to/Qwen3.5-0.8B-Q8_0.gguf \
+//!   cargo test -p crane-core --release --test qwen3_5_quantized_embedding -- \
+//!     --ignored --nocapture --test-threads=1
+//! ```
+
+use candle_core::{DType, Device, Tensor};
+use crane_core::generation::based::ModelForCausalLM;
+use crane_core::generation::GenerationConfig;
+use crane_core::models::qwen3_5::{Model, ModelFormat};
+
+const PROMPT: &str =
+    "<|im_start|>user\nBriefly explain what a crane (the bird) looks like.<|im_end|>\n<|im_start|>assistant\n";
+const MAX_NEW_TOKENS: usize = 32;
+
+fn device_and_dtype() -> (Device, DType) {
+    #[cfg(feature = "cuda")]
+    if candle_core::utils::cuda_is_available() {
+        return (Device::new_cuda(0).unwrap(), DType::F16);
+    }
+    (Device::Cpu, DType::F32)
+}
+
+/// Greedy, so two runs on one machine are directly comparable.
+fn greedy_config() -> GenerationConfig {
+    GenerationConfig {
+        max_new_tokens: MAX_NEW_TOKENS,
+        temperature: None,
+        top_p: None,
+        ..Default::default()
+    }
+}
+
+/// Load `gguf` with the embedding table dense or quantized, and return both
+/// the prefill logits and a greedy continuation.
+fn run(gguf: &str, dense: bool) -> (Vec<f32>, Vec<u32>) {
+    // SAFETY: single-threaded test (`--test-threads=1`); the variable is read
+    // once, during model construction on the next line.
+    unsafe {
+        if dense {
+            std::env::set_var("CRANE_EMBED_DENSE", "1");
+        } else {
+            std::env::remove_var("CRANE_EMBED_DENSE");
+        }
+    }
+    let (device, dtype) = device_and_dtype();
+    let mut model =
+        Model::new_with_format(gguf, &device, &dtype, ModelFormat::Gguf).expect("load GGUF model");
+    unsafe { std::env::remove_var("CRANE_EMBED_DENSE") };
+
+    let ids = model.prepare_inputs(PROMPT).expect("tokenize prompt");
+    let logits = to_f32(&model.forward_step(&ids, 0).expect("prefill"));
+
+    let tokens = model
+        .generate(&ids, &greedy_config(), None)
+        .expect("generation failed");
+    let generated = tokens[ids.len()..].to_vec();
+    assert!(!generated.is_empty(), "no tokens generated");
+    (logits, generated)
+}
+
+fn to_f32(t: &Tensor) -> Vec<f32> {
+    t.flatten_all()
+        .unwrap()
+        .to_dtype(DType::F32)
+        .unwrap()
+        .to_vec1::<f32>()
+        .unwrap()
+}
+
+fn cosine(a: &[f32], b: &[f32]) -> f64 {
+    let dot: f64 = a.iter().zip(b).map(|(x, y)| f64::from(*x) * f64::from(*y)).sum();
+    let na: f64 = a.iter().map(|x| f64::from(*x).powi(2)).sum::<f64>().sqrt();
+    let nb: f64 = b.iter().map(|y| f64::from(*y).powi(2)).sum::<f64>().sqrt();
+    dot / (na * nb)
+}
+
+#[test]
+#[ignore = "needs a local Qwen3.5-family GGUF (CRANE_QWEN35_GGUF)"]
+fn quantized_embedding_matches_dense_embedding() {
+    let Ok(gguf) = std::env::var("CRANE_QWEN35_GGUF") else {
+        eprintln!("skipped: set CRANE_QWEN35_GGUF");
+        return;
+    };
+
+    let (q_logits, q_tokens) = run(&gguf, false);
+    let (d_logits, d_tokens) = run(&gguf, true);
+    assert_eq!(q_logits.len(), d_logits.len(), "vocab size mismatch");
+
+    let cos = cosine(&q_logits, &d_logits);
+    let max_abs = q_logits
+        .iter()
+        .zip(&d_logits)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0f32, f32::max);
+    let first_diff = q_tokens.iter().zip(&d_tokens).position(|(a, b)| a != b);
+
+    println!("prefill logits cosine : {cos:.9}");
+    println!("prefill logits max|Δ| : {max_abs:.6}");
+    match first_diff {
+        None => println!("greedy tokens         : identical for all {} tokens", q_tokens.len()),
+        Some(i) => println!(
+            "greedy tokens         : diverge at {i}/{} ({} vs {})",
+            q_tokens.len(),
+            q_tokens[i],
+            d_tokens[i]
+        ),
+    }
+
+    // The embedding gather itself is exact; on a tied checkpoint the lm_head
+    // also becomes quantized, which moves logits slightly but must not change
+    // what the model is saying.
+    assert!(
+        cos > 0.9999,
+        "quantized embedding path diverged from dense: cosine {cos:.9}"
+    );
+}

--- a/crane-serve/src/chat_template.rs
+++ b/crane-serve/src/chat_template.rs
@@ -8,6 +8,7 @@
 //! * **[`HunyuanChatTemplate`]** — hardcoded template for Hunyuan models.
 
 use crate::openai_api::ChatMessage;
+use crate::reasoning::ThinkingOptions;
 use crane_core::autotokenizer::AutoTokenizer;
 
 // ─────────────────────────────────────────────────────────────
@@ -17,6 +18,16 @@ use crane_core::autotokenizer::AutoTokenizer;
 /// Formats chat messages into a model-specific prompt string.
 pub trait ChatTemplateProcessor: Send + Sync {
     fn apply(&self, messages: &[ChatMessage]) -> Result<String, String>;
+
+    /// Render with reasoning controls. Defaults to ignoring them, which is
+    /// correct for templates that have no notion of thinking (Hunyuan).
+    fn apply_with_thinking(
+        &self,
+        messages: &[ChatMessage],
+        _opts: &ThinkingOptions,
+    ) -> Result<String, String> {
+        self.apply(messages)
+    }
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -38,6 +49,14 @@ impl AutoChatTemplate {
 
 impl ChatTemplateProcessor for AutoChatTemplate {
     fn apply(&self, messages: &[ChatMessage]) -> Result<String, String> {
+        self.apply_with_thinking(messages, &ThinkingOptions::default())
+    }
+
+    fn apply_with_thinking(
+        &self,
+        messages: &[ChatMessage],
+        opts: &ThinkingOptions,
+    ) -> Result<String, String> {
         // Build the list of {role, content} values expected by the Jinja template.
         let template_messages: Vec<serde_json::Value> = messages
             .iter()
@@ -50,7 +69,15 @@ impl ChatTemplateProcessor for AutoChatTemplate {
             .collect();
 
         self.tokenizer
-            .apply_chat_template(&template_messages, true)
+            .apply_chat_template_full(
+                &template_messages,
+                Option::<&serde_json::Value>::None,
+                true,
+                opts.enable_thinking,
+                opts.reasoning_effort.as_deref(),
+            )
+            // Qwen 3.6+ templates `raise_exception` on an unsupported
+            // reasoning_effort, so this is a user-input error, not a bug.
             .map_err(|e| format!("Chat template error: {e}"))
     }
 }

--- a/crane-serve/src/engine/model_factory.rs
+++ b/crane-serve/src/engine/model_factory.rs
@@ -60,10 +60,14 @@ impl ModelType {
             "minicpm5" | "minicpm-5" | "minicpm_5" | "minicpm" => Self::Minicpm5,
             "qwen25" | "qwen2.5" | "qwen2" => Self::Qwen25,
             "qwen3" => Self::Qwen3,
-            "qwen3_5" | "qwen3.5" | "qwen35" | "qwen3_5_dense" => Self::Qwen3_5,
-            "qwen3_5_vl" | "qwen3.5_vl" | "qwen3_5-vl" | "qwen3_5vl" | "qwen35_vl" => {
-                Self::Qwen3_5VL
-            }
+            // Qwen 3.6 / 3.8 are the same architecture as 3.5 (they even
+            // declare `model_type: "qwen3_5"`), so they alias onto it rather
+            // than getting their own `ModelType`.
+            "qwen3_5" | "qwen3.5" | "qwen35" | "qwen3_5_dense" | "qwen3_6" | "qwen3.6"
+            | "qwen36" | "qwen3_8" | "qwen3.8" | "qwen38" => Self::Qwen3_5,
+            "qwen3_5_vl" | "qwen3.5_vl" | "qwen3_5-vl" | "qwen3_5vl" | "qwen35_vl"
+            | "qwen3_6_vl" | "qwen3.6_vl" | "qwen36_vl" | "qwen3_8_vl" | "qwen3.8_vl"
+            | "qwen38_vl" => Self::Qwen3_5VL,
             "qwen3_tts" | "qwen3tts" | "qwen3-tts" | "tts" => Self::Qwen3TTS,
             "voxtral_tts" | "voxtral-tts" | "voxtral" | "voxtral_4b" => Self::VoxtralTTS,
             "kokoro" | "kokoro_tts" | "kokoro-tts" | "kokoro-82m" => Self::Kokoro,
@@ -202,7 +206,9 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
                 }
                 "qwen2" | "qwen2.5" => return ModelType::Qwen25,
                 "qwen3" => return ModelType::Qwen3,
-                "qwen3_5" | "qwen3.5" => {
+                // Qwen 3.6 / 3.8 27B ship `model_type: "qwen3_5"`; the 3.6/3.8
+                // spellings are only here for retagged third-party repacks.
+                "qwen3_5" | "qwen3.5" | "qwen3_6" | "qwen3.6" | "qwen3_8" | "qwen3.8" => {
                     return if config.vision_config.is_some() {
                         ModelType::Qwen3_5VL
                     } else {
@@ -254,6 +260,22 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
                     return ModelType::Qwen3_5VL;
                 }
                 if a.contains("qwen3_5") || a.contains("qwen3.5") {
+                    return ModelType::Qwen3_5;
+                }
+                // Qwen 3.6 / 3.8 reuse the Qwen3_5 classes upstream, so these
+                // only fire for repacks that renamed `architectures`.
+                if a.contains("qwen3_6forconditional")
+                    || a.contains("qwen3.6forconditional")
+                    || a.contains("qwen3_8forconditional")
+                    || a.contains("qwen3.8forconditional")
+                {
+                    return ModelType::Qwen3_5VL;
+                }
+                if a.contains("qwen3_6")
+                    || a.contains("qwen3.6")
+                    || a.contains("qwen3_8")
+                    || a.contains("qwen3.8")
+                {
                     return ModelType::Qwen3_5;
                 }
                 if a.contains("qwen3") {
@@ -320,10 +342,12 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
         ModelType::Qwen3TTS
     } else if path_lower.contains("qwen3-asr") || path_lower.contains("qwen3_asr") || path_lower.contains("qwen3asr") {
         ModelType::Qwen3ASR
-    } else if path_lower.contains("qwen3.5") || path_lower.contains("qwen3_5") || path_lower.contains("qwen35") {
-        ModelType::Qwen3_5
-    } else if path_lower.contains("qwen3_5_vl") || path_lower.contains("qwen3.5_vl") || path_lower.contains("qwen3.5-vl") || path_lower.contains("qwen35_vl") {
+    } else if QWEN3_5_FAMILY_VL_MARKERS.iter().any(|m| path_lower.contains(m)) {
+        // Checked before the text-only branch below: "Qwen3.5-VL" contains
+        // "qwen3.5" too, and would otherwise be claimed as text-only.
         ModelType::Qwen3_5VL
+    } else if QWEN3_5_FAMILY_MARKERS.iter().any(|m| path_lower.contains(m)) {
+        ModelType::Qwen3_5
     } else if path_lower.contains("qwen3") {
         ModelType::Qwen3
     } else if path_lower.contains("qwen2") || path_lower.contains("qwen25") {
@@ -335,6 +359,22 @@ pub fn detect_model_type(model_path: &str) -> ModelType {
         ModelType::Qwen25
     }
 }
+
+/// Path-name markers for the Qwen 3.5 family. Qwen 3.6 and 3.8 are the same
+/// architecture (see `crane_core::models::qwen3_5`), so they route here too —
+/// without these, `Qwen3.8-27B-GGUF/` falls through to the bare `qwen3` branch
+/// and loads as a plain Qwen3.
+const QWEN3_5_FAMILY_MARKERS: &[&str] = &[
+    "qwen3.5", "qwen3_5", "qwen35", "qwen3.6", "qwen3_6", "qwen36", "qwen3.8", "qwen3_8", "qwen38",
+];
+
+/// VL spellings of [`QWEN3_5_FAMILY_MARKERS`], checked first since every one of
+/// these also contains its text-only marker as a substring.
+const QWEN3_5_FAMILY_VL_MARKERS: &[&str] = &[
+    "qwen3.5-vl", "qwen3.5_vl", "qwen3_5_vl", "qwen35_vl",
+    "qwen3.6-vl", "qwen3.6_vl", "qwen3_6_vl", "qwen36_vl",
+    "qwen3.8-vl", "qwen3.8_vl", "qwen3_8_vl", "qwen38_vl",
+];
 
 /// Read `general.architecture` from a `.gguf` file's header.
 fn detect_from_gguf_header(path: &Path) -> Option<ModelType> {
@@ -354,7 +394,10 @@ fn detect_from_gguf_header(path: &Path) -> Option<ModelType> {
         .ok()?
         .to_lowercase();
     match arch.as_str() {
-        "qwen35" | "qwen3_5" | "qwen3.5" => Some(ModelType::Qwen3_5),
+        // llama.cpp writes "qwen35" for Qwen 3.5, 3.6 and 3.8 alike; the
+        // 36/38 spellings guard against a future converter renaming it.
+        "qwen35" | "qwen3_5" | "qwen3.5" | "qwen36" | "qwen3_6" | "qwen3.6" | "qwen38"
+        | "qwen3_8" | "qwen3.8" => Some(ModelType::Qwen3_5),
         "qwen3" | "qwen3moe" => Some(ModelType::Qwen3),
         "qwen2" => Some(ModelType::Qwen25),
         a if a.starts_with("hunyuan") => Some(ModelType::HunyuanDense),
@@ -898,6 +941,60 @@ mod tests {
     fn detect_path_heuristic_qwen3_asr() {
         let result = detect_model_type("/models/Qwen3-ASR-0.6B-hf");
         assert_eq!(result, ModelType::Qwen3ASR);
+    }
+
+    /// Qwen 3.6 / 3.8 are the Qwen 3.5 architecture and must not fall through
+    /// to the bare `qwen3` branch of the path heuristic.
+    #[test]
+    fn detect_path_heuristic_qwen3_5_family() {
+        for path in [
+            "/models/Qwen3.5-4B-GGUF",
+            "/models/Qwen3.6-27B",
+            "/models/Qwen3.8-27B-GGUF",
+            "/models/Qwen3_8-27B",
+            "/models/qwen38-27b-q4_k_m",
+        ] {
+            assert_eq!(detect_model_type(path), ModelType::Qwen3_5, "path {path}");
+        }
+    }
+
+    /// The VL markers are substrings-plus of the text-only ones, so ordering
+    /// inside the heuristic decides these.
+    #[test]
+    fn detect_path_heuristic_qwen3_5_family_vl_beats_text() {
+        for path in [
+            "/models/Qwen3.5-VL-8B",
+            "/models/Qwen3.8-VL-27B",
+            "/models/qwen3_8_vl",
+        ] {
+            assert_eq!(detect_model_type(path), ModelType::Qwen3_5VL, "path {path}");
+        }
+    }
+
+    /// The real Qwen 3.8-27B `config.json`: `model_type` is literally
+    /// `qwen3_5`, and the vision block routes it to the VL backend.
+    #[test]
+    fn detect_from_config_json_qwen3_8_declares_qwen3_5() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("config.json"),
+            r#"{"model_type": "qwen3_5",
+                "architectures": ["Qwen3_5ForConditionalGeneration"],
+                "vision_config": {"depth": 27}}"#,
+        )
+        .unwrap();
+        let result = detect_model_type(dir.path().to_str().unwrap());
+        assert_eq!(result, ModelType::Qwen3_5VL);
+    }
+
+    #[test]
+    fn model_type_from_str_qwen3_5_family_variants() {
+        for s in ["qwen3.5", "qwen35", "qwen3.6", "qwen36", "qwen3.8", "qwen3_8", "QWEN3.8"] {
+            assert_eq!(ModelType::from_str(s), ModelType::Qwen3_5, "spelling {s}");
+        }
+        for s in ["qwen3_5_vl", "qwen3.8_vl", "qwen38_vl"] {
+            assert_eq!(ModelType::from_str(s), ModelType::Qwen3_5VL, "spelling {s}");
+        }
     }
 
     #[test]

--- a/crane-serve/src/handlers/openai.rs
+++ b/crane-serve/src/handlers/openai.rs
@@ -49,10 +49,14 @@ pub async fn chat_completions(
         return vlm::vlm_chat_completions(state, req).await;
     }
 
-    // Apply chat template.
+    // Apply chat template, forwarding the request's reasoning controls.
+    let thinking = crate::reasoning::ThinkingOptions::from_request(
+        req.chat_template_kwargs.as_ref(),
+        req.reasoning_effort.as_deref(),
+    );
     let formatted = state
         .chat_template
-        .apply(&req.messages)
+        .apply_with_thinking(&req.messages, &thinking)
         .map_err(|e| make_error(StatusCode::BAD_REQUEST, &format!("Chat template failed: {e}")))?;
 
     // Tokenize.
@@ -92,14 +96,24 @@ pub async fn chat_completions(
 
     if req.stream {
         let model_name = state.model_name.clone();
-        let stream =
-            sse::make_chat_sse_stream(request_id, model_name, response_rx, include_usage);
+        let stream = sse::make_chat_sse_stream(
+            request_id,
+            model_name,
+            response_rx,
+            include_usage,
+            crate::reasoning::ReasoningSplitter::for_prompt(&formatted),
+        );
         Ok(Sse::new(stream)
             .keep_alive(KeepAlive::default())
             .into_response())
     } else {
         let (full_text, prompt_tokens, completion_tokens, finish_reason) =
             collect_response(response_rx).await?;
+
+        // The opening `<think>` lives in the prompt, not the output, so the
+        // split is decided from `formatted`.
+        let (reasoning_content, content) =
+            crate::reasoning::split_complete(&formatted, &full_text);
 
         let response = ChatCompletionResponse {
             id: request_id,
@@ -108,10 +122,7 @@ pub async fn chat_completions(
             model: state.model_name.clone(),
             choices: vec![ChatChoice {
                 index: 0,
-                message: ChatMessage {
-                    role: "assistant".into(),
-                    content: ChatMessageContent::Text(full_text),
-                },
+                message: ChatMessage::assistant_with_reasoning(content, reasoning_content),
                 finish_reason: Some(finish_reason),
             }],
             usage: Usage {

--- a/crane-serve/src/handlers/sse.rs
+++ b/crane-serve/src/handlers/sse.rs
@@ -15,11 +15,15 @@ use crate::now_epoch;
 //  Chat completions SSE
 // ─────────────────────────────────────────────────────────────
 
+/// `splitter` routes each token delta to `content` or `reasoning_content`; its
+/// starting state comes from the rendered prompt (see
+/// [`crate::reasoning::ReasoningSplitter::for_prompt`]).
 pub fn make_chat_sse_stream(
     request_id: String,
     model_name: String,
     mut rx: mpsc::UnboundedReceiver<EngineResponse>,
     include_usage: bool,
+    mut splitter: crate::reasoning::ReasoningSplitter,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
     let created = now_epoch();
 
@@ -32,10 +36,7 @@ pub fn make_chat_sse_stream(
             model: model_name.clone(),
             choices: vec![ChunkChoice {
                 index: 0,
-                delta: ChunkDelta {
-                    role: Some("assistant".into()),
-                    content: None,
-                },
+                delta: ChunkDelta::role("assistant"),
                 finish_reason: None,
             }],
             usage: None,
@@ -45,26 +46,42 @@ pub fn make_chat_sse_stream(
         let mut _prompt_tokens = 0usize;
         let mut _completion_tokens = 0usize;
 
-        while let Some(resp) = rx.recv().await {
-            match resp {
-                EngineResponse::Token { text, .. } => {
-                    _completion_tokens += 1;
+        // A token may straddle a `</think>` tag, so one token can yield both a
+        // reasoning and a content delta — or neither, while a partial tag is
+        // buffered.
+        macro_rules! emit_deltas {
+            ($reasoning:expr, $content:expr) => {{
+                let (reasoning, content) = ($reasoning, $content);
+                for delta in [
+                    (!reasoning.is_empty()).then(|| ChunkDelta {
+                        role: None,
+                        content: None,
+                        reasoning_content: Some(reasoning),
+                    }),
+                    (!content.is_empty()).then(|| ChunkDelta::content(content)),
+                ]
+                .into_iter()
+                .flatten()
+                {
                     let chunk = ChatCompletionChunk {
                         id: request_id.clone(),
                         object: "chat.completion.chunk".into(),
                         created,
                         model: model_name.clone(),
-                        choices: vec![ChunkChoice {
-                            index: 0,
-                            delta: ChunkDelta {
-                                role: None,
-                                content: Some(text),
-                            },
-                            finish_reason: None,
-                        }],
+                        choices: vec![ChunkChoice { index: 0, delta, finish_reason: None }],
                         usage: None,
                     };
                     yield Ok(Event::default().json_data(&chunk).unwrap());
+                }
+            }};
+        }
+
+        while let Some(resp) = rx.recv().await {
+            match resp {
+                EngineResponse::Token { text, .. } => {
+                    _completion_tokens += 1;
+                    let (reasoning, content) = splitter.push(&text);
+                    emit_deltas!(reasoning, content);
                 }
                 EngineResponse::Finished {
                     finish_reason,
@@ -75,6 +92,10 @@ pub fn make_chat_sse_stream(
                     _prompt_tokens = pt;
                     _completion_tokens = ct;
 
+                    // Flush any text held back as a possible partial tag.
+                    let (reasoning, content) = splitter.finish();
+                    emit_deltas!(reasoning, content);
+
                     let chunk = ChatCompletionChunk {
                         id: request_id.clone(),
                         object: "chat.completion.chunk".into(),
@@ -82,10 +103,7 @@ pub fn make_chat_sse_stream(
                         model: model_name.clone(),
                         choices: vec![ChunkChoice {
                             index: 0,
-                            delta: ChunkDelta {
-                                role: None,
-                                content: None,
-                            },
+                            delta: ChunkDelta::empty(),
                             finish_reason: Some(finish_reason),
                         }],
                         usage: None,

--- a/crane-serve/src/handlers/vlm.rs
+++ b/crane-serve/src/handlers/vlm.rs
@@ -232,10 +232,7 @@ pub async fn vlm_chat_completions(
                 model: model_name.clone(),
                 choices: vec![ChunkChoice {
                     index: 0,
-                    delta: ChunkDelta {
-                        role: Some("assistant".into()),
-                        content: None,
-                    },
+                    delta: ChunkDelta::role("assistant"),
                     finish_reason: None,
                 }],
                 usage: None,
@@ -251,10 +248,7 @@ pub async fn vlm_chat_completions(
                     model: model_name.clone(),
                     choices: vec![ChunkChoice {
                         index: 0,
-                        delta: ChunkDelta {
-                            role: None,
-                            content: Some(text),
-                        },
+                        delta: ChunkDelta::content(text),
                         finish_reason: None,
                     }],
                     usage: None,
@@ -270,10 +264,7 @@ pub async fn vlm_chat_completions(
                 model: model_name.clone(),
                 choices: vec![ChunkChoice {
                     index: 0,
-                    delta: ChunkDelta {
-                        role: None,
-                        content: None,
-                    },
+                    delta: ChunkDelta::empty(),
                     finish_reason: Some("stop".into()),
                 }],
                 usage: None,
@@ -308,10 +299,7 @@ pub async fn vlm_chat_completions(
             model: state.model_name.clone(),
             choices: vec![ChatChoice {
                 index: 0,
-                message: ChatMessage {
-                    role: "assistant".into(),
-                    content: ChatMessageContent::Text(result),
-                },
+                message: ChatMessage::assistant(result),
                 finish_reason: Some("stop".into()),
             }],
             usage: Usage {
@@ -494,10 +482,7 @@ pub async fn qwen3_5_vlm_chat_completions(
         model: state.model_name.clone(),
         choices: vec![ChatChoice {
             index: 0,
-            message: ChatMessage {
-                role: "assistant".into(),
-                content: ChatMessageContent::Text(text),
-            },
+            message: ChatMessage::assistant(text),
             finish_reason: Some("stop".into()),
         }],
         usage: Usage {
@@ -563,10 +548,7 @@ pub async fn minicpm_v_vlm_chat_completions(
         model: state.model_name.clone(),
         choices: vec![ChatChoice {
             index: 0,
-            message: ChatMessage {
-                role: "assistant".into(),
-                content: ChatMessageContent::Text(text),
-            },
+            message: ChatMessage::assistant(text),
             finish_reason: Some("stop".into()),
         }],
         usage: Usage {
@@ -623,10 +605,7 @@ pub async fn gemma4_vlm_chat_completions(
         model: state.model_name.clone(),
         choices: vec![ChatChoice {
             index: 0,
-            message: ChatMessage {
-                role: "assistant".into(),
-                content: ChatMessageContent::Text(result),
-            },
+            message: ChatMessage::assistant(result),
             finish_reason: Some("stop".into()),
         }],
         usage: Usage {

--- a/crane-serve/src/lib.rs
+++ b/crane-serve/src/lib.rs
@@ -2,6 +2,7 @@ pub mod chat_template;
 pub mod engine;
 pub mod handlers;
 pub mod openai_api;
+pub mod reasoning;
 pub mod sglang_api;
 
 use std::sync::Arc;

--- a/crane-serve/src/lib.rs
+++ b/crane-serve/src/lib.rs
@@ -76,6 +76,14 @@ pub struct Args {
     /// there regardless).
     #[arg(long)]
     pub llm_gguf: Option<String>,
+    /// Qwen 3.5-VL / Ornith only: load the checkpoint as a plain text model
+    /// instead of a VLM, even though `config.json` declares a `vision_config`
+    /// (and `--model-type` is `auto` or `qwen3_5_vl`). The vision tower's
+    /// weights are simply never read — same checkpoint directory, no extra
+    /// VRAM for the ~600M-param ViT — and this path also unlocks `--quant`,
+    /// which the VLM load path does not support. Models are vision-capable by
+    /// default; this is an opt-out, not the default.
+    #[arg(long)]
     pub text_only: bool,
 }
 

--- a/crane-serve/src/openai_api.rs
+++ b/crane-serve/src/openai_api.rs
@@ -49,15 +49,47 @@ pub struct ChatCompletionRequest {
     pub n: Option<usize>,
     /// Response format constraint (e.g., `{"type": "json_object"}`).
     pub response_format: Option<ResponseFormat>,
+    /// Extra variables for the Jinja chat template (vLLM/SGLang convention).
+    /// Reasoning models read `enable_thinking` and `reasoning_effort` from
+    /// here; see [`crate::reasoning::ThinkingOptions`].
+    pub chat_template_kwargs: Option<serde_json::Value>,
+    /// OpenAI's top-level reasoning budget (`low` / `medium` / `xhigh` for the
+    /// Qwen 3.6+ templates). `chat_template_kwargs` takes precedence.
+    pub reasoning_effort: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChatMessage {
     pub role: String,
     pub content: ChatMessageContent,
+    /// The model's `<think>` scratchpad, separated out of `content` so clients
+    /// can display or discard it independently. Only ever set on responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 impl ChatMessage {
+    /// An assistant reply with no reasoning block.
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".into(),
+            content: ChatMessageContent::Text(content.into()),
+            reasoning_content: None,
+        }
+    }
+
+    /// An assistant reply whose scratchpad was split out of the raw output.
+    pub fn assistant_with_reasoning(
+        content: impl Into<String>,
+        reasoning_content: Option<String>,
+    ) -> Self {
+        Self {
+            role: "assistant".into(),
+            content: ChatMessageContent::Text(content.into()),
+            reasoning_content,
+        }
+    }
+
     /// Extract the plain text content from the message.
     /// For multimodal messages, concatenates all text parts.
     pub fn text_content(&self) -> String {
@@ -177,6 +209,25 @@ pub struct ChunkDelta {
     pub role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    /// Streamed counterpart of [`ChatMessage::reasoning_content`]: deltas
+    /// generated inside a `<think>` block arrive here instead of `content`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+}
+
+impl ChunkDelta {
+    pub fn role(role: impl Into<String>) -> Self {
+        Self { role: Some(role.into()), content: None, reasoning_content: None }
+    }
+
+    pub fn content(text: impl Into<String>) -> Self {
+        Self { role: None, content: Some(text.into()), reasoning_content: None }
+    }
+
+    /// Empty delta, used by the terminal `finish_reason` chunk.
+    pub fn empty() -> Self {
+        Self { role: None, content: None, reasoning_content: None }
+    }
 }
 
 // ═════════════════════════════════════════════════════════════

--- a/crane-serve/src/reasoning.rs
+++ b/crane-serve/src/reasoning.rs
@@ -1,0 +1,328 @@
+//! Thinking control and `<think>` separation for reasoning models.
+//!
+//! Two halves of the same feature:
+//!
+//! * **[`ThinkingOptions`]** — what the *request* asks for, forwarded into the
+//!   Jinja chat template as `enable_thinking` / `reasoning_effort`.
+//! * **[`ReasoningSplitter`]** — what comes *back*: reasoning models emit their
+//!   scratchpad and their answer in one token stream, and the two have to be
+//!   separated before the answer reaches the client.
+//!
+//! The subtlety is that the opening `<think>` usually is **not** in the model's
+//! output at all — Qwen 3.5/3.6/3.8 templates end the generation prompt with a
+//! dangling `<think>\n`, so the completion opens mid-scratchpad and the first
+//! tag the model emits is the *closing* one. Deciding "are we in reasoning?"
+//! from the output alone therefore gets it backwards; [`ReasoningSplitter`]
+//! reads the rendered prompt instead, which also gets the
+//! `enable_thinking: false` case right (those templates pre-close the block, so
+//! the completion is pure content).
+
+use serde_json::Value;
+
+pub const THINK_OPEN: &str = "<think>";
+pub const THINK_CLOSE: &str = "</think>";
+
+// ─────────────────────────────────────────────────────────────
+//  Request-side: what the template is told
+// ─────────────────────────────────────────────────────────────
+
+/// Reasoning knobs forwarded to the chat template.
+///
+/// `None` means "leave the template variable undefined", which is not the same
+/// as passing a value — the Qwen templates branch on `is defined` and on
+/// `|default('xhigh')`, so an undefined variable selects the model's own
+/// default while an explicit one overrides it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ThinkingOptions {
+    pub enable_thinking: Option<bool>,
+    pub reasoning_effort: Option<String>,
+}
+
+impl ThinkingOptions {
+    /// Read the knobs from an OpenAI-style request.
+    ///
+    /// `chat_template_kwargs` is the vLLM/SGLang convention
+    /// (`{"chat_template_kwargs": {"enable_thinking": false}}`);
+    /// `reasoning_effort` is OpenAI's own top-level field. When both carry an
+    /// effort, `chat_template_kwargs` wins — it is the more specific,
+    /// template-targeted channel.
+    pub fn from_request(chat_template_kwargs: Option<&Value>, reasoning_effort: Option<&str>) -> Self {
+        let kwargs = chat_template_kwargs.and_then(Value::as_object);
+        Self {
+            enable_thinking: kwargs
+                .and_then(|k| k.get("enable_thinking"))
+                .and_then(Value::as_bool),
+            reasoning_effort: kwargs
+                .and_then(|k| k.get("reasoning_effort"))
+                .and_then(Value::as_str)
+                .or(reasoning_effort)
+                .map(str::to_owned),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+//  Response-side: splitting the stream
+// ─────────────────────────────────────────────────────────────
+
+/// Incrementally splits a completion into reasoning and content.
+///
+/// Feed it decoded token text with [`push`](Self::push) and flush with
+/// [`finish`](Self::finish). Tags are recognized even when split across token
+/// boundaries (`</` + `think>`): any trailing text that could still grow into a
+/// tag is held back rather than emitted.
+pub struct ReasoningSplitter {
+    in_reasoning: bool,
+    /// Text held back because it may be the start of a tag.
+    pending: String,
+    seen_reasoning: bool,
+    seen_content: bool,
+}
+
+impl ReasoningSplitter {
+    /// Decide the starting state from the rendered prompt.
+    ///
+    /// If the prompt's last `<think>` is not followed by a `</think>`, the
+    /// template left the block open and the completion begins inside it.
+    pub fn for_prompt(prompt: &str) -> Self {
+        let open = prompt.rfind(THINK_OPEN);
+        let close = prompt.rfind(THINK_CLOSE);
+        let in_reasoning = match (open, close) {
+            (Some(o), Some(c)) => o > c,
+            (Some(_), None) => true,
+            (None, _) => false,
+        };
+        Self {
+            in_reasoning,
+            pending: String::new(),
+            seen_reasoning: false,
+            seen_content: false,
+        }
+    }
+
+    /// A splitter for output known to contain no reasoning block.
+    pub fn disabled() -> Self {
+        Self {
+            in_reasoning: false,
+            pending: String::new(),
+            seen_reasoning: false,
+            seen_content: false,
+        }
+    }
+
+    /// Whether the completion is currently inside a reasoning block.
+    pub fn in_reasoning(&self) -> bool {
+        self.in_reasoning
+    }
+
+    /// Consume `text`, returning `(reasoning_delta, content_delta)`. Either may
+    /// be empty; both are empty while a partial tag is buffered.
+    pub fn push(&mut self, text: &str) -> (String, String) {
+        self.pending.push_str(text);
+        let mut reasoning = String::new();
+        let mut content = String::new();
+
+        loop {
+            let tag = if self.in_reasoning { THINK_CLOSE } else { THINK_OPEN };
+            if let Some(idx) = self.pending.find(tag) {
+                let before: String = self.pending[..idx].into();
+                self.emit(&before, &mut reasoning, &mut content);
+                self.pending = self.pending[idx + tag.len()..].to_string();
+                self.in_reasoning = !self.in_reasoning;
+                continue;
+            }
+            // No complete tag. Hold back only a suffix that could still become
+            // one; everything before it is safe to emit.
+            let keep = partial_tag_suffix_len(&self.pending, tag);
+            let split = self.pending.len() - keep;
+            let ready: String = self.pending[..split].into();
+            self.emit(&ready, &mut reasoning, &mut content);
+            self.pending = self.pending[split..].to_string();
+            break;
+        }
+        (reasoning, content)
+    }
+
+    /// Flush whatever is buffered; call once the stream ends.
+    pub fn finish(&mut self) -> (String, String) {
+        let rest = std::mem::take(&mut self.pending);
+        let mut reasoning = String::new();
+        let mut content = String::new();
+        self.emit(&rest, &mut reasoning, &mut content);
+        (reasoning, content)
+    }
+
+    /// Route `text` to the active sink, trimming the leading whitespace that
+    /// templates leave behind after a tag (`</think>\n\n`).
+    fn emit(&mut self, text: &str, reasoning: &mut String, content: &mut String) {
+        if text.is_empty() {
+            return;
+        }
+        if self.in_reasoning {
+            let text = if self.seen_reasoning { text } else { text.trim_start() };
+            if !text.is_empty() {
+                self.seen_reasoning = true;
+                reasoning.push_str(text);
+            }
+        } else {
+            let text = if self.seen_content { text } else { text.trim_start() };
+            if !text.is_empty() {
+                self.seen_content = true;
+                content.push_str(text);
+            }
+        }
+    }
+}
+
+/// Length of the longest suffix of `haystack` that is a proper prefix of `tag`.
+///
+/// This is what must stay buffered: `"...</"` could still become `"</think>"`,
+/// so it cannot be emitted as content yet.
+fn partial_tag_suffix_len(haystack: &str, tag: &str) -> usize {
+    let max = tag.len().saturating_sub(1).min(haystack.len());
+    (1..=max)
+        .rev()
+        .find(|&n| haystack.is_char_boundary(haystack.len() - n) && tag.starts_with(&haystack[haystack.len() - n..]))
+        .unwrap_or(0)
+}
+
+/// Split a complete (non-streamed) completion.
+///
+/// Returns `(reasoning_content, content)`; `reasoning_content` is `None` when
+/// the completion carried no reasoning block.
+pub fn split_complete(prompt: &str, output: &str) -> (Option<String>, String) {
+    let mut splitter = ReasoningSplitter::for_prompt(prompt);
+    let (mut reasoning, mut content) = splitter.push(output);
+    let (r2, c2) = splitter.finish();
+    reasoning.push_str(&r2);
+    content.push_str(&c2);
+
+    let reasoning = reasoning.trim_end().to_string();
+    let content = content.trim_end().to_string();
+    if reasoning.is_empty() {
+        (None, content)
+    } else {
+        (Some(reasoning), content)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// What Qwen 3.8 actually produces: the prompt ends with a dangling
+    /// `<think>`, so the completion opens mid-scratchpad and the only tag in
+    /// the output is the closing one.
+    #[test]
+    fn splits_completion_whose_open_tag_was_in_the_prompt() {
+        let prompt = "<|im_start|>assistant\n<think>\n";
+        let output = "We need answer user. Simple.\n</think>\n\n4";
+        let (reasoning, content) = split_complete(prompt, output);
+        assert_eq!(reasoning.as_deref(), Some("We need answer user. Simple."));
+        assert_eq!(content, "4");
+    }
+
+    /// `enable_thinking: false` pre-closes the block in the prompt, so the
+    /// completion is pure content — assuming "starts in reasoning" would file
+    /// the whole answer as scratchpad and return empty content.
+    #[test]
+    fn treats_preclosed_prompt_block_as_content() {
+        let prompt = "<|im_start|>assistant\n<think>\n\n</think>\n\n";
+        let (reasoning, content) = split_complete(prompt, "4");
+        assert_eq!(reasoning, None);
+        assert_eq!(content, "4");
+    }
+
+    /// A model that emits both tags itself must work too.
+    #[test]
+    fn splits_completion_containing_both_tags() {
+        let (reasoning, content) = split_complete("user: hi\n", "<think>hmm</think>hello");
+        assert_eq!(reasoning.as_deref(), Some("hmm"));
+        assert_eq!(content, "hello");
+    }
+
+    #[test]
+    fn non_reasoning_output_is_all_content() {
+        let (reasoning, content) = split_complete("user: hi\n", "just an answer");
+        assert_eq!(reasoning, None);
+        assert_eq!(content, "just an answer");
+    }
+
+    /// Streaming: the tag arrives split across token boundaries, and no partial
+    /// tag may leak into either sink.
+    #[test]
+    fn buffers_tag_split_across_tokens() {
+        let mut s = ReasoningSplitter::for_prompt("<think>\n");
+        let mut reasoning = String::new();
+        let mut content = String::new();
+        for tok in ["think", "ing", " a bit", "\n<", "/", "think", ">", "\n\n", "answer"] {
+            let (r, c) = s.push(tok);
+            reasoning.push_str(&r);
+            content.push_str(&c);
+        }
+        let (r, c) = s.finish();
+        reasoning.push_str(&r);
+        content.push_str(&c);
+
+        assert_eq!(reasoning, "thinking a bit\n");
+        assert_eq!(content, "answer");
+    }
+
+    /// A `<` that never becomes a tag must still be emitted, not swallowed.
+    #[test]
+    fn releases_buffered_text_that_is_not_a_tag() {
+        let mut s = ReasoningSplitter::disabled();
+        let (_, c1) = s.push("a < b");
+        let (_, c2) = s.push(" and c");
+        let (_, c3) = s.finish();
+        assert_eq!(format!("{c1}{c2}{c3}"), "a < b and c");
+    }
+
+    /// Unterminated reasoning (hit the token limit mid-thought) must not be
+    /// silently reported as the answer.
+    #[test]
+    fn unterminated_reasoning_stays_reasoning() {
+        let (reasoning, content) = split_complete("<think>\n", "still thinking when cut off");
+        assert_eq!(reasoning.as_deref(), Some("still thinking when cut off"));
+        assert_eq!(content, "");
+    }
+
+    #[test]
+    fn multibyte_text_is_not_split_mid_character() {
+        let (reasoning, content) = split_complete("<think>\n", "推理中\n</think>\n\n答案は4です");
+        assert_eq!(reasoning.as_deref(), Some("推理中"));
+        assert_eq!(content, "答案は4です");
+    }
+
+    // ── ThinkingOptions ──
+
+    #[test]
+    fn thinking_options_read_chat_template_kwargs() {
+        let kwargs = serde_json::json!({"enable_thinking": false, "reasoning_effort": "low"});
+        let opts = ThinkingOptions::from_request(Some(&kwargs), None);
+        assert_eq!(opts.enable_thinking, Some(false));
+        assert_eq!(opts.reasoning_effort.as_deref(), Some("low"));
+    }
+
+    #[test]
+    fn thinking_options_fall_back_to_top_level_effort() {
+        let opts = ThinkingOptions::from_request(None, Some("medium"));
+        assert_eq!(opts.enable_thinking, None);
+        assert_eq!(opts.reasoning_effort.as_deref(), Some("medium"));
+    }
+
+    /// The template-targeted channel is the more specific one.
+    #[test]
+    fn thinking_options_prefer_kwargs_over_top_level_effort() {
+        let kwargs = serde_json::json!({"reasoning_effort": "low"});
+        let opts = ThinkingOptions::from_request(Some(&kwargs), Some("xhigh"));
+        assert_eq!(opts.reasoning_effort.as_deref(), Some("low"));
+    }
+
+    /// An absent knob must stay absent, so the template's own default applies.
+    #[test]
+    fn thinking_options_default_to_undefined() {
+        let opts = ThinkingOptions::from_request(None, None);
+        assert_eq!(opts, ThinkingOptions::default());
+    }
+}

--- a/crane-serve/tests/thinking_control.rs
+++ b/crane-serve/tests/thinking_control.rs
@@ -1,0 +1,167 @@
+//! End-to-end thinking control against a real checkpoint's chat template.
+//!
+//! Renders the prompt through the model's own embedded Jinja template for each
+//! `enable_thinking` / `reasoning_effort` combination, then runs a synthetic
+//! completion back through the splitter — the same pair of steps the server
+//! performs, minus the GPU.
+//!
+//! Gated on a checkpoint path (`.gguf` file, or a directory with
+//! `tokenizer_config.json` / `chat_template.jinja`):
+//!
+//! ```sh
+//! CRANE_QWEN38_MODEL=~/models/Qwen3.8-27B-Q4_K_M.gguf \
+//!     cargo test -p crane-serve --test thinking_control -- --ignored --nocapture
+//! ```
+
+use crane_core::autotokenizer::AutoTokenizer;
+use crane_serve::reasoning::{split_complete, ThinkingOptions, THINK_CLOSE, THINK_OPEN};
+
+fn load_tokenizer() -> Option<AutoTokenizer> {
+    let path = std::env::var("CRANE_QWEN38_MODEL").ok()?;
+    let path = shellexpand(&path);
+    let tok = if path.ends_with(".gguf") {
+        AutoTokenizer::from_gguf(&path).expect("load tokenizer from GGUF")
+    } else {
+        AutoTokenizer::from_pretrained(&path, None).expect("load tokenizer from directory")
+    };
+    Some(tok)
+}
+
+fn shellexpand(p: &str) -> String {
+    match p.strip_prefix("~/") {
+        Some(rest) => format!("{}/{rest}", std::env::var("HOME").unwrap_or_default()),
+        None => p.to_string(),
+    }
+}
+
+fn render(tok: &AutoTokenizer, opts: &ThinkingOptions) -> String {
+    let messages = serde_json::json!([{"role": "user", "content": "What is 2+2?"}]);
+    tok.apply_chat_template_full(
+        &messages,
+        Option::<&serde_json::Value>::None,
+        true,
+        opts.enable_thinking,
+        opts.reasoning_effort.as_deref(),
+    )
+    .expect("render chat template")
+}
+
+/// Whether the rendered prompt leaves a `<think>` block open — the condition
+/// the splitter keys off.
+fn leaves_think_open(prompt: &str) -> bool {
+    match (prompt.rfind(THINK_OPEN), prompt.rfind(THINK_CLOSE)) {
+        (Some(o), Some(c)) => o > c,
+        (Some(_), None) => true,
+        (None, _) => false,
+    }
+}
+
+#[test]
+#[ignore = "requires CRANE_QWEN38_MODEL"]
+fn thinking_on_leaves_block_open_and_splitter_recovers_the_answer() {
+    let Some(tok) = load_tokenizer() else {
+        eprintln!("skipped: set CRANE_QWEN38_MODEL");
+        return;
+    };
+
+    let prompt = render(&tok, &ThinkingOptions::default());
+    println!("--- default (thinking on) tail ---\n{}", tail(&prompt));
+    assert!(
+        leaves_think_open(&prompt),
+        "expected a dangling <think> with thinking on"
+    );
+
+    // The completion therefore contains only the CLOSING tag.
+    let output = "Two plus two is four.\n</think>\n\n4";
+    let (reasoning, content) = split_complete(&prompt, output);
+    assert_eq!(reasoning.as_deref(), Some("Two plus two is four."));
+    assert_eq!(content, "4");
+}
+
+#[test]
+#[ignore = "requires CRANE_QWEN38_MODEL"]
+fn thinking_off_pre_closes_the_block_so_output_is_pure_content() {
+    let Some(tok) = load_tokenizer() else {
+        eprintln!("skipped: set CRANE_QWEN38_MODEL");
+        return;
+    };
+
+    let opts = ThinkingOptions { enable_thinking: Some(false), reasoning_effort: None };
+    let prompt = render(&tok, &opts);
+    println!("--- enable_thinking=false tail ---\n{}", tail(&prompt));
+    assert!(
+        !leaves_think_open(&prompt),
+        "expected a pre-closed <think></think> with thinking off"
+    );
+
+    let (reasoning, content) = split_complete(&prompt, "4");
+    assert_eq!(reasoning, None, "no reasoning block should be reported");
+    assert_eq!(content, "4");
+}
+
+/// Each supported effort must reach the template and produce a distinct
+/// prompt.
+///
+/// Note the asymmetry, which is the template's design rather than a bug:
+/// `xhigh` and `low` each inject a "Reasoning effort is set to …" sentence,
+/// while **`medium` injects nothing** — it is the neutral baseline. So
+/// `medium` cannot be detected by looking for its own name in the prompt.
+#[test]
+#[ignore = "requires CRANE_QWEN38_MODEL"]
+fn reasoning_effort_reaches_the_template() {
+    let Some(tok) = load_tokenizer() else {
+        eprintln!("skipped: set CRANE_QWEN38_MODEL");
+        return;
+    };
+
+    let effort_prompt = |effort: &str| {
+        render(
+            &tok,
+            &ThinkingOptions {
+                enable_thinking: None,
+                reasoning_effort: Some(effort.to_string()),
+            },
+        )
+    };
+
+    let (low, medium, xhigh) = (effort_prompt("low"), effort_prompt("medium"), effort_prompt("xhigh"));
+    for (name, prompt) in [("low", &low), ("medium", &medium), ("xhigh", &xhigh)] {
+        println!("--- reasoning_effort={name} ---\n{}", first_system_line(prompt));
+    }
+
+    assert!(low.contains("Reasoning effort is set to low"));
+    assert!(xhigh.contains("Reasoning effort is set to xhigh"));
+    assert!(
+        !medium.contains("Reasoning effort is set to"),
+        "medium is the neutral baseline and should inject no instruction"
+    );
+    assert_ne!(low, medium);
+    assert_ne!(medium, xhigh);
+
+    // Undefined effort must fall through to the template's own default,
+    // which for Qwen 3.8 is xhigh.
+    assert_eq!(render(&tok, &ThinkingOptions::default()), xhigh);
+
+    let bogus = tok.apply_chat_template_full(
+        &serde_json::json!([{"role": "user", "content": "hi"}]),
+        Option::<&serde_json::Value>::None,
+        true,
+        None,
+        Some("turbo"),
+    );
+    assert!(bogus.is_err(), "unsupported effort should be rejected by the template");
+}
+
+fn tail(s: &str) -> String {
+    let n = s.chars().count().saturating_sub(120);
+    s.chars().skip(n).collect::<String>().replace('\n', "\\n")
+}
+
+fn first_system_line(s: &str) -> String {
+    s.lines()
+        .find(|l| l.contains("Reasoning effort"))
+        .unwrap_or("<no reasoning instruction found>")
+        .chars()
+        .take(140)
+        .collect()
+}

--- a/data/crane-model-download
+++ b/data/crane-model-download
@@ -101,6 +101,13 @@ MODELS = {
         "quant_template": "Qwen3.5-9B-{quant}.gguf",
         "description": "Qwen 3.5 9B, hybrid GDN + attention, GGUF quant (Apache-2.0)",
     },
+    "qwen3.8-27b-gguf": {
+        "repo_id": "unsloth/Qwen3.8-27B-GGUF",
+        "dirname": "Qwen3.8-27B-GGUF",
+        "kind": "llm",
+        "quant_template": "Qwen3.8-27B-{quant}.gguf",
+        "description": "Qwen 3.8 27B, same arch as Qwen 3.5 scaled up, GGUF quant (Apache-2.0)",
+    },
     "moonshine-g2p-en-us": {
         "repo_id": "moonshine-ai/moonshine",
         "dirname": "moonshine-g2p/en_us",

--- a/tests/test_qwen35_family_shapes.py
+++ b/tests/test_qwen35_family_shapes.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Cross-check a Qwen 3.5-family checkpoint against what Crane's `qwen3_5`
+loader expects — from the safetensors *headers* only, so it costs a few
+hundred KB of range requests instead of a 55 GB download.
+
+Manual tool, not part of `cargo test`. Use it before porting effort: if every
+tensor name and shape matches, the checkpoint loads through the existing
+module and the remaining work is config plumbing, not modeling.
+
+    ./tests/test_qwen35_family_shapes.py                     # Qwen3.8-27B
+    ./tests/test_qwen35_family_shapes.py Qwen/Qwen3.6-27B
+    ./tests/test_qwen35_family_shapes.py Qwen/Qwen3.5-4B
+
+Exits non-zero on any missing tensor or shape mismatch. Tensors present in the
+checkpoint but never requested are reported, not failed — Qwen 3.6/3.8 ship an
+`mtp.*` draft head that Crane deliberately does not load.
+"""
+import json
+import struct
+import sys
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+REPO = sys.argv[1] if len(sys.argv) > 1 else "Qwen/Qwen3.8-27B"
+BASE = f"https://huggingface.co/{REPO}/resolve/main/"
+
+
+def fetch(name):
+    return urllib.request.urlopen(BASE + name).read()
+
+
+def header(shard):
+    """Read a safetensors header: u64 length prefix, then that many JSON bytes."""
+    req = urllib.request.Request(BASE + shard, headers={"Range": "bytes=0-7"})
+    n = struct.unpack("<Q", urllib.request.urlopen(req).read())[0]
+    req = urllib.request.Request(BASE + shard, headers={"Range": f"bytes=8-{7 + n}"})
+    return json.loads(urllib.request.urlopen(req).read())
+
+
+def load_headers():
+    try:
+        shards = sorted(set(json.loads(fetch("model.safetensors.index.json"))["weight_map"].values()))
+    except urllib.error.HTTPError:
+        shards = ["model.safetensors"]  # single-shard checkpoint
+    hdrs = {}
+    with ThreadPoolExecutor(8) as ex:
+        for h in ex.map(header, shards):
+            hdrs.update(h)
+    hdrs.pop("__metadata__", None)
+    return hdrs, shards
+
+
+def expected(cfg):
+    """Every tensor `crane-core/src/models/qwen3_5/` asks for, with its shape."""
+    t = cfg["text_config"]
+    H, HD = t["hidden_size"], t["head_dim"]
+    NH, NKV = t["num_attention_heads"], t["num_key_value_heads"]
+    NV = t["linear_num_value_heads"]
+    KD = t["linear_num_key_heads"] * t["linear_key_head_dim"]
+    VD = NV * t["linear_value_head_dim"]
+    INTER = t["intermediate_size"]
+    interval = t.get("full_attention_interval", 4)
+    kinds = t.get("layer_types") or [
+        "full_attention" if (i + 1) % interval == 0 else "linear_attention"
+        for i in range(t["num_hidden_layers"])
+    ]
+
+    want = {
+        "model.language_model.embed_tokens.weight": [t["vocab_size"], H],
+        "model.language_model.norm.weight": [H],
+    }
+    if not t.get("tie_word_embeddings", False):
+        want["lm_head.weight"] = [t["vocab_size"], H]
+
+    for i, kind in enumerate(kinds):
+        p = f"model.language_model.layers.{i}"
+        want[f"{p}.input_layernorm.weight"] = [H]
+        want[f"{p}.post_attention_layernorm.weight"] = [H]
+        want[f"{p}.mlp.gate_proj.weight"] = [INTER, H]
+        want[f"{p}.mlp.up_proj.weight"] = [INTER, H]
+        want[f"{p}.mlp.down_proj.weight"] = [H, INTER]
+        if kind == "full_attention":
+            # q_proj is 2x wide when the output gate is fused in.
+            gate = 2 if t.get("attn_output_gate", True) else 1
+            want[f"{p}.self_attn.q_proj.weight"] = [gate * NH * HD, H]
+            want[f"{p}.self_attn.k_proj.weight"] = [NKV * HD, H]
+            want[f"{p}.self_attn.v_proj.weight"] = [NKV * HD, H]
+            want[f"{p}.self_attn.o_proj.weight"] = [H, NH * HD]
+            want[f"{p}.self_attn.q_norm.weight"] = [HD]
+            want[f"{p}.self_attn.k_norm.weight"] = [HD]
+        else:
+            want[f"{p}.linear_attn.in_proj_qkv.weight"] = [2 * KD + VD, H]
+            want[f"{p}.linear_attn.in_proj_z.weight"] = [VD, H]
+            want[f"{p}.linear_attn.in_proj_a.weight"] = [NV, H]
+            want[f"{p}.linear_attn.in_proj_b.weight"] = [NV, H]
+            want[f"{p}.linear_attn.out_proj.weight"] = [H, VD]
+            want[f"{p}.linear_attn.conv1d.weight"] = [2 * KD + VD, 1, t["linear_conv_kernel_dim"]]
+            want[f"{p}.linear_attn.norm.weight"] = [t["linear_value_head_dim"]]
+            want[f"{p}.linear_attn.A_log"] = [NV]
+            want[f"{p}.linear_attn.dt_bias"] = [NV]
+
+    v = cfg.get("vision_config")
+    if v:
+        VH, VI = v["hidden_size"], v["intermediate_size"]
+        MERGED = VH * v["spatial_merge_size"] ** 2
+        want["model.visual.patch_embed.proj.weight"] = [
+            VH, v["in_channels"], v["temporal_patch_size"], v["patch_size"], v["patch_size"]]
+        want["model.visual.patch_embed.proj.bias"] = [VH]
+        want["model.visual.pos_embed.weight"] = [v["num_position_embeddings"], VH]
+        for i in range(v["depth"]):
+            p = f"model.visual.blocks.{i}"
+            want[f"{p}.attn.qkv.weight"] = [3 * VH, VH]
+            want[f"{p}.attn.qkv.bias"] = [3 * VH]
+            want[f"{p}.attn.proj.weight"] = [VH, VH]
+            want[f"{p}.attn.proj.bias"] = [VH]
+            want[f"{p}.mlp.linear_fc1.weight"] = [VI, VH]
+            want[f"{p}.mlp.linear_fc1.bias"] = [VI]
+            want[f"{p}.mlp.linear_fc2.weight"] = [VH, VI]
+            want[f"{p}.mlp.linear_fc2.bias"] = [VH]
+            for n in ("norm1", "norm2"):
+                want[f"{p}.{n}.weight"] = [VH]
+                want[f"{p}.{n}.bias"] = [VH]
+        want["model.visual.merger.linear_fc1.weight"] = [MERGED, MERGED]
+        want["model.visual.merger.linear_fc1.bias"] = [MERGED]
+        want["model.visual.merger.linear_fc2.weight"] = [v["out_hidden_size"], MERGED]
+        want["model.visual.merger.linear_fc2.bias"] = [v["out_hidden_size"]]
+        # Pre-merge norm, so `hidden_size` — matches PatchMerger::new with
+        # use_postshuffle_norm = false.
+        want["model.visual.merger.norm.weight"] = [VH]
+        want["model.visual.merger.norm.bias"] = [VH]
+    return want
+
+
+def main():
+    cfg = json.loads(fetch("config.json"))
+    print(f"{REPO}: model_type={cfg.get('model_type')} architectures={cfg.get('architectures')}")
+
+    gate = cfg["text_config"].get("output_gate_type")
+    if gate is not None and gate not in ("swish", "silu"):
+        print(f"  !! output_gate_type={gate!r} — the GDN gate is swish-only in Crane")
+
+    hdrs, shards = load_headers()
+    want = expected(cfg)
+
+    bad = []
+    for name, shape in want.items():
+        got = hdrs.get(name)
+        if got is None:
+            bad.append(f"MISSING {name}")
+        elif got["shape"] != shape:
+            bad.append(f"SHAPE   {name}: want {shape}, got {got['shape']}")
+
+    extra = sorted(k for k in hdrs if k not in want)
+    print(f"checked {len(want)} tensors across {len(shards)} shard(s): {len(bad)} mismatches")
+    for b in bad[:20]:
+        print("  ", b)
+    if extra:
+        print(f"not loaded by Crane ({len(extra)}): {', '.join(sorted({k.split('.')[0] for k in extra}))}")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION

Adding support for the great qwen 3.8  
as this is same architecture as 3.5 and because of size GGUF is almost inevitable, this fix is to be merged too: https://github.com/lucasjinreal/Crane/pull/99

speed benchmark for comparison:

Qwen3.8-27B (Q4_K_M, thinking off, RTX 3090)

| pp   | metric       | crane | ollama | lmstudio |
|------|---------------|-------|--------|-----------|
| 512  | prefill t/s  | 583   | 346    | 318       |
| 512  | decode t/s   | 19.95 | 7.7    | 19.9      |
| 2048 | prefill t/s  | 480   | 355    | 418       |
| 2048 | decode t/s   | 19.74 | 7.5    | 18.9      |
| 4096 | prefill t/s  | 451   | 345    | 474       |
| 4096 | decode t/s   | 21.02 | 7.2    | 19.2      |