### PR TITLE
Host G2P lexicons on HF

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,14 +42,14 @@ jobs:
             models::kokoro_tts::ipa::tests::en_kokoro_normalizer_matches_reference_corpus
         env:
           CRANE_TEST_DATA_DIR: /tmp/crane-test-data
-      - name: Download G2P dictionary (moonshine-g2p-en-us)
-        run: python3 data/crane-model-download --model moonshine-g2p-en-us --path /tmp/crane-models
+      - name: Download G2P dictionary (g2p-lexicons)
+        run: python3 data/crane-model-download --model g2p-lexicons --path /tmp/crane-models
       - name: CER benchmark (no-OOV, rules tier only)
         run: |
           cargo test -p crane-core --features onnx --lib -- --ignored --nocapture \
             models::g2p::languages::english::tests::cer_benchmark_without_oov
         env:
-          CRANE_G2P_EN_US_DIR: /tmp/crane-models/g2p/moonshine-g2p/en_us
+          CRANE_G2P_EN_US_DIR: /tmp/crane-models/g2p/g2p-lexicons/en_us
 
   build-metal:
     runs-on: macos-latest

--- a/crane-core/src/models/g2p/README.md
+++ b/crane-core/src/models/g2p/README.md
@@ -1,0 +1,81 @@
+# G2P (Grapheme-to-Phoneme)
+
+G2P turns written text into phonemes. A phoneme is a unit of sound, like
+the "k" sound in "cat". Text-to-speech models don't read letters. They
+read phonemes. So before Crane can speak a sentence, this module has to
+convert it from text to phonemes first.
+
+Phonemes are written using IPA, the International Phonetic Alphabet. IPA
+gives every sound in every language its own symbol. That's what lets one
+system handle English, German, and other languages without inventing a
+new alphabet for each one.
+
+For each supported language, G2P has a lexicon: a dictionary that maps
+words to their IPA pronunciation. The lexicon is backed by
+[`lexicon.rs`](lexicon.rs)'s FST (a compact, fast lookup structure). Not
+every word is in the dictionary. For words the lexicon doesn't cover, each
+language falls back to hand-written rules and/or a small neural model. See
+[`languages/`](languages) for that per-language logic.
+
+## Dictionary sources
+
+Lexicon data comes from third-party dictionaries. Scripts in
+[`data/g2p/`](../../../../data/g2p) at the repo root convert each one into
+the plain `word<TAB>ipa` format `Lexicon::from_tsv` expects:
+
+- **German** (`de`): extracted directly from a German Wiktionary XML dump
+  by `extract-de-wiktionary-ipa.py`. Wiktionary is the ultimate source for
+  the German data most other IPA dictionaries redistribute, including
+  `open-dict-data/ipa-dict`. Extracting it ourselves gets the license
+  right. It's CC BY-SA 4.0, with proper attribution, instead of a
+  downstream copy that mislabels it.
+- **English** (`en_us`): converted from `open-dict-data/ipa-dict`'s
+  `en_US.txt` by `ipa-dict-to-tsv.py`. This specific language file is
+  MIT-licensed.
+
+Each conversion script writes a `<output>.PROVENANCE.md` next to its TSV.
+That file records the exact source and license. License and attribution
+can vary per language file, even within the same upstream project. The
+German case above is a real example of that. Check the provenance file
+before adding a new language's dictionary to a model's assets, and before
+publishing a converted dictionary anywhere.
+
+## Dictionary IPA isn't what every model expects
+
+These dictionaries transcribe pronunciation using standard,
+linguistics-reference-style IPA conventions. For example, the
+primary/secondary stress marks `ˈ`/`ˌ` are placed before a syllable's
+entire onset consonant cluster. Affricates and diphthongs are written as
+multi-codepoint sequences like `t͡ʃ` or `aɪ`. That's the right choice for
+the lexicon itself. It's what lets `benchmark.rs`'s CER benchmark validate
+G2P output against a reference corpus written in the same convention. It
+also keeps the lexicon usable by any future consumer, not just one
+specific model.
+
+But a TTS model was trained on whatever phoneme convention its own
+training pipeline produced. That's frequently not this dictionary
+convention. For example, Kokoro's German checkpoint was fine-tuned on
+espeak-ng-style phonemization. Espeak-ng places stress immediately before
+the vowel, not before the onset cluster. Kokoro's vocabulary also has
+single-codepoint tokens for affricates and diphthongs that dictionary IPA
+spells with multiple codepoints. Feeding a model raw dictionary IPA it
+wasn't trained on produces audible artifacts. See the reposition-stress
+fix in `kokoro_tts/ipa.rs` and `kokoro_tts/model.rs` for a real example: a
+word-initial stress mark with no preceding consonant synthesized as a
+spurious vowel.
+
+**Each model implementation is responsible for bridging this gap itself,
+in its own module, not in `g2p/`.** For example, `kokoro_tts/ipa.rs`
+builds an [`IpaNormalizer`](ipa_postprocess.rs) with Kokoro-vocab-specific
+replacement tables
+(`SHARED_KOKORO_REPLACEMENTS`/`EN_EXTRA_KOKORO_REPLACEMENTS`/`DE_EXTRA_KOKORO_REPLACEMENTS`).
+It also has a dedicated `reposition_stress_before_vowel()` scanning
+function for the stress-placement mismatch, applied to German only, right
+before phonemes are handed to the model.
+
+When wiring up a new phoneme-consuming model, check what phoneme
+convention that model's own training data actually used. Don't just check
+whether it's IPA. Do this before assuming G2P's lexicon output can be fed
+to it directly. Then add the model's own normalization step alongside its
+other model-specific code, the same way `kokoro_tts` does. Don't modify
+`g2p/`'s shared lexicon output to suit one model.

--- a/crane-serve/src/engine/model_factory.rs
+++ b/crane-serve/src/engine/model_factory.rs
@@ -693,10 +693,11 @@ pub fn create_tts(
 /// `tokenizer.json`, `onnx/`, `voices/`); G2P assets are located at
 /// `{model_path}/g2p/`, following Moonshine's per-language directory layout
 /// (see [`crane_core::models::g2p::MoonshineG2p::from_g2p_dir`]). A real
-/// deployment symlinks or copies its G2P data there, e.g.:
+/// deployment symlinks or copies its G2P data there, e.g. after running
+/// `crane-model-download`'s `g2p-lexicons` and `g2p-oov-en-us` targets:
 ///
 /// ```text
-/// ln -s /path/to/moonshine-g2p <model_path>/g2p
+/// ln -s /path/to/g2p/g2p-lexicons <model_path>/g2p
 /// ```
 ///
 /// # Errors

--- a/data/crane-model-download
+++ b/data/crane-model-download
@@ -12,7 +12,7 @@ Examples:
     ./crane-model-download --model qwen3-asr-0.6b --path ~/models
     ./crane-model-download --model silero-vad --path ~/models
     ./crane-model-download --model qwen3.5-9b-gguf --path ~/models --quant Q8_0
-    ./crane-model-download --model moonshine-g2p-en-us --path ~/models
+    ./crane-model-download --model g2p-lexicons --path ~/models
     ./crane-model-download --model kokoro --path ~/models
 
 Run directly (uv picks up the inline metadata above and manages the
@@ -108,30 +108,37 @@ MODELS = {
         "quant_template": "Qwen3.8-27B-{quant}.gguf",
         "description": "Qwen 3.8 27B, same arch as Qwen 3.5 scaled up, GGUF quant (Apache-2.0)",
     },
-    "moonshine-g2p-en-us": {
+    "g2p-lexicons": {
+        "repo_id": "crane-local-ai/g2p-lexicons",
+        "dirname": "g2p-lexicons",
+        "kind": "g2p",
+        "repo_type": "dataset",
+        # Local names match what MoonshineG2p::from_g2p_dir hardcodes
+        # (en_us/dict_filtered_heteronyms.tsv, de/dict.tsv), replacing the
+        # lexicons moonshine-g2p-en-us/de used to fetch from Moonshine's CDN.
+        "files": {
+            "de/de.tsv": "de/dict.tsv",
+            "de/PROVENANCE.md": "de/PROVENANCE.md",
+            "en_US/en_US.tsv": "en_us/dict_filtered_heteronyms.tsv",
+            "en_US/PROVENANCE.md": "en_us/PROVENANCE.md",
+        },
+        "description": "Crane G2P word-to-IPA lexicons: German (Wiktionary, CC BY-SA 4.0) + English/US (ipa-dict, MIT)",
+    },
+    "g2p-oov-en-us": {
         "repo_id": "moonshine-ai/moonshine",
-        "dirname": "moonshine-g2p/en_us",
+        "dirname": "g2p-lexicons",
         "kind": "g2p",
         "source": "url",
         "base_url": "https://download.moonshine.ai/tts/en_us",
+        # Lands in the same g2p-lexicons/en_us/ directory as the g2p-lexicons
+        # entry above -- our own dataset has no OOV model, so English still
+        # needs this neural fallback from Moonshine.
         "files": {
-            "dict_filtered_heteronyms.tsv": "dict_filtered_heteronyms.tsv",
-            "g2p-config.json": "g2p-config.json",
-            "oov/model.onnx": "oov/model.onnx",
-            "oov/onnx-config.json": "oov/onnx-config.json",
+            "g2p-config.json": "en_us/g2p-config.json",
+            "oov/model.onnx": "en_us/oov/model.onnx",
+            "oov/onnx-config.json": "en_us/oov/onnx-config.json",
         },
-        "description": "Moonshine G2P English lexicon + OOV ONNX model (MIT)",
-    },
-    "moonshine-g2p-de": {
-        "repo_id": "moonshine-ai/moonshine",
-        "dirname": "moonshine-g2p/de",
-        "kind": "g2p",
-        "source": "url",
-        "base_url": "https://download.moonshine.ai/tts/de",
-        "files": {
-            "dict.tsv": "dict.tsv",
-        },
-        "description": "Moonshine G2P German lexicon, no OOV model (MIT)",
+        "description": "Moonshine English G2P OOV fallback model only, no lexicon -- use with g2p-lexicons (MIT)",
     },
     "kokoro": {
         "repo_id": "onnx-community/Kokoro-82M-v1.0-ONNX",
@@ -264,6 +271,24 @@ def download_url_files(info, local_dir):
             sys.exit(1)
 
 
+def print_done(info, target):
+    if info["kind"] == "amt":
+        # MuScriptor isn't served through crane-serve — it's a standalone
+        # CLI, so the generic crane-serve hint below would be actively
+        # wrong here rather than just imprecise.
+        print(
+            f"\nDone. Use with: cargo run -p crane-examples --release --features cuda "
+            f"--bin muscriptor_transcribe -- --model-dir {target} --transcribe audio.wav"
+        )
+    elif info["kind"] == "g2p":
+        # g2p assets aren't a --model-path themselves; Kokoro expects them
+        # symlinked in at {model_path}/g2p (see
+        # crane_core::models::g2p::MoonshineG2p::from_g2p_dir).
+        print(f"\nDone. Use with: ln -s {target} <model_path>/g2p")
+    else:
+        print(f"\nDone. Use with: crane-serve --model-path {target}")
+
+
 def download_model(model_key, path, token, quant):
     info = MODELS[model_key]
     local_dir = os.path.join(os.path.expanduser(path), info["kind"], info["dirname"])
@@ -272,7 +297,7 @@ def download_model(model_key, path, token, quant):
         print(f"Downloading {info['repo_id']} ({info['base_url']}) to {local_dir} ...")
         os.makedirs(local_dir, exist_ok=True)
         download_url_files(info, local_dir)
-        print(f"\nDone. Use with: crane-serve --model-path {local_dir}")
+        print_done(info, local_dir)
         return
 
     try:
@@ -287,6 +312,7 @@ def download_model(model_key, path, token, quant):
         sys.exit(1)
 
     quant_template = info.get("quant_template")
+    repo_type = info.get("repo_type", "model")
 
     if quant_template:
         filename = quant_template.format(quant=quant)
@@ -309,12 +335,20 @@ def download_model(model_key, path, token, quant):
                 os.makedirs(local_dir, exist_ok=True)
                 for repo_path, local_name in files.items():
                     cached = hf_hub_download(
-                        repo_id=info["repo_id"], filename=repo_path, token=token
+                        repo_id=info["repo_id"],
+                        filename=repo_path,
+                        repo_type=repo_type,
+                        token=token,
                     )
-                    shutil.copy2(cached, os.path.join(local_dir, local_name))
+                    local_target = os.path.join(local_dir, local_name)
+                    os.makedirs(os.path.dirname(local_target), exist_ok=True)
+                    shutil.copy2(cached, local_target)
             else:
                 snapshot_download(
-                    repo_id=info["repo_id"], local_dir=local_dir, token=token
+                    repo_id=info["repo_id"],
+                    local_dir=local_dir,
+                    repo_type=repo_type,
+                    token=token,
                 )
 
         # Additional files pulled from a *different* repo into the same
@@ -350,17 +384,7 @@ def download_model(model_key, path, token, quant):
             )
         sys.exit(1)
 
-    if info["kind"] == "amt":
-        # MuScriptor isn't served through crane-serve — it's a standalone
-        # CLI, so the generic crane-serve hint below would be actively
-        # wrong here rather than just imprecise (unlike e.g. g2p/vad, which
-        # are auxiliary assets crane-serve's own pipelines do load).
-        print(
-            f"\nDone. Use with: cargo run -p crane-examples --release --features cuda "
-            f"--bin muscriptor_transcribe -- --model-dir {target} --transcribe audio.wav"
-        )
-    else:
-        print(f"\nDone. Use with: crane-serve --model-path {target}")
+    print_done(info, target)
 
 
 def main():
@@ -373,7 +397,8 @@ def main():
         "  crane-model-download --model qwen3-asr-0.6b --path ~/models\n"
         "  crane-model-download --model silero-vad --path ~/models\n"
         "  crane-model-download --model qwen3.5-9b-gguf --path ~/models --quant Q8_0\n"
-        "  crane-model-download --model moonshine-g2p-en-us --path ~/models\n"
+        "  crane-model-download --model g2p-lexicons --path ~/models\n"
+        "  crane-model-download --model g2p-oov-en-us --path ~/models\n"
         "  crane-model-download --model kokoro --path ~/models\n",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )

--- a/data/g2p/extract-de-wiktionary-ipa.py
+++ b/data/g2p/extract-de-wiktionary-ipa.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["mwparserfromhell"]
+# ///
+"""Extract a German word -> IPA lexicon from a German Wiktionary XML dump.
+
+The output is `word<TAB>ipa` lines (no header, no slashes), matching
+`crane-core/src/models/g2p/lexicon.rs`'s `Lexicon::from_tsv` format. A word
+with multiple pronunciations produces multiple lines with the same word.
+
+Examples:
+    # Download the latest dump and extract into de_wiktionary_ipa.tsv
+    ./extract-de-wiktionary-ipa.py --output de_wiktionary_ipa.tsv
+
+    # Use an already-downloaded dump (preferred for a reproducible build)
+    ./extract-de-wiktionary-ipa.py --dump-path dewiktionary-20260804-pages-articles.xml.bz2 \\
+        --output de_wiktionary_ipa.tsv
+
+Each run also writes `<output>.PROVENANCE.md` recording the dump URL/date
+used and the CC BY-SA attribution chain (Wiktionary contributors -> this
+script), since the extracted data is a derivative of Wiktionary content and
+must carry that attribution forward.
+
+If interrupted (Ctrl-C, crash, connection drop), re-running the exact same
+command resumes: progress is checkpointed to `<output>.checkpoint.json`
+every `--checkpoint-every` pages, alongside a partial `<output>` that doubles
+as the recovered entry set, so nothing needs to be held only in memory. This
+is a separate, coarser cadence than `--progress-every`'s log line: a
+checkpoint re-sorts and rewrites the whole (multi-hundred-thousand-line)
+output file, so it deliberately doesn't run on every progress tick.
+"""
+
+import argparse
+import bz2
+import html
+import json
+import re
+import signal
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import mwparserfromhell
+
+LATEST_DUMP_URL = (
+    "https://dumps.wikimedia.org/dewiktionary/latest/"
+    "dewiktionary-latest-pages-articles.xml.bz2"
+)
+
+LAUTSCHRIFT_TEMPLATE_NAMES = {"Lautschrift", "Lautschrift?"}
+IPA_MARKER_RE = re.compile(r"^:\{\{IPA\??\}\}")
+LEVEL2_HEADING_RE = re.compile(r"^==([^=].*)==\s*$")
+ZERO_WIDTH_RE = re.compile("[\u2060\u200b]")  # word joiner, zero-width space
+
+
+def strip_tag_ns(tag):
+    """Strips a MediaWiki export XML namespace prefix from an element tag."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def iter_dump_pages(dump_path):
+    """Streams (title, ns, text) tuples from a MediaWiki export XML dump.
+
+    Transparently decompresses `.bz2` input. Uses `iterparse` with
+    element-clearing so memory stays bounded regardless of dump size (a
+    German Wiktionary dump has several million `<page>` elements).
+    """
+    opener = bz2.open if str(dump_path).endswith(".bz2") else open
+    with opener(dump_path, "rt", encoding="utf-8") as handle:
+        title = None
+        ns = None
+        text = None
+        in_revision = False
+        for event, elem in ET.iterparse(handle, events=("start", "end")):
+            tag = strip_tag_ns(elem.tag)
+            if event == "start":
+                if tag == "revision":
+                    in_revision = True
+                continue
+            if tag == "title":
+                title = elem.text or ""
+            elif tag == "ns":
+                ns = elem.text or ""
+            elif tag == "text" and in_revision:
+                text = elem.text or ""
+            elif tag == "revision":
+                in_revision = False
+            elif tag == "page":
+                if title is not None and ns is not None:
+                    yield title, ns, text or ""
+                title, ns, text = None, None, None
+                elem.clear()
+
+
+def is_deutsch_heading(heading_text):
+    """Returns whether a level-2 heading marks a German-language word entry.
+
+    German Wiktionary headings look like `== Haus ({{Sprache|Deutsch}}) ==`.
+    """
+    for template in mwparserfromhell.parse(heading_text).filter_templates():
+        if str(template.name).strip() != "Sprache":
+            continue
+        if template.params and str(template.params[0].value).strip() == "Deutsch":
+            return True
+    return False
+
+
+def clean_ipa_value(raw):
+    """Normalizes one `{{Lautschrift|...}}` template argument into plain IPA text."""
+    value = html.unescape(html.unescape(raw)).strip()
+    return ZERO_WIDTH_RE.sub("", value)
+
+
+def is_valid_ipa(value):
+    """Rejects placeholder/malformed IPA values.
+
+    Covers: missing, leading "-", ellipsis, stray template braces, a literal
+    "/" (either leftover IPA-slash delimiters an editor typed into the
+    template by mistake, e.g. `{{Lautschrift|/ˈvɪl.jam/}}`, or two alternate
+    readings packed into one value with "/" instead of separate templates —
+    neither is parseable as a single pronunciation), and stress-mark-only
+    stubs (e.g. `{{Lautschrift|ˈ|spr=des}}`, a placeholder some Wiktionary
+    entries use when nobody has filled in the actual pronunciation yet).
+    """
+    if not value or value.startswith("-") or "…" in value or "{" in value or "}" in value or "/" in value:
+        return False
+    return value.strip("ˈˌ") != ""
+
+
+def extract_lautschrift_values(line):
+    """Yields every valid IPA value from `{{Lautschrift|...}}` templates on one wikitext line."""
+    for template in mwparserfromhell.parse(line).filter_templates():
+        if str(template.name).strip() not in LAUTSCHRIFT_TEMPLATE_NAMES:
+            continue
+        if not template.has("1"):
+            continue
+        value = clean_ipa_value(str(template.get("1").value))
+        if is_valid_ipa(value):
+            yield value
+
+
+def extract_pronunciations(wikitext):
+    """Extracts every German-section IPA pronunciation from one page's wikitext.
+
+    Walks the page line by line rather than parsing the whole page as one
+    wikicode tree: German Wiktionary's `Aussprache`/`Worttrennung`/etc.
+    subsections are plain bare template calls on their own line (not `===`
+    headings), so a line-oriented state machine is the natural fit, mirroring
+    how `devio-at/german-ipa-dict`'s own extractor is structured. Unlike that
+    script, this one doesn't capture the regional-variant prose around each
+    IPA value, since `Lexicon::from_tsv` has no field for it.
+    """
+    in_de_section = False
+    pron_found = False
+    in_ipa = False
+    results = []
+
+    for line in wikitext.splitlines():
+        stripped = line.strip()
+
+        heading_match = LEVEL2_HEADING_RE.match(stripped)
+        if heading_match:
+            in_de_section = is_deutsch_heading(heading_match.group(1))
+            pron_found = False
+            in_ipa = False
+            continue
+
+        if not in_de_section:
+            continue
+
+        if stripped == "{{Aussprache}}":
+            pron_found = True
+            in_ipa = False
+            continue
+
+        if stripped.startswith("{{"):
+            # A different bare pseudo-heading (e.g. {{Bedeutungen}}) ends the
+            # Aussprache block.
+            pron_found = False
+            in_ipa = False
+            continue
+
+        if not pron_found:
+            continue
+
+        if IPA_MARKER_RE.match(stripped):
+            in_ipa = True
+        elif in_ipa and not stripped.startswith("::"):
+            in_ipa = False
+
+        if not in_ipa or "{{Lautschrift" not in stripped:
+            continue
+
+        results.extend(extract_lautschrift_values(stripped))
+
+    return results
+
+
+def is_eligible_title(title):
+    """Filters out non-lemma pages: namespaced pages, suffix stubs, and multi-word phrases.
+
+    Multi-word phrase entries (e.g. "Haus und Hof") are real Wiktionary
+    pages but aren't G2P lookup targets, since Crane's lexicon is only ever
+    queried one token at a time (see `text_normalize::split_text_to_words`)
+    — keeping them would just be dead weight in the lexicon.
+    """
+    return ":" not in title and not title.startswith("-") and " " not in title
+
+
+def download_dump(url, dest):
+    """Downloads a dump file to `dest`, printing simple progress to stderr."""
+    print(f"Downloading {url} -> {dest}", file=sys.stderr)
+    # Wikimedia's dump server 403s requests with no User-Agent (bot policy).
+    request = urllib.request.Request(url, headers={"User-Agent": "crane-g2p-dict-builder/1.0"})
+    with urllib.request.urlopen(request) as response:
+        total = int(response.headers.get("Content-Length", 0))
+        read = 0
+        with open(dest, "wb") as out:
+            while chunk := response.read(1024 * 1024):
+                out.write(chunk)
+                read += len(chunk)
+                if total:
+                    print(f"\r  {read / 1e6:.0f} / {total / 1e6:.0f} MB", end="", file=sys.stderr)
+        print(file=sys.stderr)
+
+
+def dump_identity(dump_path):
+    """Returns a cheap fingerprint of a dump file, used to detect a stale checkpoint."""
+    path = Path(dump_path)
+    return {"dump_path": str(path), "size": path.stat().st_size}
+
+
+def load_checkpoint(checkpoint_path, output_path, dump_path):
+    """Loads (pages_already_scanned, entries) from a prior interrupted run.
+
+    Progress is recovered from two files: the checkpoint JSON (page count +
+    dump fingerprint) and the partial output TSV itself, which doubles as
+    the entry set — so a resumed run never has to re-hold the whole result
+    in memory from scratch. Falls back to a fresh start if either file is
+    missing or the checkpoint was made against a different dump (page N
+    means something different in a different dump snapshot).
+    """
+    if not checkpoint_path.exists() or not output_path.exists():
+        return 0, set()
+
+    state = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    if state.get("dump") != dump_identity(dump_path):
+        print("Checkpoint is for a different dump file; starting over.", file=sys.stderr)
+        return 0, set()
+
+    entries = set()
+    with open(output_path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            word, ipa = line.split("\t", 1)
+            entries.add((word, ipa))
+    return state["pages_scanned"], entries
+
+
+def save_checkpoint(checkpoint_path, output_path, dump_path, pages_scanned, entries):
+    """Atomically flushes progress: rewrites the output TSV, then the checkpoint marker.
+
+    Writing the output before the checkpoint means a crash between the two
+    writes is safe — worst case, a resumed run re-derives the same
+    `pages_scanned` count and re-flushes the same entries, it never resumes
+    from a checkpoint that claims more progress than what's on disk.
+    """
+    tmp_output = Path(str(output_path) + ".tmp")
+    with open(tmp_output, "w", encoding="utf-8") as f:
+        f.writelines(f"{word}\t{ipa}\n" for word, ipa in sorted(entries))
+    tmp_output.replace(output_path)
+    checkpoint_path.write_text(
+        json.dumps({"pages_scanned": pages_scanned, "dump": dump_identity(dump_path)}),
+        encoding="utf-8",
+    )
+
+
+def write_provenance(path, dump_source):
+    """Writes the CC BY-SA attribution/provenance note accompanying the output TSV."""
+    path.write_text(
+        "# Provenance and license\n\n"
+        "This word-to-IPA lexicon was extracted from the German-language\n"
+        "edition of Wiktionary (https://de.wiktionary.org) using\n"
+        "`data/g2p/extract-de-wiktionary-ipa.py` in the Crane repository,\n"
+        "pulling the `{{Lautschrift}}` pronunciation template out of each\n"
+        "German (`{{Sprache|Deutsch}}`) entry's `{{Aussprache}}` section.\n\n"
+        f"Dump source: {dump_source}\n\n"
+        "## License\n\n"
+        "Wiktionary text content is dual-licensed under Creative Commons\n"
+        "Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) and the\n"
+        "GNU Free Documentation License (GFDL). This extracted dataset is a\n"
+        "derivative work and is therefore likewise licensed\n"
+        "**CC BY-SA 4.0** (https://creativecommons.org/licenses/by-sa/4.0/)\n"
+        "— redistributing or adapting it must preserve attribution to\n"
+        "Wiktionary contributors and stay under a compatible share-alike\n"
+        "license. It is not MIT-licensed.\n\n"
+        "Attribution: Wiktionary contributors, https://de.wiktionary.org,\n"
+        "extracted via `de.wiktionary.org`'s public XML dump.\n",
+        encoding="utf-8",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dump-path", type=Path, help="Path to a local dewiktionary-*-pages-articles.xml(.bz2) dump")
+    parser.add_argument(
+        "--download-to",
+        type=Path,
+        default=Path("dewiktionary-latest-pages-articles.xml.bz2"),
+        help="Where to save the dump if --dump-path is not given and it needs downloading (default: %(default)s)",
+    )
+    parser.add_argument("--output", type=Path, required=True, help="Output TSV path (word<TAB>ipa lines)")
+    parser.add_argument(
+        "--progress-every", type=int, default=100_000, help="Print a progress line every N pages scanned"
+    )
+    parser.add_argument(
+        "--checkpoint-every",
+        type=int,
+        default=500_000,
+        help="Re-sort and flush the output + checkpoint file every N pages scanned (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    dump_source = str(args.dump_path) if args.dump_path else LATEST_DUMP_URL
+    dump_path = args.dump_path
+    if dump_path is None:
+        dump_path = args.download_to
+        if not dump_path.exists():
+            download_dump(LATEST_DUMP_URL, dump_path)
+        else:
+            print(f"Using already-downloaded {dump_path}", file=sys.stderr)
+
+    checkpoint_path = Path(str(args.output) + ".checkpoint.json")
+    resume_from, entries = load_checkpoint(checkpoint_path, args.output, dump_path)
+    if resume_from:
+        print(f"Resuming: {resume_from} pages already scanned, {len(entries)} entries loaded", file=sys.stderr)
+
+    pages_scanned = 0
+    german_pages = 0
+
+    # A process manager (or `timeout`) stops a long-running job with SIGTERM,
+    # not Ctrl-C's SIGINT — handle both the same way: set a flag rather than
+    # raising immediately, so the loop only ever stops *between* fully-
+    # processed pages. Raising asynchronously (e.g. via KeyboardInterrupt)
+    # could land mid-page, after `pages_scanned` was incremented but before
+    # that page's entries were added — checkpointing at that instant would
+    # mark the page "done" while silently dropping the entries it hadn't
+    # gotten to yet.
+    stop_requested = False
+
+    def _request_stop(signum, frame):
+        nonlocal stop_requested
+        stop_requested = True
+
+    signal.signal(signal.SIGTERM, _request_stop)
+    signal.signal(signal.SIGINT, _request_stop)
+
+    def flush(final):
+        save_checkpoint(checkpoint_path, args.output, dump_path, pages_scanned, entries)
+        if final:
+            checkpoint_path.unlink(missing_ok=True)
+            write_provenance(Path(str(args.output) + ".PROVENANCE.md"), dump_source)
+
+    for title, ns, text in iter_dump_pages(dump_path):
+        pages_scanned += 1
+        if pages_scanned <= resume_from:
+            continue
+
+        # Process this page fully *before* printing/checkpointing/stopping on
+        # it, so a checkpoint claiming "page N scanned" always has page N's
+        # own contribution folded into `entries` already.
+        if ns == "0" and is_eligible_title(title):
+            pronunciations = extract_pronunciations(text)
+            if pronunciations:
+                german_pages += 1
+                for ipa in pronunciations:
+                    entries.add((title, ipa))
+
+        if args.progress_every and pages_scanned % args.progress_every == 0:
+            print(f"  scanned {pages_scanned} pages, {len(entries)} entries so far", file=sys.stderr)
+
+        if stop_requested or (args.checkpoint_every and pages_scanned % args.checkpoint_every == 0):
+            flush(final=False)
+            if stop_requested:
+                print(f"Stopped after {pages_scanned} pages; re-run the same command to resume.", file=sys.stderr)
+                return
+
+    flush(final=True)
+
+    print(
+        f"Scanned {pages_scanned} pages, {german_pages} German entries with "
+        f"pronunciations, wrote {len(entries)} word/IPA lines to {args.output}",
+        file=sys.stderr,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/data/g2p/ipa-dict-to-tsv.py
+++ b/data/g2p/ipa-dict-to-tsv.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Converts an open-dict-data/ipa-dict wordlist into Crane's G2P lexicon TSV format.
+
+Upstream: https://github.com/open-dict-data/ipa-dict
+
+ipa-dict's raw `data/<lang>.txt` files are `word<TAB>value` lines, where
+`value` is one or more `/`-delimited IPA alternatives separated by ", "
+(e.g. `a	/ˈeɪ/, /ə/`). This script strips the slash delimiters and expands
+each alternative onto its own line, producing the `word<TAB>ipa` format
+`crane-core/src/models/g2p/lexicon.rs`'s `Lexicon::from_tsv` expects.
+
+Each ipa-dict language file has its own license and attribution (see
+ipa-dict's own README credits section) rather than one blanket license for
+the whole repository, so `--license` and `--attribution` are required
+arguments here rather than an assumed default -- they are recorded in
+`<output>.PROVENANCE.md` alongside the TSV.
+
+Example:
+    ./ipa-dict-to-tsv.py --input ../.tmp/ipa-dict/data/en_US.txt \\
+        --output en_us.tsv \\
+        --license MIT \\
+        --attribution "English (US) IPA data based on a modified version of \\
+cmudict-ipa by @lingz, with stress markers added via syllabify by \\
+@kylebgorman (MIT), via open-dict-data/ipa-dict."
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def parse_ipa_dict_line(line):
+    """Splits one ipa-dict `word<TAB>value` line into `(word, [ipa, ...])`.
+
+    ipa-dict values are one or more `/`-delimited alternatives joined by
+    ", " (e.g. `/ˈeɪ/, /ə/`). Splitting on ", " first and stripping `/`
+    from each piece afterwards also handles the rarer case of a single
+    slash pair containing an internal comma (e.g. `en_UK.txt`'s
+    `the	/ðə, ði/`), since `str.strip` only trims a piece's own
+    leading/trailing characters.
+    """
+    word, raw_value = line.split("\t", 1)
+    alternatives = []
+    for piece in raw_value.split(", "):
+        ipa = piece.strip().strip("/")
+        if ipa:
+            alternatives.append(ipa)
+    return word, alternatives
+
+
+def convert(input_path):
+    """Yields every `(word, ipa)` pair in an ipa-dict file, one per alternative."""
+    with open(input_path, "r", encoding="utf-8") as f:
+        for line_num, raw_line in enumerate(f, start=1):
+            line = raw_line.rstrip("\n")
+            if not line:
+                continue
+            if "\t" not in line:
+                print(f"{input_path}:{line_num}: missing tab, skipping: {line!r}", file=sys.stderr)
+                continue
+            word, alternatives = parse_ipa_dict_line(line)
+            for ipa in alternatives:
+                yield word, ipa
+
+
+def write_provenance(path, input_path, license_name, attribution):
+    """Writes the license/attribution note accompanying the output TSV."""
+    path.write_text(
+        "# Provenance and license\n\n"
+        f"This word-to-IPA lexicon was converted from open-dict-data/ipa-dict's\n"
+        f"`{input_path.name}` using `data/g2p/ipa-dict-to-tsv.py` in the Crane\n"
+        "repository: each `/`-delimited IPA alternative is expanded onto its\n"
+        "own line, matching this project's lexicon TSV format.\n\n"
+        "## License\n\n"
+        f"**{license_name}**. {attribution}\n",
+        encoding="utf-8",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--input", type=Path, required=True, help="Path to an ipa-dict data/<lang>.txt file")
+    parser.add_argument("--output", type=Path, required=True, help="Output TSV path (word<TAB>ipa lines)")
+    parser.add_argument(
+        "--license",
+        required=True,
+        help='Short license identifier for this language file, e.g. "MIT" or "CC BY-SA 4.0" '
+        "(see ipa-dict's README credits section -- each language has its own, not one blanket license)",
+    )
+    parser.add_argument(
+        "--attribution",
+        required=True,
+        help="Attribution text for this language, copied from ipa-dict's README credits section",
+    )
+    args = parser.parse_args()
+
+    entries = set(convert(args.input))
+    with open(args.output, "w", encoding="utf-8") as f:
+        f.writelines(f"{word}\t{ipa}\n" for word, ipa in sorted(entries))
+
+    write_provenance(Path(str(args.output) + ".PROVENANCE.md"), args.input, args.license, args.attribution)
+
+    print(f"Wrote {len(entries)} word/IPA lines to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We should host them on our own. The generated once from Moonshine aren't up to date. Also this way we can respect the licenses correctly.