### PR TITLE
crane-serve: Emit JSON error frames in SSE streams instead of raw text

### DIFF
--- a/crane-serve/src/handlers/sse.rs
+++ b/crane-serve/src/handlers/sse.rs
@@ -165,7 +165,14 @@ pub fn make_chat_sse_stream(
                     break;
                 }
                 EngineResponse::Error(e) => {
-                    yield Ok(Event::default().data(format!("error: {e}")));
+                    let error_response = ErrorResponse {
+                        error: ErrorDetail {
+                            message: e,
+                            r#type: "server_error".into(),
+                            code: None,
+                        },
+                    };
+                    yield Ok(Event::default().json_data(&error_response).unwrap());
                     break;
                 }
             }
@@ -250,7 +257,14 @@ pub fn make_completion_sse_stream(
                     break;
                 }
                 EngineResponse::Error(e) => {
-                    yield Ok(Event::default().data(format!("error: {e}")));
+                    let error_response = ErrorResponse {
+                        error: ErrorDetail {
+                            message: e,
+                            r#type: "server_error".into(),
+                            code: None,
+                        },
+                    };
+                    yield Ok(Event::default().json_data(&error_response).unwrap());
                     break;
                 }
             }
@@ -296,7 +310,14 @@ pub fn make_generate_sse_stream(
                     break;
                 }
                 EngineResponse::Error(e) => {
-                    yield Ok(Event::default().data(format!("error: {e}")));
+                    let error_response = ErrorResponse {
+                        error: ErrorDetail {
+                            message: e,
+                            r#type: "server_error".into(),
+                            code: None,
+                        },
+                    };
+                    yield Ok(Event::default().json_data(&error_response).unwrap());
                     break;
                 }
             }


### PR DESCRIPTION
All three SSE stream builders wrote EngineResponse::Error as a bare "error: <message>" data line while every other event in the same streams used .json_data(...). OpenAI-compatible clients that JSON.parse() each SSE chunk (e.g. OpenCode) failed with "Unexpected identifier "error"" instead of surfacing the actual engine error.