### PR TITLE
Migrate to new tekken crate

### DIFF
--- a/crane-core/Cargo.toml
+++ b/crane-core/Cargo.toml
@@ -42,7 +42,7 @@ tokenizers = { workspace = true }
 ribo = "0.1.3"
 base64 = "0.22"
 fancy-regex = "0.18"
-tekken-rs = "0.1.1"
+tekken = { version = "0.2.0", default-features = false }
 zip = "8"
 fst = { workspace = true }
 lru = { version = "0.12", optional = true }


### PR DESCRIPTION
First of all, thank you for building this project. I have been using to host my local models and it has been working great!

I am also the author of [tekken-rs](https://crates.io/crates/tekken-rs) and recently renamed it to simply [tekken](https://crates.io/crates/tekken) to make it easier to import, find, and align with its library name. Since crates.io has no rename mechanism, this meant publishing a new crate; tekken-rs 0.1.2 is the final release under the old name.

Version 0.2.0 of tekken also adds:
- Support for v15 of the tokenizer
- Image tokenization support
- Audio and image dependencies gated behind feature flags

Two things to note:
- tekken-rs's library name was already tekken, so all existing use tekken::... imports will keep working
- Crane only uses tekken for text tokenization in the Voxtral TTS front-end, so disabling the default audio/image features drops hound, rubato, rustfft, ndarray, and the image crate from tekken's subtree